### PR TITLE
feat(formulus): Unified back button navigation for WebView and native screens

### DIFF
--- a/formulus/android/app/src/main/assets/formplayer_dist/index.html
+++ b/formulus/android/app/src/main/assets/formplayer_dist/index.html
@@ -11,8 +11,8 @@
     <title>Formulus Form Player</title>
     <!-- Include the required Formulus load script -->
     <script src="./formulus-load.js"></script>
-    <script type="module" src="./public/index-C4W92oq5.js"></script>
-    <link rel="stylesheet" href="./public/index-DY58rjqA.css">
+    <script type="module" src="./public/index-CeSsc9Vd.js"></script>
+    <link rel="stylesheet" href="./public/index-azmow9Aj.css">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/formulus/src/components/CustomAppWebView.tsx
+++ b/formulus/src/components/CustomAppWebView.tsx
@@ -2,13 +2,14 @@ import React, {
   useRef,
   useEffect,
   useState,
+  useCallback,
   forwardRef,
   useImperativeHandle,
   useMemo,
   SyntheticEvent,
 } from 'react';
 import { View, ActivityIndicator, AppState, StyleSheet } from 'react-native';
-import { WebView } from 'react-native-webview';
+import { WebView, WebViewNavigation } from 'react-native-webview';
 import { useIsFocused } from '@react-navigation/native';
 import { Platform } from 'react-native';
 import { readFileAssets, MainBundlePath, readFile } from 'react-native-fs';
@@ -20,6 +21,7 @@ export interface CustomAppWebViewHandle {
   reload: () => void;
   goBack: () => void;
   goForward: () => void;
+  canGoBack: () => boolean;
   injectJavaScript: (script: string) => void;
   sendFormInit: (formData: FormInitData) => Promise<void>;
   sendAttachmentData: (attachmentData: File) => Promise<void>;
@@ -29,12 +31,65 @@ interface CustomAppWebViewProps {
   appUrl: string;
   appName?: string; // To identify the source of logs
   onLoadEndProp?: () => void; // Propagate WebView's onLoadEnd event
+  onCanGoBackChange?: (canGoBack: boolean) => void; // Notify parent when WebView back-navigability changes
 }
 
 const INJECTION_SCRIPT_PATH =
   Platform.OS === 'android'
     ? 'webview/FormulusInjectionScript.js'
     : 'FormulusInjectionScript.js';
+
+const hashNavigationTrackingScript = `
+    (function() {
+      if (window.__formulusHashNavInstalled) return;
+      window.__formulusHashNavInstalled = true;
+
+      // Track the initial URL so we can determine canGoBack.
+      // We consider "can go back" = the browser history length is > 1
+      // AND we are not at the initial entry point.
+      var initialHref = window.location.href;
+      var navigationDepth = 0;
+
+      function notifyCanGoBack() {
+        var canGoBack = navigationDepth > 0;
+        try {
+          window.ReactNativeWebView.postMessage(JSON.stringify({
+            type: 'hashNavigationStateChange',
+            canGoBack: canGoBack,
+            url: window.location.href,
+            depth: navigationDepth
+          }));
+        } catch(e) { /* ignore if bridge not ready */ }
+      }
+
+      // Intercept pushState / replaceState so we can track depth accurately
+      var origPushState = history.pushState;
+      history.pushState = function() {
+        origPushState.apply(this, arguments);
+        navigationDepth++;
+        notifyCanGoBack();
+      };
+
+      var origReplaceState = history.replaceState;
+      history.replaceState = function() {
+        origReplaceState.apply(this, arguments);
+        // replaceState doesn't add depth
+        notifyCanGoBack();
+      };
+
+      window.addEventListener('popstate', function() {
+        navigationDepth = Math.max(0, navigationDepth - 1);
+        notifyCanGoBack();
+      });
+
+      window.addEventListener('hashchange', function() {
+        // hashchange after pushState is already handled, but if the hash
+        // was changed directly (e.g. location.hash = ...) we catch it here.
+        // We bump depth only if it wasn't already bumped by pushState.
+        notifyCanGoBack();
+      });
+    })();
+  `;
 
 const consoleLogScript = `
     (function() {
@@ -101,9 +156,16 @@ const consoleLogScript = `
 const CustomAppWebView = forwardRef<
   CustomAppWebViewHandle,
   CustomAppWebViewProps
->(({ appUrl, appName, onLoadEndProp }, ref) => {
+>(({ appUrl, appName, onLoadEndProp, onCanGoBackChange }, ref) => {
   const webViewRef = useRef<WebView | null>(null);
   const hasLoadedOnceRef = useRef(false);
+
+  const canGoBackRef = useRef(false);
+
+  const onCanGoBackChangeRef = useRef(onCanGoBackChange);
+  useEffect(() => {
+    onCanGoBackChangeRef.current = onCanGoBackChange;
+  }, [onCanGoBackChange]);
 
   const [injectionScript, setInjectionScript] =
     useState<string>(consoleLogScript);
@@ -123,8 +185,8 @@ const CustomAppWebView = forwardRef<
           script = await readFile(iosPath, 'utf8');
         }
 
-        // Combine and set state
-        const fullScript = consoleLogScript + '\n' + script;
+        const fullScript =
+          consoleLogScript + '\n' + hashNavigationTrackingScript + '\n' + script;
         setInjectionScript(fullScript);
         setIsScriptReady(true);
       } catch (err) {
@@ -144,6 +206,15 @@ const CustomAppWebView = forwardRef<
     manager.handleWebViewMessage = event => {
       try {
         const eventData = JSON.parse(event.nativeEvent.data);
+
+        if (eventData.type === 'hashNavigationStateChange') {
+          const newCanGoBack = !!eventData.canGoBack;
+          if (canGoBackRef.current !== newCanGoBack) {
+            canGoBackRef.current = newCanGoBack;
+            onCanGoBackChangeRef.current?.(newCanGoBack);
+          }
+          return;
+        }
 
         // Handle API re-injection requests from WebView
         if (eventData.type === 'requestApiReinjection') {
@@ -193,6 +264,17 @@ const CustomAppWebView = forwardRef<
     return manager;
   }, [appName]);
 
+  const handleNavigationStateChange = useCallback(
+    (navState: WebViewNavigation) => {
+      const newCanGoBack = navState.canGoBack;
+      if (canGoBackRef.current !== newCanGoBack) {
+        canGoBackRef.current = newCanGoBack;
+        onCanGoBackChange?.(newCanGoBack);
+      }
+    },
+    [onCanGoBackChange],
+  );
+
   // Expose imperative handle
   useImperativeHandle(
     ref,
@@ -200,6 +282,7 @@ const CustomAppWebView = forwardRef<
       reload: () => webViewRef.current?.reload?.(),
       goBack: () => webViewRef.current?.goBack?.(),
       goForward: () => webViewRef.current?.goForward?.(),
+      canGoBack: () => canGoBackRef.current,
       injectJavaScript: (script: string) =>
         webViewRef.current?.injectJavaScript(script),
       sendFormInit: (formData: FormInitData) =>
@@ -295,6 +378,7 @@ const CustomAppWebView = forwardRef<
     <WebView
       ref={webViewRef}
       source={{ uri: appUrl }}
+      onNavigationStateChange={handleNavigationStateChange}
       onMessage={messageManager.handleWebViewMessage}
       onError={handleError}
       onLoadStart={() =>

--- a/formulus/src/components/CustomAppWebView.tsx
+++ b/formulus/src/components/CustomAppWebView.tsx
@@ -186,7 +186,11 @@ const CustomAppWebView = forwardRef<
         }
 
         const fullScript =
-          consoleLogScript + '\n' + hashNavigationTrackingScript + '\n' + script;
+          consoleLogScript +
+          '\n' +
+          hashNavigationTrackingScript +
+          '\n' +
+          script;
         setInjectionScript(fullScript);
         setIsScriptReady(true);
       } catch (err) {

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -142,6 +142,11 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
     const handleClose = useCallback(() => {
       if (isClosing || isSubmitting) return;
 
+      if (webViewRef.current?.canGoBack?.()) {
+        webViewRef.current.goBack();
+        return;
+      }
+
       Alert.alert(
         'Close form?',
         'This will close the current form. Any changes made will not be saved, but will be available as a draft next time you open the form.',

--- a/formulus/src/navigation/MainAppNavigator.tsx
+++ b/formulus/src/navigation/MainAppNavigator.tsx
@@ -22,7 +22,6 @@ const MainAppNavigator: React.FC = () => {
     checkConfiguration();
   }, []);
 
-
   useFocusEffect(
     React.useCallback(() => {
       const checkConfig = async () => {

--- a/formulus/src/navigation/MainAppNavigator.tsx
+++ b/formulus/src/navigation/MainAppNavigator.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { BackHandler, Platform } from 'react-native';
 import { createStackNavigator } from '@react-navigation/stack';
-import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { useFocusEffect } from '@react-navigation/native';
 import MainTabNavigator from './MainTabNavigator';
 import WelcomeScreen from '../screens/WelcomeScreen';
 import FormManagementScreen from '../screens/FormManagementScreen';
@@ -13,7 +12,6 @@ import { colors } from '../theme/colors';
 const Stack = createStackNavigator<MainAppStackParamList>();
 
 const MainAppNavigator: React.FC = () => {
-  const navigation = useNavigation();
   const [isConfigured, setIsConfigured] = useState<boolean | null>(null);
 
   useEffect(() => {
@@ -24,44 +22,6 @@ const MainAppNavigator: React.FC = () => {
     checkConfiguration();
   }, []);
 
-  // Handle Android hardware back button in a conservative way:
-  // only intercept when there is actual stack history above the root.
-  useEffect(() => {
-    if (Platform.OS !== 'android') {
-      return;
-    }
-
-    const onBackPress = () => {
-      const state = navigation.getState?.();
-
-      // Only handle back when we're in a stack with more than one route and
-      // not at the root (index > 0). This avoids interfering with tab presses
-      // and prevents the app from getting into an odd state.
-      if (
-        state &&
-        state.type === 'stack' &&
-        Array.isArray(state.routes) &&
-        state.routes.length > 1 &&
-        typeof state.index === 'number' &&
-        state.index > 0
-      ) {
-        navigation.goBack();
-        return true;
-      }
-
-      // Let React Navigation / Android handle back normally (may exit app at root)
-      return false;
-    };
-
-    const subscription = BackHandler.addEventListener(
-      'hardwareBackPress',
-      onBackPress,
-    );
-
-    return () => {
-      subscription.remove();
-    };
-  }, [navigation]);
 
   useFocusEffect(
     React.useCallback(() => {

--- a/formulus/src/screens/HomeScreen.tsx
+++ b/formulus/src/screens/HomeScreen.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { Alert, BackHandler, StyleSheet, View, ActivityIndicator, Platform } from 'react-native';
+import {
+  Alert,
+  BackHandler,
+  StyleSheet,
+  View,
+  ActivityIndicator,
+  Platform,
+} from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import RNFS from 'react-native-fs';
 import CustomAppWebView, {
@@ -27,7 +34,11 @@ const HomeScreen = ({ navigation }: { navigation: any }) => {
 
         Alert.alert('Exit app?', 'Are you sure you want to exit Formulus?', [
           { text: 'Cancel', style: 'cancel' },
-          { text: 'Exit', style: 'destructive', onPress: () => BackHandler.exitApp() },
+          {
+            text: 'Exit',
+            style: 'destructive',
+            onPress: () => BackHandler.exitApp(),
+          },
         ]);
         return true;
       };

--- a/formulus/src/screens/HomeScreen.tsx
+++ b/formulus/src/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { StyleSheet, View, ActivityIndicator, Platform } from 'react-native';
+import { Alert, BackHandler, StyleSheet, View, ActivityIndicator, Platform } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import RNFS from 'react-native-fs';
 import CustomAppWebView, {
   CustomAppWebViewHandle,
@@ -11,6 +12,34 @@ const HomeScreen = ({ navigation }: { navigation: any }) => {
   const [localUri, setLocalUri] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const customAppRef = useRef<CustomAppWebViewHandle>(null);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      if (Platform.OS !== 'android') {
+        return;
+      }
+
+      const onBackPress = () => {
+        if (customAppRef.current?.canGoBack?.()) {
+          customAppRef.current.goBack();
+          return true;
+        }
+
+        Alert.alert('Exit app?', 'Are you sure you want to exit Formulus?', [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Exit', style: 'destructive', onPress: () => BackHandler.exitApp() },
+        ]);
+        return true;
+      };
+
+      const subscription = BackHandler.addEventListener(
+        'hardwareBackPress',
+        onBackPress,
+      );
+
+      return () => subscription.remove();
+    }, []),
+  );
 
   const checkAndSetAppUri = async () => {
     try {

--- a/formulus/src/screens/WelcomeScreen.tsx
+++ b/formulus/src/screens/WelcomeScreen.tsx
@@ -13,7 +13,13 @@ const WelcomeScreen = () => {
   const navigation = useNavigation<WelcomeScreenNavigationProp>();
 
   const handleGetStarted = () => {
-    navigation.navigate('MainApp');
+    // Use reset instead of navigate so that "Welcome" is removed from the
+    // stack history.  This prevents the hardware back button from returning
+    // the user to the Welcome screen after they've configured the server.
+    navigation.reset({
+      index: 0,
+      routes: [{ name: 'MainApp' }],
+    });
   };
 
   return (


### PR DESCRIPTION
## Description
When custom apps (ento, AnthroCollect) run inside Formulus via `react-native-webview`, the Android hardware back button previously either closed the entire app or jumped to the Welcome screen — ignoring the custom app's internal navigation history.

This PR makes the back button work seamlessly across both native and WebView navigation so there is no difference between the two.

### What changed

| File | Change |
|---|---|
| `CustomAppWebView.tsx` | Track `canGoBack` via `onNavigationStateChange` and an injected hash-navigation listener (`pushState`/`popstate`/`hashchange`) for apps using `HashRouter` |
| `HomeScreen.tsx` | Focus-aware `BackHandler` that goes back inside the WebView first, then shows an exit confirmation at root |
| `FormplayerModal.tsx` | Check WebView `canGoBack` before showing the "Close form?" alert, allowing back navigation within multi-step forms |
| `WelcomeScreen.tsx` | Use `navigation.reset()` instead of `navigate()` so Welcome is never left in the stack history |
| `MainAppNavigator.tsx` | Removed custom `BackHandler` — React Navigation's built-in stack handler manages screen-level back |

### Back button behaviour

| Where you are | Back button does |
|---|---|
| Home tab → custom app has history | Goes back inside the custom app |
| Home tab → custom app at root | Shows "Exit app?" confirmation |
| Formplayer modal → form has history | Goes back inside the form |
| Formplayer modal → form at root | Shows "Close form?" confirmation |
| FormManagement / ObservationDetail | Pops back to the Home screen |

### Why the Welcome screen bug happened

`WelcomeScreen` used `navigation.navigate('MainApp')` which **pushed** MainApp on top of Welcome, leaving the stack as `[Welcome, MainApp]`. Every back press popped to Welcome. Switching to `navigation.reset()` ensures the stack only contains `[MainApp]`.

---
Now when you press the back button on the Home screen with no WebView history, you'll get a simple confirmation dialog:

> **Exit app?**  
> Are you sure you want to exit Formulus?  
> \[Cancel\] \[Exit\]

- **Cancel** — dismisses the dialog and stays in the app  
- **Exit** — closes the app  

Closes #297