### PR TITLE
[Formulus] feat: Clear local state when switching Synkronus servers

### DIFF
--- a/formulus/src/services/ServerSwitchService.ts
+++ b/formulus/src/services/ServerSwitchService.ts
@@ -1,0 +1,80 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import RNFS from 'react-native-fs';
+import {database} from '../database/database';
+import {databaseService} from '../database/DatabaseService';
+import {synkronusApi} from '../api/synkronus';
+import {logout} from '../api/synkronus/Auth';
+import {serverConfigService} from './ServerConfigService';
+
+/**
+ * Handles cleanup when switching Synkronus servers to avoid cross-server data.
+ */
+class ServerSwitchService {
+  /**
+   * Count pending local observations (unsynced).
+   */
+  async getPendingObservationCount(): Promise<number> {
+    const localRepo = databaseService.getLocalRepo();
+    const pending = await localRepo.getPendingChanges();
+    return pending.length;
+  }
+
+  /**
+   * Count pending attachment uploads.
+   */
+  async getPendingAttachmentCount(): Promise<number> {
+    return await synkronusApi.getUnsyncedAttachmentCount();
+  }
+
+  /**
+   * Fully reset local state and persist the new server URL.
+   */
+  async resetForServerChange(serverUrl: string): Promise<void> {
+    // 1) Reset DB
+    await database.write(async () => {
+      await database.unsafeResetDatabase();
+    });
+
+    // 2) Clear sync/app metadata + tokens
+    await AsyncStorage.multiRemove([
+      '@last_seen_version',
+      '@last_attachment_version',
+      '@lastSync',
+      '@appVersion',
+      '@settings',
+      '@server_url',
+      '@token',
+      '@refreshToken',
+      '@tokenExpiresAt',
+      '@user',
+    ]);
+    // Reinitialize app version to baseline
+    await AsyncStorage.setItem('@appVersion', '0');
+
+    // 3) Clear attachments on disk
+    const attachmentsDirectory = `${RNFS.DocumentDirectoryPath}/attachments`;
+    try {
+      if (await RNFS.exists(attachmentsDirectory)) {
+        await RNFS.unlink(attachmentsDirectory);
+      }
+    } catch (error) {
+      console.warn('Failed to delete attachments directory:', error);
+    }
+    await RNFS.mkdir(attachmentsDirectory);
+    await RNFS.mkdir(`${attachmentsDirectory}/pending_upload`);
+
+    // 4) Clear app bundle and forms
+    await synkronusApi.removeAppBundleFiles();
+
+    // 5) Clear auth/session
+    await logout().catch(error =>
+      console.warn('Logout during server switch failed:', error),
+    );
+
+    // 6) Save the new server URL (recreates @settings/@server_url)
+    await serverConfigService.saveServerUrl(serverUrl);
+  }
+}
+
+export const serverSwitchService = new ServerSwitchService();
+

--- a/formulus/src/services/ServerSwitchService.ts
+++ b/formulus/src/services/ServerSwitchService.ts
@@ -77,4 +77,3 @@ class ServerSwitchService {
 }
 
 export const serverSwitchService = new ServerSwitchService();
-

--- a/formulus/src/services/__tests__/ServerSwitchService.test.ts
+++ b/formulus/src/services/__tests__/ServerSwitchService.test.ts
@@ -1,0 +1,114 @@
+/// <reference types="jest" />
+
+import {describe, it, expect, jest, beforeEach} from '@jest/globals';
+
+const mockDatabase = {
+  write: jest.fn(async (cb?: () => Promise<void> | void) => {
+    if (cb) {
+      await cb();
+    }
+  }),
+  unsafeResetDatabase: jest.fn(),
+};
+
+jest.mock('../../database/database', () => ({
+  database: mockDatabase,
+}));
+
+const mockLocalRepo = {getPendingChanges: jest.fn()};
+jest.mock('../../database/DatabaseService', () => ({
+  databaseService: {
+    getLocalRepo: jest.fn(() => mockLocalRepo),
+  },
+}));
+
+const mockAsyncStorage = {
+  multiRemove: jest.fn(),
+  setItem: jest.fn(),
+};
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
+
+const mockRNFS = {
+  DocumentDirectoryPath: '/mock/doc',
+  exists: jest.fn(),
+  unlink: jest.fn(),
+  mkdir: jest.fn(),
+};
+jest.mock('react-native-fs', () => mockRNFS);
+
+const mockSynkronusApi = {
+  removeAppBundleFiles: jest.fn(),
+  getUnsyncedAttachmentCount: jest.fn(),
+};
+jest.mock('../../api/synkronus', () => ({
+  synkronusApi: mockSynkronusApi,
+}));
+
+const mockLogout = jest.fn(() => Promise.resolve());
+jest.mock('../../api/synkronus/Auth', () => ({
+  logout: mockLogout,
+}));
+
+const mockServerConfigService = {
+  saveServerUrl: jest.fn(),
+};
+jest.mock('../ServerConfigService', () => ({
+  serverConfigService: mockServerConfigService,
+}));
+
+const {serverSwitchService} = require('../ServerSwitchService');
+
+describe('ServerSwitchService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resets local state and saves new server URL', async () => {
+    mockRNFS.exists.mockResolvedValueOnce(true);
+
+    await serverSwitchService.resetForServerChange('https://new.example');
+
+    expect(mockDatabase.write).toHaveBeenCalled();
+    expect(mockDatabase.unsafeResetDatabase).toHaveBeenCalled();
+
+    expect(mockAsyncStorage.multiRemove).toHaveBeenCalledWith([
+      '@last_seen_version',
+      '@last_attachment_version',
+      '@lastSync',
+      '@appVersion',
+      '@settings',
+      '@server_url',
+      '@token',
+      '@refreshToken',
+      '@tokenExpiresAt',
+      '@user',
+    ]);
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith('@appVersion', '0');
+
+    expect(mockRNFS.exists).toHaveBeenCalledWith('/mock/doc/attachments');
+    expect(mockRNFS.unlink).toHaveBeenCalledWith('/mock/doc/attachments');
+    expect(mockRNFS.mkdir).toHaveBeenCalledWith('/mock/doc/attachments');
+    expect(mockRNFS.mkdir).toHaveBeenCalledWith(
+      '/mock/doc/attachments/pending_upload',
+    );
+
+    expect(mockSynkronusApi.removeAppBundleFiles).toHaveBeenCalled();
+    expect(mockLogout).toHaveBeenCalled();
+    expect(mockServerConfigService.saveServerUrl).toHaveBeenCalledWith(
+      'https://new.example',
+    );
+  });
+
+  it('returns pending observation count', async () => {
+    mockLocalRepo.getPendingChanges.mockResolvedValueOnce([1, 2, 3]);
+    const result = await serverSwitchService.getPendingObservationCount();
+    expect(result).toBe(3);
+  });
+
+  it('returns pending attachment count', async () => {
+    mockSynkronusApi.getUnsyncedAttachmentCount.mockResolvedValueOnce(5);
+    const result = await serverSwitchService.getPendingAttachmentCount();
+    expect(result).toBe(5);
+  });
+});
+

--- a/formulus/src/services/__tests__/ServerSwitchService.test.ts
+++ b/formulus/src/services/__tests__/ServerSwitchService.test.ts
@@ -111,4 +111,3 @@ describe('ServerSwitchService', () => {
     expect(result).toBe(5);
   });
 });
-


### PR DESCRIPTION
## Description

Implements full local data reset when users switch Synkronus server URLs to prevent cross-server data corruption.

## Changes

- Added `ServerSwitchService` to orchestrate complete local state reset
- Updated `SettingsScreen` to detect server URL changes and prompt user
- Shows unsynced data counts (observations + attachments) before reset
- Offers three options:
  - **Sync then switch** (recommended): Syncs all data first, then resets
  - **Proceed without syncing**: Immediately wipes and switches
  - **Cancel**: Aborts the operation

## What Gets Reset

- WatermelonDB (all observations)
- Sync cursors (\`@last_seen_version\`, \`@last_attachment_version\`)
- App bundle and form definitions (\`/app\`, \`/forms\`)
- Attachment files (\`/attachments\`, \`/attachments/pending_upload\`)
- Auth tokens and user session
- All AsyncStorage sync/app metadata

## Testing

- ✅ Unit tests added for \`ServerSwitchService\`
- ✅ All tests passing
- ✅ Tested on device.

Resolves #109