### PR TITLE
chore: upgrade Node.js to v24 for Metro bundler compatibility

### DIFF
--- a/.github/workflows/formulus-android.yml
+++ b/.github/workflows/formulus-android.yml
@@ -20,8 +20,7 @@ on:
     types: [published]
 
 env:
-  NODE_VERSION_ASSETS: '20'
-  NODE_VERSION_ANDROID: '18.x'
+  NODE_VERSION: '24'
 
 jobs:
   build-formplayer-assets:
@@ -37,7 +36,7 @@ jobs:
       - name: Set up Node.js for assets
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION_ASSETS }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: |
             formulus-formplayer/package-lock.json
@@ -84,7 +83,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION_ANDROID }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: |
             formulus/package-lock.json

--- a/formulus/package.json
+++ b/formulus/package.json
@@ -83,6 +83,6 @@
     "typescript-eslint": "^8.51.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   }
 }


### PR DESCRIPTION

## Description
Fix build failure caused by Metro's use of Array.toReversed() (ES2023) which requires Node.js 20+. Update CI workflows to use Node 24 and set minimum engine requirement to >=20 in package.json.

Resolves: "configs.toReversed is not a function" error in Android builds
<!-- Provide a clear description of what changed and why -->

