### PR TITLE
feat: implement native-as-source version management

### DIFF
--- a/formulus-formplayer/package-lock.json
+++ b/formulus-formplayer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "formulus-formplayer",
-  "version": "0.0.3",
+  "version": "1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "formulus-formplayer",
-      "version": "0.0.3",
+      "version": "1.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/formulus-formplayer/package.json
+++ b/formulus-formplayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formulus-formplayer",
-  "version": "0.0.3",
+  "version": "1.0",
   "private": true,
   "homepage": ".",
   "dependencies": {
@@ -35,6 +35,9 @@
   "scripts": {
     "start": "react-scripts start",
     "sync-interface": "node scripts/sync-interface.js",
+    "sync:version": "node scripts/sync-version-from-parent.js",
+    "prebuild": "npm run sync:version && npm run sync-interface && react-scripts build",
+    "prestart": "npm run sync:version && react-scripts start",
     "build": "npm run sync-interface && react-scripts build",
     "upload:android": "npm run build && node scripts/clean-rn-assets.js && node scripts/copy-to-rn.js",
     "build:rn": "npm run build && npm run copy-to-rn",

--- a/formulus-formplayer/scripts/sync-version-from-parent.js
+++ b/formulus-formplayer/scripts/sync-version-from-parent.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Generate formplayer/src/version.ts from the RN app's generated src/version.ts.
+ * Does NOT modify package.json or lockfiles.
+ */
+
+const FORMULUS_VERSION_TS = path.join(__dirname, '..', '..', 'formulus', 'src', 'version.ts');
+const OUT_PATH = path.join(__dirname, '..', 'src', 'version.ts');
+
+function extractAppVersion(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const match = content.match(/export const APP_VERSION = ['"]([^'"]+)['"]/);
+  if (!match) {
+    throw new Error('APP_VERSION not found in formulus/src/version.ts');
+  }
+  return match[1];
+}
+
+function writeVersionTs(version) {
+  const contents = `/**
+ * ⚠️ AUTO-GENERATED — DO NOT EDIT
+ * Source: formulus/src/version.ts
+ */
+
+export const APP_VERSION = '${version}';
+`;
+  fs.writeFileSync(OUT_PATH, contents, 'utf8');
+  console.log(`Generated formplayer src/version.ts with APP_VERSION=${version}`);
+}
+
+function main() {
+  const version = extractAppVersion(FORMULUS_VERSION_TS);
+  writeVersionTs(version);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`sync-version-from-parent failed: ${err.message}`);
+  process.exit(1);
+}
+

--- a/formulus-formplayer/src/FormulusInterfaceDefinition.ts
+++ b/formulus-formplayer/src/FormulusInterfaceDefinition.ts
@@ -10,6 +10,10 @@
  *
  * Current Version: 1.0.17
  */
+/**
+ * Current version of the interface (manual, bump on breaking changes)
+ */
+export const FORMULUS_INTERFACE_VERSION = '1.1.0';
 
 /**
  * Data passed to the Formulus app when a form is initialized
@@ -403,11 +407,6 @@ export interface FormulusCallbacks {
   ) => void;
   onReceiveFocus?: () => void;
 }
-
-/**
- * Current version of the interface
- */
-export const FORMULUS_INTERFACE_VERSION = '1.1.0';
 
 /**
  * Check if the current interface version is compatible with the required version

--- a/formulus-formplayer/src/version.ts
+++ b/formulus-formplayer/src/version.ts
@@ -1,0 +1,6 @@
+/**
+ * ⚠️ AUTO-GENERATED — DO NOT EDIT
+ * Source: formulus/src/version.ts
+ */
+
+export const APP_VERSION = '1.0';

--- a/formulus/package-lock.json
+++ b/formulus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "formulus-app",
-  "version": "0.0.1",
+  "version": "1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "formulus-app",
-      "version": "0.0.1",
+      "version": "1.0",
       "dependencies": {
         "@notifee/react-native": "^9.1.8",
         "@nozbe/watermelondb": "^0.28.0",

--- a/formulus/package.json
+++ b/formulus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formulus-app",
-  "version": "0.0.1",
+  "version": "1.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",
@@ -14,7 +14,9 @@
     "generate": "ts-node --project scripts/tsconfig.json scripts/generateInjectionScript.ts",
     "generate:api": "openapi-generator-cli generate -i ../synkronus/openapi/synkronus.yaml -g typescript-axios -o src/api/synkronus/generated --additional-properties=supportsES6=true,useSingleRequestParameter=true,modelPropertyNaming=original",
     "generate_qr": "ts-node --project scripts/tsconfig.json scripts/generateQR.ts",
-    "prebuild": "npm run generate"
+    "generate:version": "node scripts/sync-version-to-package.js",
+    "prebuild": "npm run generate && npm run generate:version",
+    "prestart": "npm run generate:version"
   },
   "dependencies": {
     "@notifee/react-native": "^9.1.8",

--- a/formulus/scripts/sync-version-to-package.js
+++ b/formulus/scripts/sync-version-to-package.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Generate src/version.ts from native source of truth (Android versionName).
+ * Optional: warn if iOS MARKETING_VERSION differs.
+ * Does NOT touch package.json or lockfiles.
+ */
+
+const ROOT = path.join(__dirname, '..');
+
+function readFileSafe(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function getAndroidVersionName() {
+  const gradlePath = path.join(ROOT, 'android/app/build.gradle');
+  const content = readFileSafe(gradlePath);
+  const match = content.match(/versionName\s*=\s*["']([^"']+)["']/);
+  if (!match) {
+    throw new Error('versionName not found in android/app/build.gradle');
+  }
+  return match[1];
+}
+
+function getIosMarketingVersion() {
+  const pbxPath = path.join(ROOT, 'ios/Formulus.xcodeproj/project.pbxproj');
+  if (!fs.existsSync(pbxPath)) return null;
+  const content = readFileSafe(pbxPath);
+  const match = content.match(/MARKETING_VERSION\s*=\s*([0-9A-Za-z.-]+);/);
+  return match ? match[1] : null;
+}
+
+function writeVersionTs(version) {
+  const outPath = path.join(ROOT, 'src/version.ts');
+  const contents = `/**
+ * ⚠️ AUTO-GENERATED — DO NOT EDIT
+ * Source: android/app/build.gradle versionName
+ */
+
+export const APP_VERSION = '${version}';
+`;
+  fs.writeFileSync(outPath, contents, 'utf8');
+  console.log(`Generated src/version.ts with APP_VERSION=${version}`);
+}
+
+function main() {
+  const androidVersion = getAndroidVersionName();
+  const iosVersion = getIosMarketingVersion();
+
+  if (iosVersion && iosVersion !== androidVersion) {
+    console.warn(
+      `Warning: iOS MARKETING_VERSION (${iosVersion}) differs from Android versionName (${androidVersion}). Align them to avoid mismatches.`,
+    );
+  }
+
+  writeVersionTs(androidVersion);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`sync-version-to-package failed: ${err.message}`);
+  process.exit(1);
+}

--- a/formulus/src/version.ts
+++ b/formulus/src/version.ts
@@ -1,0 +1,6 @@
+/**
+ * ⚠️ AUTO-GENERATED — DO NOT EDIT
+ * Source: android/app/build.gradle versionName
+ */
+
+export const APP_VERSION = '1.0';

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -10,6 +10,10 @@
  *
  * Current Version: 1.0.17
  */
+/**
+ * Current version of the interface (manual, bump on breaking changes)
+ */
+export const FORMULUS_INTERFACE_VERSION = '1.1.0';
 
 /**
  * Data passed to the Formulus app when a form is initialized
@@ -419,11 +423,6 @@ export interface FormulusCallbacks {
   ) => void;
   onReceiveFocus?: () => void;
 }
-
-/**
- * Current version of the interface
- */
-export const FORMULUS_INTERFACE_VERSION = '1.1.0';
 
 /**
  * Check if the current interface version is compatible with the required version

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -5,6 +5,7 @@ It handles the messages received from the WebView and executes the corresponding
 import {GeolocationService} from '../services/GeolocationService';
 import {WebViewMessageEvent, WebView} from 'react-native-webview';
 import RNFS from 'react-native-fs';
+import {AppVersionService} from '../services/AppVersionService';
 
 export type HandlerArgs = {
   data: any;
@@ -274,8 +275,8 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
     },
     onGetVersion: async (): Promise<string> => {
       console.log('FormulusMessageHandlers: onGetVersion handler invoked.');
-      // Replace with your actual version retrieval logic.
-      const version = '0.1.0-native'; // Example version
+      const appVersionService = AppVersionService.getInstance();
+      const version = await appVersionService.getVersion();
       return version;
     },
     onSubmitObservation: async (data: {


### PR DESCRIPTION
## Descripton

Eliminates all hardcoded version numbers and establishes native platform configs as the single source of truth.

## Changes

### React Native App (`formulus`)
- **New**: `scripts/sync-version-to-package.js` - Generates `src/version.ts` from `build.gradle`
- **Updated**: `FormulusMessageHandlers.ts` - Uses `AppVersionService` instead of hardcoded `'0.1.0-native'`
- **Updated**: `FormulusInterfaceDefinition.ts` - Manual `FORMULUS_INTERFACE_VERSION` (separate from app version)
- **Scripts**: `generate:version` runs on `prebuild`/`prestart`

### Web Component (`formulus-formplayer`)
- **New**: `scripts/sync-version-from-parent.js` - Syncs version from RN app
- **Updated**: `FormulusInterfaceDefinition.ts` - Manual `FORMULUS_INTERFACE_VERSION`
- **Scripts**: `sync:version` runs on `prebuild`/`prestart`

### Generated Files
Both projects now have auto-generated `src/version.ts`:
export const APP_VERSION = '1.0'; // From native configs## Workflow

**Update app version:**
1. Update `android/app/build.gradle` → `versionName = "1.1.0"`
2. Update iOS `project.pbxproj` → `MARKETING_VERSION = 1.1.0`
3. Build/start auto-regenerates version files

**Update interface version:**
Manually bump `FORMULUS_INTERFACE_VERSION` in both interface definition files (only on breaking changes).

**Rule**: App version comes from native configs. Generated `version.ts` files propagate it. Interface version is manually maintained separately.

Closes #115