### PR TITLE
feat(formplayer): enable AJV $data cross-field validation

### DIFF
--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -734,6 +734,9 @@ function App() {
     ({ data }: { data: FormData }) => {
       setData(data);
 
+      // Expose current form data globally for extension renderers
+      (window as any).formulusCurrentFormData = data;
+
       // Save draft data whenever form data changes
       if (formInitData) {
         draftService.saveDraft(formInitData.formType, data, formInitData);
@@ -747,6 +750,7 @@ function App() {
     const instance = new Ajv({
       allErrors: true,
       strict: false, // Allow custom keywords like x-formulus-validation
+      $data: true,
     });
     addErrors(instance);
     addFormats(instance);


### PR DESCRIPTION

Adds two changes to the formplayer:

1. **`$data: true`** in the AJV configuration: allows JSON Schema rules to reference other fields in the same form using `$data` pointers (e.g., `{"const": {"$data": "1/otherField"}}`).
2. **`window.formulusCurrentFormData`**: exposes current form data globally so extension renderers can access it.

These changes enable custom apps to define cross-field validation rules in their `schema.json` files, such as ensuring a QR code scanned at the end of a form matches the one assigned at the beginning.