### PR TITLE
fix(database): handle object formType parameters in WatermelonDB queries

### DIFF
--- a/formulus/src/database/repositories/WatermelonDBRepo.ts
+++ b/formulus/src/database/repositories/WatermelonDBRepo.ts
@@ -201,6 +201,15 @@ export class WatermelonDBRepo implements LocalRepoInterface {
     try {
       console.log('Fetching observations for form type ID:', formId);
 
+      // Validate formId parameter
+      if (!formId || typeof formId !== 'string' || formId.trim() === '') {
+        console.warn(
+          'Invalid formId provided to getObservationsByFormType:',
+          formId,
+        );
+        return [];
+      }
+
       // First, let's check all observations in the database for debugging
       const allObservations = await this.observationsCollection.query().fetch();
       console.log(`Total observations in database: ${allObservations.length}`);

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -952,7 +952,7 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
       }
     },
     onGetObservations: async (
-      formType: string,
+      formType: string | { formType: string },
       isDraft?: boolean,
       includeDeleted?: boolean,
     ) => {
@@ -960,14 +960,31 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
         'FormulusMessageHandlers: onGetObservations handler invoked.',
         { formType, isDraft, includeDeleted },
       );
-      if (typeof formType !== 'string') {
+
+      // Extract the actual formType string value
+      let formTypeString: string;
+      if (typeof formType === 'string') {
+        formTypeString = formType;
+      } else if (
+        typeof formType === 'object' &&
+        formType !== null &&
+        'formType' in formType
+      ) {
         console.debug(
-          'FormulusMessageHandlers: onGetObservations handler invoked with formType object, expected string',
+          'FormulusMessageHandlers: onGetObservations received formType as object, extracting string value',
         );
+        formTypeString = formType.formType;
+      } else {
+        console.error(
+          'FormulusMessageHandlers: onGetObservations received invalid formType parameter',
+          formType,
+        );
+        return [];
       }
+
       const service = await FormService.getInstance();
       //TODO: Handle deleted etc.
-      return await service.getObservationsByFormType(formType);
+      return await service.getObservationsByFormType(formTypeString);
     },
     onOpenFormplayer: async (data: FormInitData) => {
       return startFormplayerOperation(


### PR DESCRIPTION
The webview was passing formType as an object (e.g., {formType: 'household'}) instead of a string, causing WatermelonDB query errors:
- "Invalid Comparison passed to Query builder"
- "Invalid value passed to query"
- "formId.trim is not a function"

Changes:
- Updated FormulusMessageHandlers.onGetObservations to accept both string and object formType parameters and extract the string value
- Improved WatermelonDBRepo.getObservationsByFormType validation to check the parameter type before calling string methods
- Added better error logging for invalid parameters

This ensures observations can be fetched successfully regardless of how the formType parameter is passed from the webview.

