### PR TITLE
[formplayer] phase 1 question shell and card selects

### DIFF
--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -25,6 +25,7 @@ import FileQuestionRenderer, { fileQuestionTester } from './FileQuestionRenderer
 import AudioQuestionRenderer, { audioQuestionTester } from './AudioQuestionRenderer';
 import GPSQuestionRenderer, { gpsQuestionTester } from './GPSQuestionRenderer';
 import VideoQuestionRenderer, { videoQuestionTester } from './VideoQuestionRenderer';
+import { shellMaterialRenderers } from './material-wrappers';
 
 import ErrorBoundary from './ErrorBoundary';
 import { draftService } from './DraftService';
@@ -671,7 +672,11 @@ function App() {
                     schema={schema}
                     uischema={uischema}
                     data={data}
-                    renderers={[...materialRenderers, ...customRenderers]}
+                    renderers={[
+                      ...shellMaterialRenderers,
+                      ...materialRenderers,
+                      ...customRenderers,
+                    ]}
                     cells={materialCells}
                     onChange={handleDataChange}
                     validationMode="ValidateAndShow"

--- a/formulus-formplayer/src/AudioQuestionRenderer.tsx
+++ b/formulus-formplayer/src/AudioQuestionRenderer.tsx
@@ -1,16 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { ControlProps, rankWith, formatIs } from '@jsonforms/core';
-import {
-  Box,
-  Button,
-  Typography,
-  Paper,
-  IconButton,
-  LinearProgress,
-  Alert,
-  Chip,
-} from '@mui/material';
+import { Box, Button, Typography, Paper, IconButton, LinearProgress, Chip } from '@mui/material';
 import {
   Mic as MicIcon,
   Stop as StopIcon,
@@ -21,6 +12,7 @@ import {
 } from '@mui/icons-material';
 import FormulusClient from './FormulusInterface';
 import { AudioResult } from './FormulusInterfaceDefinition';
+import QuestionShell from './QuestionShell';
 
 interface AudioQuestionRendererProps extends ControlProps {
   data: any;
@@ -210,34 +202,19 @@ const AudioQuestionRenderer: React.FC<AudioQuestionRendererProps> = ({
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 
+  const validationError =
+    errors && Array.isArray(errors) && errors.length > 0
+      ? errors.map((error: any) => error.message || String(error)).join(', ')
+      : null;
+
   return (
-    <Box sx={{ mb: 2 }}>
-      {/* Label */}
-      {schema.title && (
-        <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 500 }}>
-          {schema.title}
-          {schema.description && (
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-              {schema.description}
-            </Typography>
-          )}
-        </Typography>
-      )}
-
-      {/* Error Display */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Validation Errors */}
-      {errors && Array.isArray(errors) && errors.length > 0 && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {errors.map((error: any) => error.message).join(', ')}
-        </Alert>
-      )}
-
+    <QuestionShell
+      title={schema.title}
+      description={schema.description}
+      required={Boolean((uischema as any)?.options?.required ?? (schema as any)?.options?.required)}
+      error={error || validationError}
+      helperText="Record clear audio. You can re-record or delete as needed."
+    >
       <Paper
         variant="outlined"
         sx={{
@@ -401,7 +378,7 @@ const AudioQuestionRenderer: React.FC<AudioQuestionRendererProps> = ({
           </Box>
         )}
       </Paper>
-    </Box>
+    </QuestionShell>
   );
 };
 

--- a/formulus-formplayer/src/FileQuestionRenderer.tsx
+++ b/formulus-formplayer/src/FileQuestionRenderer.tsx
@@ -1,14 +1,5 @@
 import React, { useState, useCallback, useRef } from 'react';
-import {
-  Button,
-  Typography,
-  Box,
-  Alert,
-  CircularProgress,
-  Paper,
-  IconButton,
-  Chip,
-} from '@mui/material';
+import { Button, Typography, Box, CircularProgress, Paper, IconButton, Chip } from '@mui/material';
 import {
   AttachFile as FileIcon,
   Delete as DeleteIcon,
@@ -21,6 +12,7 @@ import { withJsonFormsControlProps } from '@jsonforms/react';
 import { ControlProps, rankWith, schemaTypeIs, and, schemaMatches } from '@jsonforms/core';
 import FormulusClient from './FormulusInterface';
 import { FileResult } from './FormulusInterfaceDefinition';
+import QuestionShell from './QuestionShell';
 
 // Tester function - determines when this renderer should be used
 export const fileQuestionTester = rankWith(
@@ -136,35 +128,29 @@ const FileQuestionRenderer: React.FC<ControlProps> = ({
 
   const hasData = data && typeof data === 'object' && data.type === 'file';
   const hasError = errors && (Array.isArray(errors) ? errors.length > 0 : errors.length > 0);
+  const validationError = hasError
+    ? Array.isArray(errors)
+      ? errors.join(', ')
+      : (errors as any)
+    : null;
 
   return (
-    <Box sx={{ mb: 2 }}>
-      {/* Title and Description */}
-      {schema.title && (
-        <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 500 }}>
-          {schema.title}
-        </Typography>
-      )}
-      {schema.description && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {schema.description}
-        </Typography>
-      )}
-
-      {/* Error Display */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Validation Errors */}
-      {hasError && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {Array.isArray(errors) ? errors.join(', ') : errors}
-        </Alert>
-      )}
-
+    <QuestionShell
+      title={schema.title}
+      description={schema.description}
+      required={Boolean((uischema as any)?.options?.required ?? (schema as any)?.options?.required)}
+      error={error || validationError}
+      helperText="Attach a file. Images, PDFs, and documents are supported."
+      metadata={
+        process.env.NODE_ENV === 'development' ? (
+          <Box sx={{ mt: 1, p: 1, bgcolor: 'info.light', borderRadius: 1 }}>
+            <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+              Debug: fieldId="{fieldId}", path="{path}", format="select_file"
+            </Typography>
+          </Box>
+        ) : undefined
+      }
+    >
       {/* File Selection Button */}
       {!hasData && (
         <Button
@@ -242,16 +228,7 @@ const FileQuestionRenderer: React.FC<ControlProps> = ({
           </Box>
         </Paper>
       )}
-
-      {/* Development Debug Info */}
-      {process.env.NODE_ENV === 'development' && (
-        <Box sx={{ mt: 2, p: 1, bgcolor: 'info.light', borderRadius: 1 }}>
-          <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-            Debug: fieldId="{fieldId}", path="{path}", format="select_file"
-          </Typography>
-        </Box>
-      )}
-    </Box>
+    </QuestionShell>
   );
 };
 

--- a/formulus-formplayer/src/GPSQuestionRenderer.tsx
+++ b/formulus-formplayer/src/GPSQuestionRenderer.tsx
@@ -8,7 +8,6 @@ import {
   Card,
   CardContent,
   Chip,
-  Alert,
   CircularProgress,
   Grid,
   Divider,
@@ -19,6 +18,7 @@ import {
   Delete as DeleteIcon,
   MyLocation as MyLocationIcon,
 } from '@mui/icons-material';
+import QuestionShell from './QuestionShell';
 // GPS is now captured automatically by the native app for all forms.
 // This renderer is kept only for backward-compatibility with existing
 // form schemas that still reference the "gps" format. It no longer
@@ -92,36 +92,33 @@ const GPSQuestionRenderer: React.FC<GPSQuestionRendererProps> = (props) => {
   const isDisabled = !enabled || isCapturing;
 
   return (
-    <Box sx={{ mb: 2 }}>
-      {/* Field Label */}
-      <Typography variant="h6" sx={{ mb: 1, fontWeight: 500 }}>
-        {schema.title || 'GPS Location'}
-      </Typography>
-
-      {/* Field Description */}
-      {schema.description && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {schema.description}
-        </Typography>
+    <QuestionShell
+      title={schema.title || 'GPS Location'}
+      description={schema.description}
+      required={Boolean(
+        (props.uischema as any)?.options?.required ?? (schema as any)?.options?.required,
       )}
-
-      {/* Error Display */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Validation Errors */}
-      {hasValidationErrors && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {Array.isArray(errors) ? errors.map((error: any) => error.message).join(', ') : errors}
-        </Alert>
-      )}
-
-      {/* Location Display or Capture Button */}
+      error={
+        error ||
+        (hasValidationErrors
+          ? Array.isArray(errors)
+            ? errors.map((error: any) => error.message || String(error)).join(', ')
+            : errors
+          : null)
+      }
+      helperText="GPS is captured automatically; use this only if the form requires manual capture."
+      metadata={
+        process.env.NODE_ENV === 'development' ? (
+          <Box sx={{ mt: 1, p: 1, bgcolor: 'grey.100', borderRadius: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              Debug - Path: {path} | Data: {JSON.stringify(data)}
+            </Typography>
+          </Box>
+        ) : undefined
+      }
+    >
       {locationData ? (
-        <Card variant="outlined" sx={{ mb: 2 }}>
+        <Card variant="outlined">
           <CardContent>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
               <LocationIcon color="primary" sx={{ mr: 1 }} />
@@ -239,16 +236,7 @@ const GPSQuestionRenderer: React.FC<GPSQuestionRendererProps> = (props) => {
           </Typography>
         </Box>
       )}
-
-      {/* Debug Information (only in development) */}
-      {process.env.NODE_ENV === 'development' && (
-        <Box sx={{ mt: 2, p: 1, bgcolor: 'grey.100', borderRadius: 1 }}>
-          <Typography variant="caption" color="text.secondary">
-            Debug - Path: {path} | Data: {JSON.stringify(data)}
-          </Typography>
-        </Box>
-      )}
-    </Box>
+    </QuestionShell>
   );
 };
 

--- a/formulus-formplayer/src/PhotoQuestionRenderer.tsx
+++ b/formulus-formplayer/src/PhotoQuestionRenderer.tsx
@@ -1,19 +1,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { ControlProps, rankWith, schemaTypeIs, and, schemaMatches } from '@jsonforms/core';
-import {
-  Button,
-  Box,
-  Typography,
-  Card,
-  CardMedia,
-  CardContent,
-  IconButton,
-  Alert,
-} from '@mui/material';
+import { Button, Box, Typography, Card, CardMedia, CardContent, IconButton } from '@mui/material';
 import { PhotoCamera, Delete, Refresh } from '@mui/icons-material';
 import FormulusClient from './FormulusInterface';
 import { CameraResult } from './FormulusInterfaceDefinition';
+import QuestionShell from './QuestionShell';
 
 // Tester function to identify photo question types
 export const photoQuestionTester = rankWith(
@@ -169,39 +161,56 @@ const PhotoQuestionRenderer: React.FC<PhotoQuestionProps> = ({
   // Get display label from schema or uischema
   const label = (uischema as any)?.label || schema.title || 'Photo';
   const description = schema.description;
-  const isRequired = schema.required || false;
+  const isRequired = Boolean(
+    (uischema as any)?.options?.required ?? (schema as any)?.options?.required ?? false,
+  );
+
+  const validationError = errors && errors.length > 0 ? String(errors[0]) : null;
 
   return (
-    <Box sx={{ mb: 2, width: '100%' }}>
-      {/* Label and description */}
-      <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'medium' }}>
-        {label}
-        {isRequired && <span style={{ color: 'red' }}> *</span>}
-      </Typography>
-
-      {description && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {description}
-        </Typography>
-      )}
-
-      {/* Error display - full width, pushes content down */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2, width: '100%', display: 'block' }}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Form validation errors */}
-      {errors && errors.length > 0 && (
-        <Alert severity="error" sx={{ mb: 2, width: '100%' }}>
-          {String(errors[0])}
-        </Alert>
-      )}
-
-      {/* Photo display or camera button */}
+    <QuestionShell
+      title={label}
+      description={description}
+      required={isRequired}
+      error={error || validationError}
+      helperText={
+        currentPhotoData?.filename ? `File: ${currentPhotoData.filename}` : 'Capture a clear photo.'
+      }
+      metadata={
+        process.env.NODE_ENV === 'development' ? (
+          <Box sx={{ p: 1, bgcolor: '#f5f5f5', borderRadius: 1 }}>
+            <Typography variant="caption" component="div">
+              Debug Info:
+            </Typography>
+            <Typography variant="caption" component="pre" sx={{ fontSize: '0.7rem' }}>
+              {JSON.stringify(
+                {
+                  fieldId,
+                  path,
+                  currentPhotoData,
+                  hasPhotoData: !!currentPhotoData,
+                  hasFilename: !!currentPhotoData?.filename,
+                  hasUri: !!currentPhotoData?.uri,
+                  photoUrl,
+                  hasPhotoUrl: !!photoUrl,
+                  shouldShowThumbnail: !!(
+                    currentPhotoData &&
+                    currentPhotoData.filename &&
+                    photoUrl
+                  ),
+                  isLoading,
+                  error,
+                },
+                null,
+                2,
+              )}
+            </Typography>
+          </Box>
+        ) : undefined
+      }
+    >
       {currentPhotoData && currentPhotoData.filename && photoUrl ? (
-        <Card sx={{ maxWidth: 400, mb: 2 }}>
+        <Card sx={{ maxWidth: 400 }}>
           <CardMedia
             component="img"
             height="200"
@@ -261,35 +270,7 @@ const PhotoQuestionRenderer: React.FC<PhotoQuestionProps> = ({
           </Button>
         </Box>
       )}
-
-      {/* Debug info in development */}
-      {process.env.NODE_ENV === 'development' && (
-        <Box sx={{ mt: 2, p: 1, bgcolor: '#f5f5f5', borderRadius: 1 }}>
-          <Typography variant="caption" component="div">
-            Debug Info:
-          </Typography>
-          <Typography variant="caption" component="pre" sx={{ fontSize: '0.7rem' }}>
-            {JSON.stringify(
-              {
-                fieldId,
-                path,
-                currentPhotoData,
-                hasPhotoData: !!currentPhotoData,
-                hasFilename: !!currentPhotoData?.filename,
-                hasUri: !!currentPhotoData?.uri,
-                photoUrl,
-                hasPhotoUrl: !!photoUrl,
-                shouldShowThumbnail: !!(currentPhotoData && currentPhotoData.filename && photoUrl),
-                isLoading,
-                error,
-              },
-              null,
-              2,
-            )}
-          </Typography>
-        </Box>
-      )}
-    </Box>
+    </QuestionShell>
   );
 };
 

--- a/formulus-formplayer/src/QrcodeQuestionRenderer.tsx
+++ b/formulus-formplayer/src/QrcodeQuestionRenderer.tsx
@@ -1,19 +1,11 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { ControlProps, rankWith, schemaTypeIs, and, schemaMatches } from '@jsonforms/core';
-import {
-  Button,
-  Box,
-  Typography,
-  Card,
-  CardContent,
-  IconButton,
-  Alert,
-  TextField,
-} from '@mui/material';
+import { Button, Box, Typography, Card, CardContent, IconButton, TextField } from '@mui/material';
 import { QrCodeScanner, Delete, Refresh } from '@mui/icons-material';
 import FormulusClient from './FormulusInterface';
 import { QrcodeResult } from './FormulusInterfaceDefinition';
+import QuestionShell from './QuestionShell';
 
 // Tester function to identify QR code question types
 export const qrcodeQuestionTester = rankWith(
@@ -149,39 +141,45 @@ const QrcodeQuestionRenderer: React.FC<QrcodeQuestionProps> = ({
   // Get display label from schema or uischema
   const label = (uischema as any)?.label || schema.title || 'QR Code';
   const description = schema.description;
-  const isRequired = schema.required || false;
+  const isRequired = Boolean(
+    (uischema as any)?.options?.required ?? (schema as any)?.options?.required ?? false,
+  );
+
+  const validationError = errors && errors.length > 0 ? String(errors[0]) : null;
 
   return (
-    <Box sx={{ mb: 2, width: '100%' }}>
-      {/* Label and description */}
-      <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'medium' }}>
-        {label}
-        {isRequired && <span style={{ color: 'red' }}> *</span>}
-      </Typography>
-
-      {description && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {description}
-        </Typography>
-      )}
-
-      {/* Error display - full width, pushes content down */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2, width: '100%', display: 'block' }}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Form validation errors */}
-      {errors && errors.length > 0 && (
-        <Alert severity="error" sx={{ mb: 2, width: '100%' }}>
-          {String(errors[0])}
-        </Alert>
-      )}
-
-      {/* QR code value display or scanner button */}
+    <QuestionShell
+      title={label}
+      description={description}
+      required={isRequired}
+      error={error || validationError}
+      helperText="Scan the code or enter it manually if needed."
+      metadata={
+        process.env.NODE_ENV === 'development' ? (
+          <Box sx={{ p: 1, bgcolor: '#f5f5f5', borderRadius: 1 }}>
+            <Typography variant="caption" component="div">
+              Debug Info:
+            </Typography>
+            <Typography variant="caption" component="pre" sx={{ fontSize: '0.7rem' }}>
+              {JSON.stringify(
+                {
+                  fieldId,
+                  path,
+                  currentQrcodeValue,
+                  hasQrcodeValue: !!currentQrcodeValue,
+                  isLoading,
+                  error,
+                },
+                null,
+                2,
+              )}
+            </Typography>
+          </Box>
+        ) : undefined
+      }
+    >
       {currentQrcodeValue ? (
-        <Card sx={{ mb: 2 }}>
+        <Card>
           <CardContent>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <Typography variant="body2" color="text.secondary">
@@ -263,30 +261,7 @@ const QrcodeQuestionRenderer: React.FC<QrcodeQuestionProps> = ({
           </Box>
         </Box>
       )}
-
-      {/* Debug info in development */}
-      {process.env.NODE_ENV === 'development' && (
-        <Box sx={{ mt: 2, p: 1, bgcolor: '#f5f5f5', borderRadius: 1 }}>
-          <Typography variant="caption" component="div">
-            Debug Info:
-          </Typography>
-          <Typography variant="caption" component="pre" sx={{ fontSize: '0.7rem' }}>
-            {JSON.stringify(
-              {
-                fieldId,
-                path,
-                currentQrcodeValue,
-                hasQrcodeValue: !!currentQrcodeValue,
-                isLoading,
-                error,
-              },
-              null,
-              2,
-            )}
-          </Typography>
-        </Box>
-      )}
-    </Box>
+    </QuestionShell>
   );
 };
 

--- a/formulus-formplayer/src/QuestionShell.tsx
+++ b/formulus-formplayer/src/QuestionShell.tsx
@@ -1,0 +1,102 @@
+import React, { ReactNode } from 'react';
+import { Box, Typography, Alert, Stack, Divider } from '@mui/material';
+
+export interface QuestionShellProps {
+  title?: string;
+  description?: string;
+  required?: boolean;
+  error?: string | string[] | null;
+  helperText?: ReactNode;
+  actions?: ReactNode;
+  metadata?: ReactNode;
+  children: ReactNode;
+}
+
+const normalizeError = (error?: string | string[] | null): string | null => {
+  if (!error) return null;
+  if (Array.isArray(error)) {
+    return error.filter(Boolean).join(', ') || null;
+  }
+  return error;
+};
+
+const QuestionShell: React.FC<QuestionShellProps> = ({
+  title,
+  description,
+  required = false,
+  error,
+  helperText,
+  actions,
+  metadata,
+  children,
+}) => {
+  const normalizedError = normalizeError(error);
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1.5,
+      }}
+    >
+      {(title || description) && (
+        <Stack spacing={0.5}>
+          {title && (
+            <Typography variant="h6" sx={{ fontWeight: 700, lineHeight: 1.3 }}>
+              {title}
+              {required && (
+                <Box component="span" sx={{ color: 'error.main', ml: 0.5 }}>
+                  *
+                </Box>
+              )}
+            </Typography>
+          )}
+          {description && (
+            <Typography variant="body1" color="text.secondary">
+              {description}
+            </Typography>
+          )}
+        </Stack>
+      )}
+
+      {normalizedError && (
+        <Alert severity="error" sx={{ width: '100%' }}>
+          {normalizedError}
+        </Alert>
+      )}
+
+      <Box
+        sx={{
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 1,
+        }}
+      >
+        {children}
+      </Box>
+
+      {(helperText || actions) && (
+        <Stack spacing={1}>
+          {helperText && (
+            <Typography variant="body2" color="text.secondary">
+              {helperText}
+            </Typography>
+          )}
+          {actions}
+        </Stack>
+      )}
+
+      {metadata && (
+        <Stack spacing={1}>
+          <Divider />
+          <Box>{metadata}</Box>
+        </Stack>
+      )}
+    </Box>
+  );
+};
+
+export default QuestionShell;

--- a/formulus-formplayer/src/SignatureQuestionRenderer.tsx
+++ b/formulus-formplayer/src/SignatureQuestionRenderer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { Button, Typography, Box, Alert, CircularProgress, Paper, IconButton } from '@mui/material';
+import { Button, Typography, Box, CircularProgress, Paper, IconButton } from '@mui/material';
 import {
   Draw as SignatureIcon,
   Delete as DeleteIcon,
@@ -9,6 +9,7 @@ import { withJsonFormsControlProps } from '@jsonforms/react';
 import { ControlProps, rankWith, formatIs } from '@jsonforms/core';
 import FormulusClient from './FormulusInterface';
 import { SignatureResult } from './FormulusInterfaceDefinition';
+import QuestionShell from './QuestionShell';
 
 // Tester function - determines when this renderer should be used
 export const signatureQuestionTester = rankWith(
@@ -227,39 +228,28 @@ const SignatureQuestionRenderer: React.FC<ControlProps> = ({
   }
 
   const hasData = data && typeof data === 'object' && data.type === 'signature';
-  const hasError = errors && (Array.isArray(errors) ? errors.length > 0 : errors.length > 0);
+  const validationError = errors && (Array.isArray(errors) ? errors.join(', ') : errors);
 
   return (
-    <Box sx={{ mb: 2 }}>
-      {/* Title and Description */}
-      {schema.title && (
-        <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 500 }}>
-          {schema.title}
-        </Typography>
-      )}
-      {schema.description && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {schema.description}
-        </Typography>
-      )}
-
-      {/* Error Display */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Validation Errors */}
-      {hasError && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {Array.isArray(errors) ? errors.join(', ') : errors}
-        </Alert>
-      )}
-
+    <QuestionShell
+      title={schema.title}
+      description={schema.description}
+      required={Boolean((uischema as any)?.options?.required ?? (schema as any)?.options?.required)}
+      error={error || validationError}
+      helperText="Capture a clear signature. You can use native capture or draw on canvas."
+      metadata={
+        process.env.NODE_ENV === 'development' ? (
+          <Box sx={{ mt: 1, p: 1, bgcolor: 'info.light', borderRadius: 1 }}>
+            <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+              Debug: fieldId="{fieldId}", path="{path}", format="signature"
+            </Typography>
+          </Box>
+        ) : undefined
+      }
+    >
       {/* Canvas Signature Pad */}
       {showCanvas && (
-        <Paper sx={{ p: 2, mb: 2 }}>
+        <Paper sx={{ p: 2 }}>
           <Typography variant="subtitle2" sx={{ mb: 2 }}>
             Draw your signature below:
           </Typography>
@@ -325,7 +315,7 @@ const SignatureQuestionRenderer: React.FC<ControlProps> = ({
 
       {/* Action Buttons */}
       {!showCanvas && (
-        <Box sx={{ mb: 2 }}>
+        <Box>
           <Button
             variant="contained"
             startIcon={isCapturing ? <CircularProgress size={20} /> : <SignatureIcon />}
@@ -389,16 +379,7 @@ const SignatureQuestionRenderer: React.FC<ControlProps> = ({
           </Box>
         </Paper>
       )}
-
-      {/* Development Debug Info */}
-      {process.env.NODE_ENV === 'development' && (
-        <Box sx={{ mt: 2, p: 1, bgcolor: 'info.light', borderRadius: 1 }}>
-          <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-            Debug: fieldId="{fieldId}", path="{path}", format="signature"
-          </Typography>
-        </Box>
-      )}
-    </Box>
+    </QuestionShell>
   );
 };
 

--- a/formulus-formplayer/src/VideoQuestionRenderer.tsx
+++ b/formulus-formplayer/src/VideoQuestionRenderer.tsx
@@ -1,17 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { rankWith, ControlProps, formatIs } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import {
-  Button,
-  Typography,
-  Box,
-  Card,
-  CardContent,
-  Chip,
-  Alert,
-  Grid,
-  Divider,
-} from '@mui/material';
+import { Button, Typography, Box, Card, CardContent, Chip, Grid, Divider } from '@mui/material';
 import {
   Videocam as VideocamIcon,
   PlayArrow as PlayIcon,
@@ -21,6 +11,7 @@ import {
   Delete as DeleteIcon,
   VideoFile as VideoFileIcon,
 } from '@mui/icons-material';
+import QuestionShell from './QuestionShell';
 // Note: The shared Formulus interface v1.1.0 no longer exposes a
 // requestVideo() API. This renderer therefore does not actively
 // trigger native video recording anymore. It can still display
@@ -129,36 +120,34 @@ const VideoQuestionRenderer: React.FC<VideoQuestionRendererProps> = (props) => {
   const isDisabled = !enabled;
 
   return (
-    <Box sx={{ mb: 2 }}>
-      {/* Field Label */}
-      <Typography variant="h6" sx={{ mb: 1, fontWeight: 500 }}>
-        {schema.title || 'Video Recording'}
-      </Typography>
-
-      {/* Field Description */}
-      {schema.description && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {schema.description}
-        </Typography>
+    <QuestionShell
+      title={schema.title || 'Video Recording'}
+      description={schema.description}
+      required={Boolean(
+        (props.uischema as any)?.options?.required ?? (schema as any)?.options?.required,
       )}
-
-      {/* Error Display */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Validation Errors */}
-      {hasValidationErrors && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {Array.isArray(errors) ? errors.map((error: any) => error.message).join(', ') : errors}
-        </Alert>
-      )}
-
+      error={
+        error ||
+        (hasValidationErrors
+          ? Array.isArray(errors)
+            ? errors.map((error: any) => error.message || String(error)).join(', ')
+            : errors
+          : null)
+      }
+      helperText="Capture a video if required. Current app version may not support recording."
+      metadata={
+        process.env.NODE_ENV === 'development' ? (
+          <Box sx={{ mt: 1, p: 1, bgcolor: 'grey.100', borderRadius: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              Debug - Path: {path} | Data: {JSON.stringify(data)}
+            </Typography>
+          </Box>
+        ) : undefined
+      }
+    >
       {/* Video Display or Record Button */}
       {videoData ? (
-        <Card variant="outlined" sx={{ mb: 2 }}>
+        <Card variant="outlined">
           <CardContent>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
               <VideoFileIcon color="primary" sx={{ mr: 1 }} />
@@ -316,16 +305,7 @@ const VideoQuestionRenderer: React.FC<VideoQuestionRendererProps> = (props) => {
           </Typography>
         </Box>
       )}
-
-      {/* Debug Information (only in development) */}
-      {process.env.NODE_ENV === 'development' && (
-        <Box sx={{ mt: 2, p: 1, bgcolor: 'grey.100', borderRadius: 1 }}>
-          <Typography variant="caption" color="text.secondary">
-            Debug - Path: {path} | Data: {JSON.stringify(data)}
-          </Typography>
-        </Box>
-      )}
-    </Box>
+    </QuestionShell>
   );
 };
 

--- a/formulus-formplayer/src/material-wrappers.tsx
+++ b/formulus-formplayer/src/material-wrappers.tsx
@@ -32,7 +32,9 @@ const wrapWithShell =
     const { schema, uischema, errors } = props;
     const label = (uischema as any)?.label || schema.title;
     const description = schema.description;
-    const required = Boolean((uischema as any)?.options?.required ?? (schema as any)?.options?.required);
+    const required = Boolean(
+      (uischema as any)?.options?.required ?? (schema as any)?.options?.required,
+    );
 
     return (
       <QuestionShell title={label} description={description} required={required} error={errors}>
@@ -47,7 +49,9 @@ const CardEnumControl = (props: AnyControlProps) => {
   const { data, handleChange, path, schema, uischema, errors, enabled = true } = props;
   const label = (uischema as any)?.label || schema.title;
   const description = schema.description;
-  const required = Boolean((uischema as any)?.options?.required ?? (schema as any)?.options?.required);
+  const required = Boolean(
+    (uischema as any)?.options?.required ?? (schema as any)?.options?.required,
+  );
 
   const options =
     schema.oneOf?.map((o: any) => ({
@@ -115,7 +119,10 @@ export const shellMaterialRenderers = [
   },
   // Card-style select/oneOf/radio
   { tester: cardEnumControlTester, renderer: withJsonFormsControlProps(CardEnumControl) },
-  { tester: materialEnumControlTester, renderer: withJsonFormsControlProps(wrapWithShell(MaterialEnumControl)) },
+  {
+    tester: materialEnumControlTester,
+    renderer: withJsonFormsControlProps(wrapWithShell(MaterialEnumControl)),
+  },
   {
     tester: materialOneOfEnumControlTester,
     renderer: withJsonFormsControlProps(wrapWithShell(MaterialOneOfEnumControl)),

--- a/formulus-formplayer/src/material-wrappers.tsx
+++ b/formulus-formplayer/src/material-wrappers.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { isEnumControl, RankedTester, rankWith, ControlProps } from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import {
+  MaterialTextControl,
+  materialTextControlTester,
+  MaterialNumberControl,
+  materialNumberControlTester,
+  MaterialIntegerControl,
+  materialIntegerControlTester,
+  MaterialDateControl,
+  materialDateControlTester,
+  MaterialDateTimeControl,
+  materialDateTimeControlTester,
+  MaterialTimeControl,
+  materialTimeControlTester,
+  MaterialEnumControl,
+  materialEnumControlTester,
+  MaterialOneOfEnumControl,
+  materialOneOfEnumControlTester,
+  MaterialRadioGroupControl,
+  materialRadioGroupControlTester,
+} from '@jsonforms/material-renderers';
+import { Card, CardActionArea, CardContent, Typography, Box } from '@mui/material';
+import QuestionShell from './QuestionShell';
+
+type AnyControlProps = ControlProps & { errors?: string };
+
+const wrapWithShell =
+  (Inner: React.ComponentType<any>) =>
+  (props: ControlProps): React.ReactElement => {
+    const { schema, uischema, errors } = props;
+    const label = (uischema as any)?.label || schema.title;
+    const description = schema.description;
+    const required = Boolean((uischema as any)?.options?.required ?? (schema as any)?.options?.required);
+
+    return (
+      <QuestionShell title={label} description={description} required={required} error={errors}>
+        <Inner {...(props as any)} />
+      </QuestionShell>
+    );
+  };
+
+const cardEnumControlTester: RankedTester = rankWith(6, isEnumControl);
+
+const CardEnumControl = (props: AnyControlProps) => {
+  const { data, handleChange, path, schema, uischema, errors, enabled = true } = props;
+  const label = (uischema as any)?.label || schema.title;
+  const description = schema.description;
+  const required = Boolean((uischema as any)?.options?.required ?? (schema as any)?.options?.required);
+
+  const options =
+    schema.oneOf?.map((o: any) => ({
+      value: o.const ?? o.enum?.[0] ?? o,
+      label: o.title ?? String(o.const ?? o),
+    })) || (schema.enum || []).map((v: any) => ({ value: v, label: String(v) }));
+
+  return (
+    <QuestionShell title={label} description={description} required={required} error={errors}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {options.map((opt) => {
+          const selected = data === opt.value;
+          return (
+            <Card
+              key={String(opt.value)}
+              variant={selected ? 'elevation' : 'outlined'}
+              sx={{
+                borderColor: selected ? 'primary.main' : 'divider',
+                boxShadow: selected ? 3 : 0,
+              }}
+            >
+              <CardActionArea
+                disabled={!enabled}
+                onClick={() => handleChange(path, opt.value)}
+                sx={{ p: 1.5 }}
+              >
+                <CardContent sx={{ py: 0.5, '&:last-child': { pb: 0.5 } }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: selected ? 700 : 500 }}>
+                    {opt.label}
+                  </Typography>
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          );
+        })}
+      </Box>
+    </QuestionShell>
+  );
+};
+
+export const shellMaterialRenderers = [
+  {
+    tester: materialTextControlTester,
+    renderer: withJsonFormsControlProps(wrapWithShell(MaterialTextControl)),
+  },
+  {
+    tester: materialNumberControlTester,
+    renderer: withJsonFormsControlProps(wrapWithShell(MaterialNumberControl)),
+  },
+  {
+    tester: materialIntegerControlTester,
+    renderer: withJsonFormsControlProps(wrapWithShell(MaterialIntegerControl)),
+  },
+  {
+    tester: materialDateControlTester,
+    renderer: withJsonFormsControlProps(wrapWithShell(MaterialDateControl)),
+  },
+  {
+    tester: materialDateTimeControlTester,
+    renderer: withJsonFormsControlProps(wrapWithShell(MaterialDateTimeControl)),
+  },
+  {
+    tester: materialTimeControlTester,
+    renderer: withJsonFormsControlProps(wrapWithShell(MaterialTimeControl)),
+  },
+  // Card-style select/oneOf/radio
+  { tester: cardEnumControlTester, renderer: withJsonFormsControlProps(CardEnumControl) },
+  { tester: materialEnumControlTester, renderer: withJsonFormsControlProps(wrapWithShell(MaterialEnumControl)) },
+  {
+    tester: materialOneOfEnumControlTester,
+    renderer: withJsonFormsControlProps(wrapWithShell(MaterialOneOfEnumControl)),
+  },
+  {
+    tester: materialRadioGroupControlTester,
+    renderer: withJsonFormsControlProps(wrapWithShell(MaterialRadioGroupControl)),
+  },
+];

--- a/formulus-formplayer/src/theme.ts
+++ b/formulus-formplayer/src/theme.ts
@@ -142,6 +142,14 @@ const themeOptions: ThemeOptions = {
     borderRadius: parsePx(tokens.border.radius.lg), // 12px - Material Design 3 default
   },
   components: {
+    MuiFormControl: {
+      styleOverrides: {
+        root: {
+          width: '100%',
+          marginBottom: parsePx(tokens.spacing[4]),
+        },
+      },
+    },
     // Button styling - Material Design 3 with ODE tokens
     MuiButton: {
       styleOverrides: {
@@ -199,6 +207,8 @@ const themeOptions: ThemeOptions = {
     MuiTextField: {
       styleOverrides: {
         root: {
+          width: '100%',
+          marginBottom: parsePx(tokens.spacing[4]),
           '& .MuiOutlinedInput-root': {
             borderRadius: parsePx(tokens.border.radius.sm), // 4px - Material Design 3 text field
             backgroundColor: 'transparent',


### PR DESCRIPTION
## Description

- Add shared `QuestionShell` to standardize title/description/error hierarchy across questions.
- Wrap standard Material JSONForms controls with the shell and render enum/oneOf/radio as card-style selects.
- Apply mobile-friendly spacing via theme overrides; align custom media renderers to the shell pattern.

Closes #100

## Testing
- [x] Manually tested (`npm start` on port 3001)

## Checklist

- [x] Code follows project style guidelines
- [x] All existing tests pass (lint/format run; no new tests added)
