### PR TITLE
feat: add documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,114 @@
+---
+name: Documentation Issue
+about: Report documentation issues, suggest improvements, or request new documentation
+title: '[Docs] Brief description of the issue or improvement'
+labels: documentation
+assignees: ''
+---
+
+## Component
+<!-- Which component's documentation is affected? -->
+- [ ] formulus (React Native mobile app)
+- [ ] formulus-formplayer (React web app)
+- [ ] synkronus (Go backend server)
+- [ ] synkronus-cli (Command-line utility)
+- [ ] Design System / Design Tokens
+- [ ] API Documentation
+- [ ] Setup / Installation Guides
+- [ ] Deployment Documentation
+- [ ] General / Root Documentation
+- [ ] Other (please specify)
+
+## Documentation Type
+<!-- What type of documentation issue is this? -->
+- [ ] Missing documentation (documentation doesn't exist)
+- [ ] Outdated documentation (information is incorrect or stale)
+- [ ] Unclear documentation (hard to understand)
+- [ ] Incomplete documentation (missing important details)
+- [ ] Broken links or references
+- [ ] Formatting or typo issues
+- [ ] Translation needed
+- [ ] New documentation needed
+- [ ] Other (please describe)
+
+## Which part of the documentation needs improvement?
+
+<!-- Please provide the specific file path, section, or URL -->
+**File/Path:** <!-- e.g., README.md, docs/api-reference.md, formulus/README.md -->
+**Section:** <!-- e.g., "Installation", "API Authentication", "Design Tokens - Colors" -->
+**URL (if applicable):** <!-- Link to the documentation if hosted online -->
+
+## Describe the issue or suggestion
+
+<!-- What is unclear / wrong / missing, or what new docs would be useful -->
+<!-- Be as specific as possible -->
+
+### Current State
+<!-- What does the documentation currently say or show? -->
+<!-- If it's missing, describe what you expected to find -->
+
+### Problem or Gap
+<!-- What's the issue? What's confusing, incorrect, or missing? -->
+
+## Proposed Change (if any)
+
+<!-- If you have a suggestion: what you would change, add or remove -->
+<!-- You can provide specific text, structure, or examples -->
+
+### Suggested Content
+<!-- What should the documentation say instead? -->
+<!-- Feel free to provide draft content, examples, or structure -->
+
+### Suggested Structure
+<!-- If applicable, how should the documentation be organized? -->
+
+## Why is this change important?
+
+<!-- What confusion/error does it prevent or what benefit does it bring? -->
+<!-- Consider: -->
+<!-- - Does it block users from completing tasks? -->
+<!-- - Does it cause misunderstandings or incorrect usage? -->
+<!-- - Does it improve developer experience? -->
+<!-- - Does it reduce support requests? -->
+
+**Impact Level:**
+- [ ] Critical (blocks users or causes errors)
+- [ ] High (causes confusion or incorrect usage)
+- [ ] Medium (improves clarity or completeness)
+- [ ] Low (nice to have, minor improvement)
+
+## Additional Context
+
+### Screenshots or Examples
+<!-- If applicable, add screenshots, code examples, or mockups -->
+<!-- Drag and drop images here or use: ![description](url) -->
+
+### Related Documentation
+<!-- Links to related documentation that might be affected -->
+<!-- e.g., Related API docs, setup guides, etc. -->
+
+### User Impact
+<!-- Who is affected by this documentation issue? -->
+- [ ] New users / First-time setup
+- [ ] Developers / Contributors
+- [ ] End users / Consumers
+- [ ] System administrators
+- [ ] All users
+
+### Additional Information
+<!-- Any other context, examples, or references that might help -->
+<!-- Include: -->
+<!-- - Specific use cases or scenarios -->
+<!-- - Error messages users might encounter -->
+<!-- - Related issues or discussions -->
+<!-- - External references or standards -->
+
+## Contribution
+
+<!-- Are you willing to help improve this documentation? -->
+- [ ] I can contribute a fix/improvement
+- [ ] I can review proposed changes
+- [ ] I need help from maintainers
+
+<!-- If you're willing to contribute, mention your approach or timeline -->
+


### PR DESCRIPTION
## Description

This PR adds a comprehensive documentation issue template to complete the issue template suite. 
@Bahati308 already made an initial [PR #4](https://github.com/OpenDataEnsemble/ode/pull/4) and added bug report and feature request templates. This addition just ensures users have a structured way to report documentation issues, suggest improvements, or request new documentation.

Features:
- Component selection matching existing templates
- Documentation type categorization (missing, outdated, unclear, etc.)
- Impact level assessment (Critical, High, Medium, Low)
- User impact identification
- Contribution section to encourage community participation
- Support for screenshots, examples, and related documentation links

Completes the issue template suite started in PR #4.
Thanks!
cc @Bahati308, @Ndacyayisenga-droid 