### PR TITLE
[Formulus] Fix: Settings Screen Login Button State

### DIFF
--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -14,7 +14,7 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 import {useNavigation} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import * as Keychain from 'react-native-keychain';
-import {login, getUserInfo, UserInfo} from '../api/synkronus/Auth';
+import {login} from '../api/synkronus/Auth';
 import {serverConfigService} from '../services/ServerConfigService';
 import QRScannerModal from '../components/QRScannerModal';
 import {QRSettingsService} from '../services/QRSettingsService';
@@ -35,13 +35,10 @@ const SettingsScreen = () => {
   const [serverUrl, setServerUrl] = useState('');
   const [initialServerUrl, setInitialServerUrl] = useState('');
   const [username, setUsername] = useState('');
-  const [initialUsername, setInitialUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [initialPassword, setInitialPassword] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [showQRScanner, setShowQRScanner] = useState(false);
-  const [_loggedInUser, setLoggedInUser] = useState<UserInfo | null>(null);
 
   useEffect(() => {
     loadSettings();
@@ -188,12 +185,7 @@ const SettingsScreen = () => {
       if (credentials) {
         setUsername(credentials.username);
         setPassword(credentials.password);
-        setInitialUsername(credentials.username);
-        setInitialPassword(credentials.password);
       }
-
-      const userInfo = await getUserInfo();
-      setLoggedInUser(userInfo);
     } catch (error) {
       console.error('Failed to load settings:', error);
     } finally {
@@ -214,8 +206,7 @@ const SettingsScreen = () => {
     setIsLoggingIn(true);
     try {
       await Keychain.setGenericPassword(username, password);
-      const userInfo = await login(username, password);
-      setLoggedInUser(userInfo);
+      await login(username, password);
       ToastService.showShort('Successfully logged in!');
       navigation.navigate('MainApp');
     } catch (error: any) {
@@ -258,8 +249,7 @@ const SettingsScreen = () => {
             settings.password,
           );
           try {
-            const userInfo = await login(settings.username, settings.password);
-            setLoggedInUser(userInfo);
+            await login(settings.username, settings.password);
             ToastService.showShort('Successfully logged in!');
             navigation.navigate('MainApp');
           } catch (error: any) {
@@ -360,16 +350,9 @@ const SettingsScreen = () => {
         </View>
 
         {(() => {
-          const hasCredentialChanges =
-            serverUrl.trim() !== initialServerUrl ||
-            username.trim() !== initialUsername ||
-            password !== initialPassword;
           const isFieldsEmpty =
             !serverUrl.trim() || !username.trim() || !password.trim();
-          const isButtonDisabled =
-            isFieldsEmpty ||
-            isLoggingIn ||
-            (_loggedInUser && !hasCredentialChanges);
+          const isButtonDisabled = isFieldsEmpty || isLoggingIn;
 
           return (
             <TouchableOpacity

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -35,7 +35,9 @@ const SettingsScreen = () => {
   const [serverUrl, setServerUrl] = useState('');
   const [initialServerUrl, setInitialServerUrl] = useState('');
   const [username, setUsername] = useState('');
+  const [initialUsername, setInitialUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [initialPassword, setInitialPassword] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [showQRScanner, setShowQRScanner] = useState(false);
@@ -96,7 +98,7 @@ const SettingsScreen = () => {
             ? [
                 {
                   text: 'Cancel',
-                  style: 'cancel',
+                  style: 'cancel' as const,
                   onPress: () => {
                     setServerUrl(initialServerUrl);
                     resolve(false);
@@ -104,7 +106,7 @@ const SettingsScreen = () => {
                 },
                 {
                   text: 'Proceed without syncing',
-                  style: 'destructive',
+                  style: 'destructive' as const,
                   onPress: () => {
                     (async () => {
                       try {
@@ -137,7 +139,7 @@ const SettingsScreen = () => {
             : [
                 {
                   text: 'Cancel',
-                  style: 'cancel',
+                  style: 'cancel' as const,
                   onPress: () => {
                     setServerUrl(initialServerUrl);
                     resolve(false);
@@ -145,7 +147,7 @@ const SettingsScreen = () => {
                 },
                 {
                   text: 'Yes, wipe & switch',
-                  style: 'destructive',
+                  style: 'destructive' as const,
                   onPress: () => {
                     (async () => {
                       try {
@@ -186,6 +188,8 @@ const SettingsScreen = () => {
       if (credentials) {
         setUsername(credentials.username);
         setPassword(credentials.password);
+        setInitialUsername(credentials.username);
+        setInitialPassword(credentials.password);
       }
 
       const userInfo = await getUserInfo();
@@ -355,24 +359,43 @@ const SettingsScreen = () => {
           />
         </View>
 
-        <TouchableOpacity
-          style={[
-            styles.nextButton,
-            (!serverUrl.trim() || !username.trim() || !password.trim()) &&
-              styles.nextButtonDisabled,
-          ]}
-          onPress={handleLogin}
-          disabled={
-            !serverUrl.trim() ||
-            !username.trim() ||
-            !password.trim() ||
-            isLoggingIn
-          }>
-          <Icon name="arrow-right" size={20} color={colors.neutral[500]} />
-          <Text style={styles.nextButtonText}>
-            {isLoggingIn ? 'Logging in...' : 'Login'}
-          </Text>
-        </TouchableOpacity>
+        {(() => {
+          const hasCredentialChanges =
+            serverUrl.trim() !== initialServerUrl ||
+            username.trim() !== initialUsername ||
+            password !== initialPassword;
+          const isFieldsEmpty =
+            !serverUrl.trim() || !username.trim() || !password.trim();
+          const isButtonDisabled =
+            isFieldsEmpty ||
+            isLoggingIn ||
+            (_loggedInUser && !hasCredentialChanges);
+
+          return (
+            <TouchableOpacity
+              style={[
+                styles.nextButton,
+                isButtonDisabled && styles.nextButtonDisabled,
+              ]}
+              onPress={handleLogin}
+              disabled={!!isButtonDisabled}>
+              <Icon
+                name="arrow-right"
+                size={20}
+                color={
+                  isButtonDisabled ? colors.neutral[500] : colors.neutral.white
+                }
+              />
+              <Text
+                style={[
+                  styles.nextButtonText,
+                  isButtonDisabled && styles.nextButtonTextDisabled,
+                ]}>
+                {isLoggingIn ? 'Logging in...' : 'Login'}
+              </Text>
+            </TouchableOpacity>
+          );
+        })()}
       </ScrollView>
 
       <QRScannerModal
@@ -462,7 +485,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     height: 56,
     borderRadius: 8,
-    backgroundColor: colors.neutral[200],
+    backgroundColor: colors.brand.primary[500],
     justifyContent: 'center',
     alignItems: 'center',
     gap: 8,
@@ -477,6 +500,9 @@ const styles = StyleSheet.create({
   nextButtonText: {
     fontSize: 16,
     fontWeight: '600',
+    color: colors.neutral.white,
+  },
+  nextButtonTextDisabled: {
     color: colors.neutral[500],
   },
 });


### PR DESCRIPTION
### Problem
**UX issue**: The login button remained gray/disabled when returning to the Settings screen while already logged in.
Closes #141 

### Solution
- Added `as const` assertions to `style` properties in Alert button configurations to fix TypeScript type inference
- Added `initialUsername` and `initialPassword` state tracking alongside existing `initialServerUrl`
- Login button is now **disabled (grey)** when:
  - User is already logged in AND
  - Credentials (server URL, username, password) haven't changed from saved values
- Login button is **enabled (green)** when:
  - Not logged in, OR
  - Any credential field has been modified

### Changes
- [formulus/src/screens/SettingsScreen.tsx](cci:7://file:///home/najuna/Desktop/ode-workspace/ode/formulus/src/screens/SettingsScreen.tsx:0:0-0:0)

### Testing
1. Log in with valid credentials → navigates to home
2. Return to Settings screen → login button should be grey/disabled
3. Modify any field (server URL, username, or password) → button turns green/enabled
4. Revert changes back to original → button turns grey/disabled again