### PR TITLE
fix: Use relative path for QR logo

### DIFF
--- a/synkronus-cli/internal/cmd/qr.go
+++ b/synkronus-cli/internal/cmd/qr.go
@@ -153,7 +153,7 @@ for the Formulus mobile app. The QR encodes server URL, username, and password.`
 			}
 
 			// Generate QR code with logo using yeqown/go-qrcode
-			logoPath := "C:/Users/emil/code/ODE/synkronus-cli/qr_logo.png"
+			logoPath := "qr_logo.png"
 			qrc, err := qrcode.New(encoded)
 			if err != nil {
 				return fmt.Errorf("failed to create QR code: %w", err)


### PR DESCRIPTION
## Summary
Fixes the QR code generation command to to use relative path for the logo.

## Usage
Run from the `synkronus-cli` directory:
```bash
cd synkronus-cli
go run ./cmd/synkronus qr
```

The logo file `qr_logo.png` is already in that directory.