### PR TITLE
fix: handle root-level forms/ext.json in bundle validation

### DIFF
--- a/synkronus-cli/pkg/validation/bundle.go
+++ b/synkronus-cli/pkg/validation/bundle.go
@@ -58,7 +58,8 @@ func ValidateBundle(bundlePath string) error {
 		// Track form directories (exclude ext.json files)
 		if strings.HasPrefix(file.Name, "forms/") && !strings.HasSuffix(file.Name, "/") {
 			// Skip ext.json files - they're not form directories
-			if strings.HasSuffix(file.Name, "/ext.json") {
+			// Skip both root-level (forms/ext.json) and form-level (forms/{formName}/ext.json)
+			if file.Name == "forms/ext.json" || strings.HasSuffix(file.Name, "/ext.json") {
 				continue
 			}
 			formParts := strings.Split(file.Name, "/")
@@ -81,7 +82,8 @@ func ValidateBundle(bundlePath string) error {
 		// Validate form structure
 		if strings.HasPrefix(file.Name, "forms/") {
 			// Skip ext.json files - they're validated separately in validateExtensions
-			if strings.HasSuffix(file.Name, "/ext.json") {
+			// Skip both root-level (forms/ext.json) and form-level (forms/{formName}/ext.json)
+			if file.Name == "forms/ext.json" || strings.HasSuffix(file.Name, "/ext.json") {
 				continue
 			}
 			if err := validateFormFile(file); err != nil {
@@ -180,7 +182,8 @@ func validateFormRendererReferences(zipReader *zip.Reader) error {
 
 	// Second, collect extension renderers from ext.json files
 	for _, file := range zipReader.File {
-		if strings.HasSuffix(file.Name, "/ext.json") {
+		// Collect both root-level (forms/ext.json) and form-level (forms/{formName}/ext.json) ext.json files
+		if file.Name == "forms/ext.json" || strings.HasSuffix(file.Name, "/ext.json") {
 			rc, err := file.Open()
 			if err != nil {
 				continue // Skip if can't open
@@ -413,7 +416,8 @@ func validateExtensions(zipReader *zip.Reader) error {
 
 	// First pass: collect extension files and validate structure
 	for _, file := range zipReader.File {
-		if strings.HasSuffix(file.Name, "/ext.json") {
+		// Collect both root-level (forms/ext.json) and form-level (forms/{formName}/ext.json) ext.json files
+		if file.Name == "forms/ext.json" || strings.HasSuffix(file.Name, "/ext.json") {
 			extensionFiles[file.Name] = file
 
 			// Validate JSON structure


### PR DESCRIPTION
- Fix validation to properly handle forms/ext.json (root-level ext.json)
- Previously only handled forms/{formName}/ext.json (form-level)
- Updated all 4 locations where ext.json files are checked:
  1. Form directory tracking (skip forms/ext.json)
  2. Form file validation (skip forms/ext.json)
  3. Extension renderer collection (include forms/ext.json)
  4. Extension validation (include forms/ext.json)

Fixes validation error: 'invalid form file path: forms/ext.json'

# Pull Request Title

<!-- PR Title must follow Conventional Commits format: <type>(<scope>): <subject> -->

## Description

<!-- Provide a clear description of what changed and why -->

## Type of Change

- [ ] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [ ] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:** <!-- Please specify -->

---

## Related Issue(s)

<!-- Use keywords: Closes #123, Fixes #456, Resolves #789 -->

**Closes/Fixes/Resolves:** <!-- e.g., Closes #123 -->

---

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manually tested
- [ ] Tested on multiple platforms (if applicable)
- [ ] Not applicable

---

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:**

---

## Documentation Updates

- [ ] Documentation has been updated
- [ ] Documentation update is not required

---

## Checklist

- [ ] Code follows project style guidelines
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**
