### PR TITLE
fix: Sync mechanism issues

### DIFF
--- a/formulus/android/app/src/main/AndroidManifest.xml
+++ b/formulus/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     
@@ -45,5 +46,11 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
+
+      <service
+          android:name="app.notifee.core.ForegroundService"
+          android:exported="false"
+          android:foregroundServiceType="dataSync"
+          tools:replace="android:foregroundServiceType" />
     </application>
 </manifest>

--- a/formulus/android/app/src/main/AndroidManifest.xml
+++ b/formulus/android/app/src/main/AndroidManifest.xml
@@ -16,11 +16,13 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     
-    <!-- Notification permissions for react-native-push-notification -->
+    <!-- Notification and foreground service permissions -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
       android:name=".MainApplication"

--- a/formulus/index.js
+++ b/formulus/index.js
@@ -2,8 +2,15 @@
  * @format
  */
 
-import { AppRegistry } from 'react-native';
+import { AppRegistry, Platform } from 'react-native';
+import notifee from '@notifee/react-native';
 import App from './App';
 import { name as appName } from './app.json';
+
+if (Platform.OS === 'android') {
+  notifee.registerForegroundService(() => {
+    return new Promise(() => {});
+  });
+}
 
 AppRegistry.registerComponent(appName, () => App);

--- a/formulus/package-lock.json
+++ b/formulus/package-lock.json
@@ -34,7 +34,8 @@
         "react-native-signature-canvas": "^5.0.2",
         "react-native-url-polyfill": "^3.0.0",
         "react-native-vision-camera": "^4.7.3",
-        "react-native-webview": "^13.16.0"
+        "react-native-webview": "^13.16.0",
+        "react-native-zip-archive": "^7.0.2"
       },
       "devDependencies": {
         "@babel/core": "^7.28.5",
@@ -13335,6 +13336,16 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-zip-archive": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-zip-archive/-/react-native-zip-archive-7.0.2.tgz",
+      "integrity": "sha512-msCRJMcwH6NVZ2/zoC+1nvA0wlpYRnMxteQywS9nt4BzXn48tZpaVtE519QEZn0xe3ygvgsWx5cdPoE9Jx3bsg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.6",
+        "react-native": ">=0.60.0"
       }
     },
     "node_modules/react-native/node_modules/@jest/environment": {

--- a/formulus/package.json
+++ b/formulus/package.json
@@ -44,7 +44,8 @@
     "react-native-signature-canvas": "^5.0.2",
     "react-native-url-polyfill": "^3.0.0",
     "react-native-vision-camera": "^4.7.3",
-    "react-native-webview": "^13.16.0"
+    "react-native-webview": "^13.16.0",
+    "react-native-zip-archive": "^7.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.28.5",

--- a/formulus/src/contexts/SyncContext.tsx
+++ b/formulus/src/contexts/SyncContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   ReactNode,
 } from 'react';
+import { syncService as syncServiceInstance } from '../services/SyncService';
 
 export interface SyncProgress {
   current: number;
@@ -70,6 +71,7 @@ export const SyncProvider: React.FC<SyncProviderProps> = ({ children }) => {
   }, []);
 
   const cancelSync = useCallback(() => {
+    syncServiceInstance.cancelSync();
     setSyncState(prev => ({
       ...prev,
       isActive: false,

--- a/formulus/src/screens/HomeScreen.tsx
+++ b/formulus/src/screens/HomeScreen.tsx
@@ -13,6 +13,7 @@ import CustomAppWebView, {
   CustomAppWebViewHandle,
 } from '../components/CustomAppWebView';
 import { colors } from '../theme/colors';
+import { appEvents, Listener } from '../webview/FormulusMessageHandlers';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const HomeScreen = ({ navigation }: { navigation: any }) => {
@@ -93,6 +94,14 @@ const HomeScreen = ({ navigation }: { navigation: any }) => {
     });
     return unsubscribe;
   }, [navigation]);
+
+  useEffect(() => {
+    const onBundleUpdated: Listener = () => {
+      checkAndSetAppUri();
+    };
+    appEvents.addListener('bundleUpdated', onBundleUpdated);
+    return () => appEvents.removeListener('bundleUpdated', onBundleUpdated);
+  }, []);
 
   useEffect(() => {
     if (localUri) {

--- a/formulus/src/screens/HomeScreen.tsx
+++ b/formulus/src/screens/HomeScreen.tsx
@@ -19,6 +19,7 @@ import { appEvents, Listener } from '../webview/FormulusMessageHandlers';
 const HomeScreen = ({ navigation }: { navigation: any }) => {
   const [localUri, setLocalUri] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [webViewKey, setWebViewKey] = useState(0);
   const customAppRef = useRef<CustomAppWebViewHandle>(null);
 
   useFocusEffect(
@@ -98,6 +99,7 @@ const HomeScreen = ({ navigation }: { navigation: any }) => {
   useEffect(() => {
     const onBundleUpdated: Listener = () => {
       checkAndSetAppUri();
+      setWebViewKey(prev => prev + 1);
     };
     appEvents.addListener('bundleUpdated', onBundleUpdated);
     return () => appEvents.removeListener('bundleUpdated', onBundleUpdated);
@@ -130,6 +132,7 @@ const HomeScreen = ({ navigation }: { navigation: any }) => {
         />
       ) : (
         <CustomAppWebView
+          key={webViewKey}
           ref={customAppRef}
           appUrl={localUri}
           appName="custom_app"

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -479,7 +479,6 @@ const SyncScreen = () => {
               />
             </View>
             <Text style={styles.progressText}>
-              {syncState.progress.current}/{syncState.progress.total} -{' '}
               {Math.round(
                 (syncState.progress.current / syncState.progress.total) * 100,
               )}

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -161,7 +161,7 @@ const SyncScreen = () => {
         return;
       }
 
-      startSync(false);
+      startSync(true);
       await syncService.updateAppBundle();
       const syncTime = new Date().toISOString();
       setLastSync(syncTime);

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -246,11 +246,13 @@ const SyncScreen = () => {
   const getStatusText = (): string => {
     if (syncState.isActive) {
       if (activeOperation === 'update') return 'Updating app...';
-      if (activeOperation === 'sync_then_update') return 'Syncing & updating...';
+      if (activeOperation === 'sync_then_update')
+        return 'Syncing & updating...';
       return 'Syncing...';
     }
     if (syncState.error) return 'Error';
-    if (pendingObservations > 0 || pendingUploads.count > 0) return 'Pending sync';
+    if (pendingObservations > 0 || pendingUploads.count > 0)
+      return 'Pending sync';
     return 'All synced';
   };
 
@@ -339,8 +341,10 @@ const SyncScreen = () => {
     return 'Syncing Data';
   };
 
-  const isSyncButtonActive = activeOperation === 'sync' || activeOperation === 'sync_then_update';
-  const isUpdateButtonActive = activeOperation === 'update' || activeOperation === 'sync_then_update';
+  const isSyncButtonActive =
+    activeOperation === 'sync' || activeOperation === 'sync_then_update';
+  const isUpdateButtonActive =
+    activeOperation === 'update' || activeOperation === 'sync_then_update';
 
   return (
     <SafeAreaView style={styles.container}>

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -21,6 +21,8 @@ import { databaseService } from '../database/DatabaseService';
 import { getUserInfo } from '../api/synkronus/Auth';
 import colors from '../theme/colors';
 
+type ActiveOperation = 'sync' | 'update' | 'sync_then_update' | null;
+
 const SyncScreen = () => {
   const syncContextValue = useSyncContext();
   const {
@@ -43,6 +45,7 @@ const SyncScreen = () => {
   const [serverBundleVersion, setServerBundleVersion] =
     useState<string>('Unknown');
   const [animatedProgress] = useState(new Animated.Value(0));
+  const [activeOperation, setActiveOperation] = useState<ActiveOperation>(null);
 
   const updatePendingUploads = useCallback(async () => {
     try {
@@ -76,124 +79,150 @@ const SyncScreen = () => {
     }
   }, []);
 
-  const handleSync = useCallback(async () => {
-    if (syncState.isActive) {
-      console.log('Sync already active, ignoring request');
-      return;
+  const refreshAfterOperation = useCallback(async () => {
+    const syncTime = new Date().toISOString();
+    setLastSync(syncTime);
+    try {
+      await AsyncStorage.setItem('@lastSync', syncTime);
+    } catch (e) {
+      console.warn('Failed to save last sync time:', e);
     }
+    try {
+      await updatePendingUploads();
+    } catch (e) {
+      console.warn('Failed to update pending uploads:', e);
+    }
+    try {
+      await updatePendingObservations();
+    } catch (e) {
+      console.warn('Failed to update pending observations:', e);
+    }
+  }, [updatePendingUploads, updatePendingObservations]);
+
+  const handleSync = useCallback(async () => {
+    if (syncState.isActive) return;
 
     let syncError: string | undefined;
 
     try {
-      console.log('Starting sync...');
       startSync(true);
+      setActiveOperation('sync');
 
-      // Add timeout to prevent infinite hanging (30 minutes max)
       const syncPromise = syncService.syncObservations(true);
       const timeoutPromise = new Promise<never>((_, reject) => {
         setTimeout(
-          () => {
-            reject(new Error('Sync operation timed out after 30 minutes'));
-          },
+          () => reject(new Error('Sync timed out after 30 minutes')),
           30 * 60 * 1000,
         );
       });
 
-      const finalVersion = await Promise.race([syncPromise, timeoutPromise]);
-      console.log('✅ Sync completed successfully, version:', finalVersion);
-
-      // Update UI state even if these fail
-      try {
-        await updatePendingUploads();
-      } catch (e) {
-        console.warn('Failed to update pending uploads:', e);
-      }
-
-      try {
-        await updatePendingObservations();
-      } catch (e) {
-        console.warn('Failed to update pending observations:', e);
-      }
-
-      const syncTime = new Date().toISOString();
-      setLastSync(syncTime);
-      try {
-        await AsyncStorage.setItem('@lastSync', syncTime);
-      } catch (e) {
-        console.warn('Failed to save last sync time:', e);
-      }
+      await Promise.race([syncPromise, timeoutPromise]);
+      await refreshAfterOperation();
     } catch (error) {
-      console.error('❌ Sync error in handleSync:', error);
       syncError = (error as Error).message || 'Unknown error occurred';
-      Alert.alert('Error', 'Failed to sync!\n' + syncError);
+      Alert.alert('Sync Failed', syncError);
     } finally {
-      // Always call finishSync to clear loading state
-      console.log('Calling finishSync, error:', syncError);
       finishSync(syncError);
-      console.log('✅ Sync finished, isActive should be false now');
+      setActiveOperation(null);
     }
-  }, [
-    updatePendingUploads,
-    updatePendingObservations,
-    syncState.isActive,
-    startSync,
-    finishSync,
-  ]);
+  }, [syncState.isActive, startSync, finishSync, refreshAfterOperation]);
 
-  const handleCustomAppUpdate = useCallback(async () => {
-    if (syncState.isActive) return;
-
+  const performAppBundleUpdate = useCallback(async () => {
     try {
-      const userInfo = await getUserInfo();
-      if (!userInfo) {
-        Alert.alert(
-          'Authentication Error',
-          'Please log in to update app bundle',
-        );
-        return;
-      }
-
-      if (!updateAvailable && !isAdmin) {
-        Alert.alert(
-          'Permission Denied',
-          'Admin privileges required to force update app bundle',
-        );
-        return;
-      }
-
       startSync(true);
+      setActiveOperation('update');
+
       await syncService.updateAppBundle();
-      const syncTime = new Date().toISOString();
-      setLastSync(syncTime);
-      await AsyncStorage.setItem('@lastSync', syncTime);
       setUpdateAvailable(false);
+      await refreshAfterOperation();
       finishSync();
-      await updatePendingUploads();
-      await updatePendingObservations();
+
       const formService = await import('../services/FormService');
       const fs = await formService.FormService.getInstance();
       await fs.invalidateCache();
     } catch (error) {
       const errorMessage = (error as Error).message;
       finishSync(errorMessage);
-
       if (errorMessage.includes('401')) {
         Alert.alert(
           'Authentication Error',
           'Your session has expired. Please log in again.',
         );
       } else {
-        Alert.alert('Error', 'Failed to update app bundle!\n' + errorMessage);
+        Alert.alert('Update Failed', errorMessage);
       }
+    } finally {
+      setActiveOperation(null);
     }
+  }, [startSync, finishSync, refreshAfterOperation]);
+
+  const performSyncThenUpdate = useCallback(async () => {
+    try {
+      startSync(true);
+      setActiveOperation('sync_then_update');
+
+      await syncService.syncObservations(true);
+      await syncService.updateAppBundle();
+      setUpdateAvailable(false);
+      await refreshAfterOperation();
+      finishSync();
+
+      const formService = await import('../services/FormService');
+      const fs = await formService.FormService.getInstance();
+      await fs.invalidateCache();
+    } catch (error) {
+      const errorMessage = (error as Error).message;
+      finishSync(errorMessage);
+      Alert.alert('Operation Failed', errorMessage);
+    } finally {
+      setActiveOperation(null);
+    }
+  }, [startSync, finishSync, refreshAfterOperation]);
+
+  const handleCustomAppUpdate = useCallback(async () => {
+    if (syncState.isActive) return;
+
+    const userInfo = await getUserInfo();
+    if (!userInfo) {
+      Alert.alert('Authentication Error', 'Please log in to update app bundle');
+      return;
+    }
+
+    if (!updateAvailable && !isAdmin) {
+      Alert.alert(
+        'Permission Denied',
+        'Admin privileges required to force update app bundle',
+      );
+      return;
+    }
+
+    const hasPendingData = pendingObservations > 0 || pendingUploads.count > 0;
+
+    if (hasPendingData) {
+      const pendingCount = pendingObservations + pendingUploads.count;
+      Alert.alert(
+        'Unsynchronized Data',
+        `You have ${pendingCount} unsynchronized item${pendingCount !== 1 ? 's' : ''}. Sync your data before updating to avoid data loss.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Sync & Update',
+            onPress: () => performSyncThenUpdate(),
+          },
+        ],
+      );
+      return;
+    }
+
+    await performAppBundleUpdate();
   }, [
     syncState.isActive,
-    startSync,
-    finishSync,
-    updatePendingUploads,
-    updatePendingObservations,
     updateAvailable,
     isAdmin,
+    pendingObservations,
+    pendingUploads.count,
+    performAppBundleUpdate,
+    performSyncThenUpdate,
   ]);
 
   const checkForUpdates = useCallback(async () => {
@@ -214,20 +243,18 @@ const SyncScreen = () => {
     }
   }, []);
 
-  const getDataSyncStatus = (): string => {
+  const getStatusText = (): string => {
     if (syncState.isActive) {
-      return syncState.progress?.details || 'Syncing...';
+      if (activeOperation === 'update') return 'Updating app...';
+      if (activeOperation === 'sync_then_update') return 'Syncing & updating...';
+      return 'Syncing...';
     }
-    if (syncState.error) {
-      return 'Error';
-    }
-    if (pendingObservations > 0 || pendingUploads.count > 0) {
-      return 'Pending Sync';
-    }
+    if (syncState.error) return 'Error';
+    if (pendingObservations > 0 || pendingUploads.count > 0) return 'Pending sync';
     return 'All synced';
   };
 
-  const status = getDataSyncStatus();
+  const status = getStatusText();
   const statusColor = syncState.isActive
     ? colors.brand.primary[500]
     : syncState.error
@@ -267,7 +294,6 @@ const SyncScreen = () => {
     updateProgress,
   ]);
 
-  // Smoothly animate progress changes so the bar doesn't "twitch"
   useEffect(() => {
     if (!syncState.progress || !syncState.isActive) {
       Animated.timing(animatedProgress, {
@@ -307,13 +333,20 @@ const SyncScreen = () => {
     checkForUpdates,
   ]);
 
+  const getProgressTitle = (): string => {
+    if (activeOperation === 'sync_then_update') return 'Syncing & Updating';
+    if (activeOperation === 'update') return 'Updating App Bundle';
+    return 'Syncing Data';
+  };
+
+  const isSyncButtonActive = activeOperation === 'sync' || activeOperation === 'sync_then_update';
+  const isUpdateButtonActive = activeOperation === 'update' || activeOperation === 'sync_then_update';
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.title}>Sync</Text>
-        <Text style={styles.subtitle}>
-          {syncState.isActive ? 'Syncing...' : 'Synchronize your data'}
-        </Text>
+        <Text style={styles.subtitle}>Synchronize your data</Text>
       </View>
 
       <ScrollView
@@ -455,16 +488,8 @@ const SyncScreen = () => {
           <View style={styles.progressCard}>
             <View style={styles.progressHeader}>
               <Icon name="sync" size={20} color={colors.brand.primary[500]} />
-              <Text style={styles.progressTitle}>Sync Progress</Text>
+              <Text style={styles.progressTitle}>{getProgressTitle()}</Text>
             </View>
-            <Text style={styles.progressMode}>
-              {syncState.progress.phase === 'attachments_download'
-                ? 'App bundle update'
-                : 'Data sync'}
-            </Text>
-            <Text style={styles.progressDetails}>
-              {syncState.progress.details || 'Syncing...'}
-            </Text>
             <View style={styles.progressBar}>
               <Animated.View
                 style={[
@@ -520,13 +545,13 @@ const SyncScreen = () => {
             ]}
             onPress={handleSync}
             disabled={syncState.isActive}>
-            {syncState.isActive ? (
+            {isSyncButtonActive ? (
               <ActivityIndicator size="small" color={colors.neutral.white} />
             ) : (
               <Icon name="sync" size={20} color={colors.neutral.white} />
             )}
             <Text style={styles.actionButtonText}>
-              {syncState.isActive ? 'Syncing...' : 'Sync Data'}
+              {isSyncButtonActive ? 'Syncing...' : 'Sync Data'}
             </Text>
           </TouchableOpacity>
 
@@ -539,7 +564,7 @@ const SyncScreen = () => {
             ]}
             onPress={handleCustomAppUpdate}
             disabled={syncState.isActive || (!updateAvailable && !isAdmin)}>
-            {syncState.isActive ? (
+            {isUpdateButtonActive ? (
               <ActivityIndicator
                 size="small"
                 color={colors.brand.primary[500]}
@@ -552,15 +577,15 @@ const SyncScreen = () => {
               />
             )}
             <Text style={[styles.actionButtonText, styles.secondaryButtonText]}>
-              {syncState.isActive ? 'Updating...' : 'Update App Bundle'}
+              {isUpdateButtonActive ? 'Updating...' : 'Update App Bundle'}
             </Text>
           </TouchableOpacity>
 
-          {updateAvailable && (
+          {!syncState.isActive && updateAvailable && (
             <Text style={styles.updateNotification}>Update available</Text>
           )}
 
-          {!updateAvailable && !isAdmin && (
+          {!syncState.isActive && !updateAvailable && !isAdmin && (
             <Text style={styles.hintText}>No updates available</Text>
           )}
         </View>
@@ -748,17 +773,6 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     color: colors.brand.primary[500],
-  },
-  progressDetails: {
-    fontSize: 14,
-    color: colors.neutral[600],
-    marginBottom: 12,
-  },
-  progressMode: {
-    fontSize: 12,
-    color: colors.neutral[500],
-    marginBottom: 4,
-    fontStyle: 'italic',
   },
   progressBar: {
     height: 8,

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -196,9 +196,9 @@ const SyncScreen = () => {
     isAdmin,
   ]);
 
-  const checkForUpdates = useCallback(async (force: boolean = false) => {
+  const checkForUpdates = useCallback(async () => {
     try {
-      const hasUpdate = await syncService.checkForUpdates(force);
+      const hasUpdate = await syncService.checkForUpdates();
       setUpdateAvailable(hasUpdate);
       const currentVersion = (await AsyncStorage.getItem('@appVersion')) || '0';
       setAppBundleVersion(currentVersion);
@@ -243,7 +243,7 @@ const SyncScreen = () => {
 
     const initialize = async () => {
       await syncService.initialize();
-      await checkForUpdates(true);
+      await checkForUpdates();
       const userInfo = await getUserInfo();
       setIsAdmin(userInfo?.role === 'admin');
       const lastSyncTime = await AsyncStorage.getItem('@lastSync');
@@ -297,7 +297,7 @@ const SyncScreen = () => {
     if (!syncState.isActive && !syncState.error) {
       updatePendingUploads();
       updatePendingObservations();
-      checkForUpdates(false);
+      checkForUpdates();
     }
   }, [
     syncState.isActive,

--- a/formulus/src/services/NotificationService.ts
+++ b/formulus/src/services/NotificationService.ts
@@ -1,179 +1,56 @@
 import { Platform } from 'react-native';
 import notifee, {
   AndroidImportance,
-  AndroidStyle,
-  AndroidAction,
   AndroidForegroundServiceType,
 } from '@notifee/react-native';
 import { SyncProgress } from '../contexts/SyncContext';
 
 class NotificationService {
   private syncNotificationId = 'sync_progress';
-  private completionNotificationId = 'sync_completion';
   private channelId = 'sync_channel';
   private isConfigured = false;
   private foregroundServiceRunning = false;
 
   async configure() {
     if (this.isConfigured) return;
-
-    // Request permissions
     await notifee.requestPermission();
-
-    // Create notification channel for Android
     await notifee.createChannel({
       id: this.channelId,
       name: 'Sync Progress',
       description: 'Shows progress of data synchronization',
       importance: AndroidImportance.DEFAULT,
-      sound: undefined, // No sound
+      sound: undefined,
       vibration: false,
     });
-
     this.isConfigured = true;
-    console.log('Notifee notification service configured');
   }
 
   async showSyncProgress(progress: SyncProgress) {
-    await this.configure();
+    if (!this.foregroundServiceRunning) return;
 
     const percentage =
       progress.total > 0
         ? Math.round((progress.current / progress.total) * 100)
         : 0;
-    const phaseText = this.getPhaseText(progress.phase);
 
-    const title = 'Syncing data...';
-    let message = `${phaseText}: ${progress.current}/${progress.total}`;
-
-    if (progress.details) {
-      message += ` - ${progress.details}`;
-    }
-
-    const cancelAction: AndroidAction = {
-      title: 'Cancel',
-      pressAction: {
-        id: 'cancel_sync',
-      },
-    };
-
-    await notifee.displayNotification({
-      id: this.syncNotificationId,
-      title,
-      body: message,
-      android: {
-        channelId: this.channelId,
-        ongoing: true, // Makes notification persistent
-        style: {
-          type: AndroidStyle.BIGTEXT,
-          text: message,
-        },
-        progress: {
-          max: 100,
-          current: percentage,
-          indeterminate: progress.total === 0,
-        },
-        actions: [cancelAction],
-        pressAction: {
-          id: 'default',
-        },
-      },
-    });
-  }
-
-  async showSyncComplete(success: boolean, error?: string) {
-    await this.configure();
-
-    // Cancel the ongoing notification completely
-    console.log(
-      'Canceling progress notification with ID:',
-      this.syncNotificationId,
-    );
-
-    // First, update the notification to make it non-ongoing, then cancel it
-    await notifee.displayNotification({
-      id: this.syncNotificationId,
-      title: 'Sync completing...',
-      body: 'Finalizing sync...',
-      android: {
-        channelId: this.channelId,
-        ongoing: false, // Make it non-ongoing so it can be cancelled
-        autoCancel: true,
-      },
-    });
-
-    // Now cancel it
-    await notifee.cancelNotification(this.syncNotificationId);
-    console.log('Progress notification cancellation completed');
-
-    if (success) {
-      // Show a fresh completion notification with timestamp
-      const now = new Date();
-      const timeString = now.toLocaleTimeString('en-US', {
-        hour12: false,
-        hour: '2-digit',
-        minute: '2-digit',
-      });
-
+    try {
       await notifee.displayNotification({
-        id: `sync_completed_${Date.now()}`, // Unique ID each time
-        title: `Sync completed @ ${timeString}`,
-        body: 'All data synchronized successfully',
+        id: this.syncNotificationId,
+        title: this.getPhaseText(progress.phase),
+        body: `${percentage}%`,
         android: {
           channelId: this.channelId,
-          autoCancel: true,
-          smallIcon: 'ic_launcher',
-          ongoing: false,
-          // No actions at all - completely fresh notification
-          pressAction: {
-            id: 'default',
+          ongoing: true,
+          progress: {
+            max: 100,
+            current: percentage,
+            indeterminate: progress.total === 0,
           },
         },
       });
-    } else {
-      // For errors, show a simple error notification
-      await notifee.displayNotification({
-        id: `sync_failed_${Date.now()}`, // Unique ID each time
-        title: 'Sync failed',
-        body: error || 'An error occurred during synchronization',
-        android: {
-          channelId: this.channelId,
-          autoCancel: true,
-          smallIcon: 'ic_launcher',
-          ongoing: false,
-          pressAction: {
-            id: 'default',
-          },
-        },
-      });
+    } catch (e) {
+      console.warn('Failed to update sync progress notification:', e);
     }
-  }
-
-  async showSyncCanceled() {
-    await this.configure();
-
-    // Remove the ongoing notification
-    await notifee.cancelNotification(this.syncNotificationId);
-
-    // Small delay to ensure the previous notification is fully canceled
-    await new Promise<void>(resolve => setTimeout(() => resolve(), 100));
-
-    // Show cancellation notification with different ID
-    await notifee.displayNotification({
-      id: `${this.completionNotificationId}_canceled`,
-      title: 'Sync canceled',
-      body: 'Data synchronization was canceled by user',
-      android: {
-        channelId: this.channelId,
-        autoCancel: true,
-        smallIcon: 'ic_launcher',
-        pressAction: {
-          id: 'default',
-        },
-        actions: [], // Explicitly remove all actions (no Cancel button)
-        ongoing: false, // Ensure it's not ongoing
-      },
-    });
   }
 
   async startForegroundService() {
@@ -182,12 +59,14 @@ class NotificationService {
 
     await notifee.displayNotification({
       id: this.syncNotificationId,
-      title: 'Syncing data...',
-      body: 'Sync in progress',
+      title: 'Syncing...',
+      body: 'Starting...',
       android: {
         channelId: this.channelId,
         asForegroundService: true,
-        foregroundServiceTypes: [AndroidForegroundServiceType.DATA_SYNC],
+        foregroundServiceTypes: [
+          AndroidForegroundServiceType.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+        ],
         ongoing: true,
         progress: { max: 100, current: 0, indeterminate: true },
       },
@@ -197,12 +76,76 @@ class NotificationService {
 
   async stopForegroundService() {
     if (Platform.OS !== 'android' || !this.foregroundServiceRunning) return;
+    this.foregroundServiceRunning = false;
     try {
       await notifee.stopForegroundService();
     } catch (e) {
       console.warn('Failed to stop foreground service:', e);
     }
-    this.foregroundServiceRunning = false;
+    try {
+      await notifee.cancelNotification(this.syncNotificationId);
+    } catch (e) {
+      console.warn('Failed to cancel foreground notification:', e);
+    }
+    // Delayed cleanup: catch any fire-and-forget showSyncProgress calls
+    // that were already in-flight when we stopped the service
+    setTimeout(async () => {
+      try {
+        await notifee.cancelNotification(this.syncNotificationId);
+      } catch (_) {}
+    }, 1000);
+  }
+
+  async showSyncComplete(success: boolean, error?: string) {
+    await this.configure();
+
+    if (success) {
+      const now = new Date();
+      const timeString = now.toLocaleTimeString('en-US', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+
+      await notifee.displayNotification({
+        id: `sync_done_${Date.now()}`,
+        title: `Sync completed @ ${timeString}`,
+        body: 'All data synchronized successfully',
+        android: {
+          channelId: this.channelId,
+          autoCancel: true,
+          ongoing: false,
+          pressAction: { id: 'default' },
+        },
+      });
+    } else {
+      await notifee.displayNotification({
+        id: `sync_done_${Date.now()}`,
+        title: 'Sync failed',
+        body: error || 'An error occurred during synchronization',
+        android: {
+          channelId: this.channelId,
+          autoCancel: true,
+          ongoing: false,
+          pressAction: { id: 'default' },
+        },
+      });
+    }
+  }
+
+  async showSyncCanceled() {
+    await this.configure();
+    await notifee.displayNotification({
+      id: `sync_done_${Date.now()}`,
+      title: 'Sync canceled',
+      body: 'Synchronization was canceled',
+      android: {
+        channelId: this.channelId,
+        autoCancel: true,
+        ongoing: false,
+        pressAction: { id: 'default' },
+      },
+    });
   }
 
   async hideSyncProgress() {
@@ -210,22 +153,17 @@ class NotificationService {
   }
 
   async clearAllSyncNotifications() {
-    // Clear all sync-related notifications to prevent stale data
-    await notifee.cancelNotification(this.syncNotificationId);
-    await notifee.cancelNotification(this.completionNotificationId);
-    await notifee.cancelNotification(
-      `${this.completionNotificationId}_canceled`,
-    );
+    await notifee.cancelAllNotifications();
   }
 
   private getPhaseText(phase: SyncProgress['phase']): string {
     switch (phase) {
       case 'pull':
-        return 'Downloading';
+        return 'Downloading data';
       case 'push':
         return 'Uploading observations';
       case 'attachments_download':
-        return 'Downloading attachments';
+        return 'Updating app bundle';
       case 'attachments_upload':
         return 'Uploading attachments';
       default:

--- a/formulus/src/services/NotificationService.ts
+++ b/formulus/src/services/NotificationService.ts
@@ -92,7 +92,9 @@ class NotificationService {
     setTimeout(async () => {
       try {
         await notifee.cancelNotification(this.syncNotificationId);
-      } catch (_) {}
+      } catch (_) {
+        // ignore
+      }
     }, 1000);
   }
 

--- a/formulus/src/services/NotificationService.ts
+++ b/formulus/src/services/NotificationService.ts
@@ -1,7 +1,9 @@
+import { Platform } from 'react-native';
 import notifee, {
   AndroidImportance,
   AndroidStyle,
   AndroidAction,
+  AndroidForegroundServiceType,
 } from '@notifee/react-native';
 import { SyncProgress } from '../contexts/SyncContext';
 
@@ -10,6 +12,7 @@ class NotificationService {
   private completionNotificationId = 'sync_completion';
   private channelId = 'sync_channel';
   private isConfigured = false;
+  private foregroundServiceRunning = false;
 
   async configure() {
     if (this.isConfigured) return;
@@ -171,6 +174,35 @@ class NotificationService {
         ongoing: false, // Ensure it's not ongoing
       },
     });
+  }
+
+  async startForegroundService() {
+    if (Platform.OS !== 'android' || this.foregroundServiceRunning) return;
+    await this.configure();
+
+    await notifee.displayNotification({
+      id: this.syncNotificationId,
+      title: 'Syncing data...',
+      body: 'Sync in progress',
+      android: {
+        channelId: this.channelId,
+        asForegroundService: true,
+        foregroundServiceTypes: [AndroidForegroundServiceType.DATA_SYNC],
+        ongoing: true,
+        progress: { max: 100, current: 0, indeterminate: true },
+      },
+    });
+    this.foregroundServiceRunning = true;
+  }
+
+  async stopForegroundService() {
+    if (Platform.OS !== 'android' || !this.foregroundServiceRunning) return;
+    try {
+      await notifee.stopForegroundService();
+    } catch (e) {
+      console.warn('Failed to stop foreground service:', e);
+    }
+    this.foregroundServiceRunning = false;
   }
 
   async hideSyncProgress() {

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -323,9 +323,10 @@ export class SyncService {
     }
 
     this.isSyncing = true;
-    this.autoLoginRetryCount = 0; // Reset retry count for new bundle update
+    this.canCancel = true;
+    this.shouldCancel = false;
+    this.autoLoginRetryCount = 0;
     this.updateStatus('Starting app bundle sync...');
-    // Expose progress to the UI so users can see bundle download progress.
     this.updateProgress({
       current: 0,
       total: 100,
@@ -334,11 +335,14 @@ export class SyncService {
     });
 
     try {
-      // Get manifest to know what version we're downloading
+      if (this.shouldCancel) throw new Error('Sync cancelled');
+
       const manifest = await this.withAutoLoginRetry(
         () => synkronusApi.getManifest(),
         'get manifest',
       );
+
+      if (this.shouldCancel) throw new Error('Sync cancelled');
 
       await this.downloadAppBundle();
 
@@ -365,6 +369,8 @@ export class SyncService {
       throw error;
     } finally {
       this.isSyncing = false;
+      this.canCancel = false;
+      this.shouldCancel = false;
     }
   }
 

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -1,5 +1,4 @@
 import { synkronusApi } from '../api/synkronus';
-import RNFS from 'react-native-fs';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SyncProgress } from '../contexts/SyncContext';
 import { notificationService } from './NotificationService';
@@ -371,68 +370,21 @@ export class SyncService {
 
   private async downloadAppBundle(): Promise<void> {
     try {
-      this.updateStatus('Fetching manifest...');
-      const manifest = await this.withAutoLoginRetry(
-        () => synkronusApi.getManifest(),
-        'get manifest',
-      );
-
-      // Clean out the existing app bundle
-      await synkronusApi.removeAppBundleFiles();
-
-      // Download form specs
-      this.updateStatus('Downloading form specs...');
-      const formResults = await this.withAutoLoginRetry(
+      this.updateStatus('Downloading app bundle...');
+      await this.withAutoLoginRetry(
         () =>
-          synkronusApi.downloadFormSpecs(
-            manifest,
-            RNFS.DocumentDirectoryPath,
-            progress => {
-              const normalized = Math.max(0, Math.min(100, progress));
-              this.updateStatus(`Downloading form specs... ${normalized}%`);
-              // Use 0–50% of the overall range for form specs
-              this.updateProgress({
-                current: Math.round((normalized / 100) * 50),
-                total: 100,
-                phase: 'attachments_download',
-                details: `Downloading form specs... ${normalized}%`,
-              });
-            },
-          ),
-        'download form specs',
+          synkronusApi.downloadAndInstallBundleZip(progress => {
+            const normalized = Math.max(0, Math.min(100, progress));
+            this.updateStatus(`Downloading app bundle... ${normalized}%`);
+            this.updateProgress({
+              current: normalized,
+              total: 100,
+              phase: 'attachments_download',
+              details: `Downloading app bundle... ${normalized}%`,
+            });
+          }),
+        'download app bundle',
       );
-
-      // Download app files
-      this.updateStatus('Downloading app files...');
-      const appResults = await this.withAutoLoginRetry(
-        () =>
-          synkronusApi.downloadAppFiles(
-            manifest,
-            RNFS.DocumentDirectoryPath,
-            progress => {
-              const normalized = Math.max(0, Math.min(100, progress));
-              this.updateStatus(`Downloading app files... ${normalized}%`);
-              // Use 50–100% of the overall range for app files
-              this.updateProgress({
-                current: 50 + Math.round((normalized / 100) * 50),
-                total: 100,
-                phase: 'attachments_download',
-                details: `Downloading app files... ${normalized}%`,
-              });
-            },
-          ),
-        'download app files',
-      );
-
-      const results = [...formResults, ...appResults];
-
-      if (results.some(r => !r.success)) {
-        const errorMessages = results
-          .filter(r => !r.success)
-          .map(r => r.message)
-          .join('\n');
-        throw new Error(`Failed to download some files:\n${errorMessages}`);
-      }
     } catch (error) {
       console.error('Download failed', error);
       throw error;

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -174,9 +174,8 @@ export class SyncService {
         console.warn('Failed to clear stale notifications:', error),
       );
 
-    await notificationService.startForegroundService();
-
     try {
+      await notificationService.startForegroundService();
       // Phase 1: Pull - Get manifest and download changes
       this.updateProgress({
         current: 0,
@@ -336,9 +335,9 @@ export class SyncService {
       details: 'Preparing app bundle download...',
     });
 
-    await notificationService.startForegroundService();
-
     try {
+      await notificationService.startForegroundService();
+
       if (this.shouldCancel) throw new Error('Sync cancelled');
 
       const manifest = await this.withAutoLoginRetry(

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -165,15 +165,16 @@ export class SyncService {
     this.isSyncing = true;
     this.canCancel = true;
     this.shouldCancel = false;
-    this.autoLoginRetryCount = 0; // Reset retry count for new sync operation
+    this.autoLoginRetryCount = 0;
     this.updateStatus('Starting sync...');
 
-    // Clear any stale notifications before starting new sync
     notificationService
       .clearAllSyncNotifications()
       .catch(error =>
         console.warn('Failed to clear stale notifications:', error),
       );
+
+    await notificationService.startForegroundService();
 
     try {
       // Phase 1: Pull - Get manifest and download changes
@@ -291,7 +292,7 @@ export class SyncService {
       this.isSyncing = false;
       this.canCancel = false;
       this.shouldCancel = false;
-      // Note: Don't call hideSyncProgress() here as showSyncComplete() already handles notification cleanup
+      await notificationService.stopForegroundService();
     }
   }
 
@@ -335,6 +336,8 @@ export class SyncService {
       details: 'Preparing app bundle download...',
     });
 
+    await notificationService.startForegroundService();
+
     try {
       if (this.shouldCancel) throw new Error('Sync cancelled');
 
@@ -374,6 +377,7 @@ export class SyncService {
       this.isSyncing = false;
       this.canCancel = false;
       this.shouldCancel = false;
+      await notificationService.stopForegroundService();
     }
   }
 

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -1,5 +1,6 @@
 import { synkronusApi } from '../api/synkronus';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { appEvents } from '../webview/FormulusMessageHandlers';
 import { SyncProgress } from '../contexts/SyncContext';
 import { notificationService } from './NotificationService';
 import { FormService } from './FormService';
@@ -363,6 +364,8 @@ export class SyncService {
         phase: 'attachments_download',
         details: 'App bundle sync completed',
       });
+
+      appEvents.emit('bundleUpdated');
     } catch (error) {
       console.error('App sync failed', error);
       this.updateStatus('App sync failed');

--- a/synkronus/internal/api/api.go
+++ b/synkronus/internal/api/api.go
@@ -128,6 +128,7 @@ func NewRouter(log *logger.Logger, h *handlers.Handler) http.Handler {
 			// Read endpoints - accessible to all authenticated users
 			r.Get("/manifest", h.GetAppBundleManifest)
 			r.Get("/download/{path}", h.GetAppBundleFile)
+			r.Get("/download-zip", h.DownloadBundleZip)
 			r.Get("/versions", h.GetAppBundleVersions)
 			r.Get("/changes", h.CompareAppBundleVersions)
 

--- a/synkronus/internal/handlers/appbundle.go
+++ b/synkronus/internal/handlers/appbundle.go
@@ -125,6 +125,20 @@ func (h *Handler) streamFile(w http.ResponseWriter, file io.ReadCloser, fileInfo
 	}
 }
 
+// DownloadBundleZip serves the active app bundle as a zip file
+func (h *Handler) DownloadBundleZip(w http.ResponseWriter, r *http.Request) {
+	zipPath, err := h.appBundleService.GetBundleZipPath(r.Context())
+	if err != nil {
+		h.log.Error("Failed to get bundle zip", "error", err)
+		SendErrorResponse(w, http.StatusNotFound, err, "Bundle zip not available")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Content-Disposition", `attachment; filename="bundle.zip"`)
+	http.ServeFile(w, r, zipPath)
+}
+
 // CompareAppBundleVersions handles the /app-bundle/changes endpoint
 func (h *Handler) CompareAppBundleVersions(w http.ResponseWriter, r *http.Request) {
 	h.log.Info("App bundle comparison requested")

--- a/synkronus/internal/handlers/mocks/appbundle_service.go
+++ b/synkronus/internal/handlers/mocks/appbundle_service.go
@@ -165,6 +165,11 @@ func (m *MockAppBundleService) GetLatestAppInfo(ctx context.Context) (*appbundle
 	}, nil
 }
 
+// GetBundleZipPath returns the path to the active bundle's zip archive
+func (m *MockAppBundleService) GetBundleZipPath(ctx context.Context) (string, error) {
+	return "/mock/bundle.zip", nil
+}
+
 // CompareAppInfos compares two versions and returns the change log
 func (m *MockAppBundleService) CompareAppInfos(ctx context.Context, versionA, versionB string) (*appbundle.ChangeLog, error) {
 	// Return a mock change log

--- a/synkronus/internal/handlers/sync_e2e_test.go
+++ b/synkronus/internal/handlers/sync_e2e_test.go
@@ -348,6 +348,9 @@ func (m *mockAppBundleService) GetLatestAppInfo(ctx context.Context) (*appbundle
 func (m *mockAppBundleService) CompareAppInfos(ctx context.Context, versionA, versionB string) (*appbundle.ChangeLog, error) {
 	return &appbundle.ChangeLog{}, nil
 }
+func (m *mockAppBundleService) GetBundleZipPath(ctx context.Context) (string, error) {
+	return "/mock/bundle.zip", nil
+}
 
 type mockUserService struct{}
 

--- a/synkronus/pkg/appbundle/interface.go
+++ b/synkronus/pkg/appbundle/interface.go
@@ -63,4 +63,7 @@ type AppBundleServiceInterface interface {
 
 	// CompareAppInfos compares two versions and returns the change log
 	CompareAppInfos(ctx context.Context, versionA, versionB string) (*ChangeLog, error)
+
+	// GetBundleZipPath returns the filesystem path to the active bundle's zip archive
+	GetBundleZipPath(ctx context.Context) (string, error)
 }

--- a/synkronus/pkg/appbundle/service.go
+++ b/synkronus/pkg/appbundle/service.go
@@ -420,7 +420,7 @@ func (s *Service) hashManifest(manifest *Manifest) (string, error) {
 
 // ensureCurrentVersionSet checks if a current version is set, and if not,
 // sets the latest available version as current
-func (s *Service) ensureCurrentVersionSet(ctx context.Context) error {
+func (s *Service) ensureCurrentVersionSet(_ context.Context) error {
 	// Check if CURRENT_VERSION file exists
 	versionFile := filepath.Join(s.versionsPath, "CURRENT_VERSION")
 	if _, err := os.Stat(versionFile); err == nil {
@@ -472,7 +472,7 @@ func (s *Service) ensureCurrentVersionSet(ctx context.Context) error {
 }
 
 // GetBundleZipPath returns the filesystem path to the active bundle's zip archive
-func (s *Service) GetBundleZipPath(ctx context.Context) (string, error) {
+func (s *Service) GetBundleZipPath(_ context.Context) (string, error) {
 	zipPath := filepath.Join(s.bundlePath, "bundle.zip")
 	if _, err := os.Stat(zipPath); err != nil {
 		if os.IsNotExist(err) {

--- a/synkronus/pkg/appbundle/service.go
+++ b/synkronus/pkg/appbundle/service.go
@@ -291,6 +291,10 @@ func (s *Service) generateManifest() (*Manifest, error) {
 		// Use forward slashes for consistency across platforms
 		relPath = filepath.ToSlash(relPath)
 
+		if relPath == "bundle.zip" {
+			return nil
+		}
+
 		// Include app/forms/ in the manifest. Some bundles (e.g. AnthroCollect) put
 		// form schemas only under app/forms/<formType>/schema.json. The Formulus
 		// client downloads these via downloadAppFiles (prefix "app/") and
@@ -465,6 +469,18 @@ func (s *Service) ensureCurrentVersionSet(ctx context.Context) error {
 	s.currentVersion = latestVersion
 
 	return nil
+}
+
+// GetBundleZipPath returns the filesystem path to the active bundle's zip archive
+func (s *Service) GetBundleZipPath(ctx context.Context) (string, error) {
+	zipPath := filepath.Join(s.bundlePath, "bundle.zip")
+	if _, err := os.Stat(zipPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("bundle zip not available")
+		}
+		return "", fmt.Errorf("failed to check bundle zip: %w", err)
+	}
+	return zipPath, nil
 }
 
 // RefreshManifest forces a refresh of the manifest


### PR DESCRIPTION
## Description

Resolves #295 
Sync stops mid-way, fails when backgrounded, cancel button broken, app bundle update not transactional, redundant progress text, and slow file-by-file download.

### Changes

| Area | What changed |
|------|-------------|
| **synkronus** | Save uploaded zip alongside extracted files; serve it via `GET /app-bundle/download-zip` |
| **synkronus** | Relax bundle validation to allow non-form files under `app/forms/` (e.g. AnthroCollect extensions) |
| **formulus** | Download bundle as single zip → extract to staging dir → atomic swap into place |
| **formulus** | Android foreground service (`dataSync`) to keep sync alive when app is backgrounded |
| **formulus** | Cancel button now propagates to service layer with cancellation checkpoints |
| **formulus** | Force WebView remount after bundle update so new content loads immediately |
| **formulus** | Warn user about unsynced data before app bundle update (Sync & Update / Cancel) |
| **formulus** | Clean up sync screen: one spinner on the active button, progress = bar + percentage only |
| **formulus** | Fix foreground notification not clearing after sync completes |

### Commits

| Commit | Description |
|--------|-------------|
| `ccf43cf` | **synkronus:** save zip on push, copy on version switch, add download-zip endpoint |
| `103b53c` | **formulus:** zip-based app bundle download with transactional staging → swap |
| `d368fb4` | **formulus:** wire cancel button to service layer, add cancellation checkpoints |
| `4c1f4f4` | **formulus:** simplify progress text to percentage only |
| `16502ad` | **formulus:** emit `bundleUpdated` event, reload WebView on HomeScreen |
| `841da74` | **formulus:** register Android foreground service with notifee |
| `17523d1` | **synkronus:** fix Go lint errors (unused context params) |
| `9ea5d74` | **synkronus:** relax validation — skip non-form files under `app/forms/` |
| `68bb798` | **formulus:** use `key` prop to force WebView remount after bundle update |
| `00bd60d` | **formulus:** clean up sync screen UI, guard update with unsynced data check, fix stuck notification |
| `6ae89ec` | **formulus:** declare foreground service type in AndroidManifest, move start inside try block |

### Testing

- Sync data with attachments — completes successfully
- Background the app mid-sync on Android — sync continues and finishes
- Cancel during sync — stops promptly
- App bundle update — downloads zip, extracts to staging, swaps atomically; old bundle preserved on failure
- Upload AnthroCollect bundle (with extensions under `app/forms/`) — accepted by server
- After bundle update — WebView reloads with new content immediately
- Notification clears after sync/update completes and is swipeable

## Video DEMO
### Note: 

- In this Video, I used two different custom app-bundles. 
- You can observe the change after the App-bundle update from version **003** to **004** and to **005**

https://github.com/user-attachments/assets/1d253440-be6d-4bfc-98ad-dd8491247c4f