### PR TITLE
[Formulus]Fix bottom navigation bar covered by Android system navigation bar

### DIFF
--- a/formulus/src/navigation/MainTabNavigator.tsx
+++ b/formulus/src/navigation/MainTabNavigator.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import HomeScreen from '../screens/HomeScreen';
 import FormsScreen from '../screens/FormsScreen';
@@ -10,6 +11,10 @@ import MoreScreen from '../screens/MoreScreen';
 const Tab = createBottomTabNavigator();
 
 const MainTabNavigator: React.FC = () => {
+  const insets = useSafeAreaInsets();
+  const baseTabBarHeight = 60;
+  const tabBarHeight = baseTabBarHeight + insets.bottom;
+
   return (
     <Tab.Navigator
       screenOptions={{
@@ -20,9 +25,9 @@ const MainTabNavigator: React.FC = () => {
           backgroundColor: '#FFFFFF',
           borderTopWidth: 1,
           borderTopColor: '#E5E5E5',
-          paddingBottom: 4,
+          paddingBottom: Math.max(insets.bottom, 4),
           paddingTop: 4,
-          height: 60,
+          height: tabBarHeight,
         },
       }}>
       <Tab.Screen


### PR DESCRIPTION
## Description
The bottom navigation bar was being overlapped by the Android system navigation bar, making it partially hidden and unclickable on Android devices.
### Solution

- Use `useSafeAreaInsets()` to get device-specific safe area insets
- Dynamically adjust tab bar height: **baseHeight + insets.bottom**
- Adjust bottom padding to account for the system navigation bar

### Changes

- Modified `MainTabNavigator.tsx `to use safe area insets
- Tab bar now sits above the system navigation bar on all devices
- Works with both gesture navigation and 3-button navigation

Fixes #98