### PR TITLE
[Formulus] Fix: Clear token cache when switching servers

### DIFF
--- a/formulus/src/api/synkronus/Auth.ts
+++ b/formulus/src/api/synkronus/Auth.ts
@@ -28,6 +28,8 @@ export const login = async (
   console.log('Logging in with', username);
   const api = await synkronusApi.getApi();
 
+  synkronusApi.clearTokenCache();
+
   const res = await api.login({
     loginRequest: {username, password},
   });

--- a/formulus/src/api/synkronus/index.ts
+++ b/formulus/src/api/synkronus/index.ts
@@ -30,6 +30,7 @@ class SynkronusApi {
     if (this.config && this.config.basePath !== serverUrl) {
       this.api = null;
       this.config = null;
+      this.fastGetToken_cachedToken = null;
     }
 
     // If API exists, return it (serverUrl hasn't changed)
@@ -357,6 +358,10 @@ class SynkronusApi {
       return authToken;
     }
     throw new Error('Unable to retrieve auth token');
+  }
+
+  public clearTokenCache(): void {
+    this.fastGetToken_cachedToken = null;
   }
 
   private async downloadRawFiles(


### PR DESCRIPTION
## Description

App bundle downloads fail with 401 errors when switching between servers because the cached authentication token from the previous server is reused.

### Solution
- Clear cached token when server URL changes in `getApi()`
- Clear cached token on login to ensure fresh token for new server
- Added `clearTokenCache()` public method for explicit cache invalidation

### Changes
- `SynkronusApi.getApi()`: Clear token cache when server URL changes
- `SynkronusApi.clearTokenCache()`: New public method to clear cached token
- `Auth.login()`: Clear token cache before logging in

### Testing
- Login to local server → app bundle downloads successfully
- Switch to demo server → app bundle downloads successfully (no 401 errors)

Closes #111