### PR TITLE
feat: Add Swagger UI integration

### DIFF
--- a/.github/workflows/synkronus-docker.yml
+++ b/.github/workflows/synkronus-docker.yml
@@ -67,7 +67,7 @@ jobs:
             # For PRs: pr-number
             type=ref,event=pr
             # SHA for traceability (only for non-release events)
-            type=sha,prefix={{branch}}-,enable=${{ github.event_name != 'release' }}
+            type=sha,prefix=sha-,enable=${{ github.event_name != 'release' && github.event_name != 'pull_request' }}
           labels: |
             org.opencontainers.image.title=Synkronus
             org.opencontainers.image.description=Synchronization API for offline-first applications

--- a/synkronus/Dockerfile
+++ b/synkronus/Dockerfile
@@ -39,6 +39,12 @@ WORKDIR /app
 # Copy binary from builder
 COPY --from=builder /app/synkronus .
 
+# Copy openapi directory for Swagger UI
+COPY --from=builder /app/openapi /app/openapi
+
+# Copy static directory for static files
+COPY --from=builder /app/static /app/static
+
 # Create directories for data storage with proper permissions
 RUN mkdir -p /app/data/app-bundles && \
     chown -R synkronus:synkronus /app

--- a/synkronus/openapi/swagger-ui.html
+++ b/synkronus/openapi/swagger-ui.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Synkronus API Documentation</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script>
+      window.onload = () => {
+        SwaggerUIBundle({
+          url: "/openapi/synkronus.yaml",
+          dom_id: "#swagger-ui",
+        });
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Add Swagger UI Integration

Adds interactive API documentation at `/openapi/swagger`. Closes #21

- Serves Swagger UI from `/openapi` route
- Redirects `/openapi/swagger` to `/openapi/swagger-ui.html`
- Updates Dockerfile to include openapi directory

All tests pass.

### Test Swagger UI endpoints locally
`curl http://localhost/openapi/swagger` or `curl http://localhost/openapi/swagger-ui.html`