### PR TITLE
fix: use namespace import for react-native-image-picker

### DIFF
--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -7,7 +7,7 @@ import { WebViewMessageEvent, WebView } from 'react-native-webview';
 import RNFS from 'react-native-fs';
 import * as Keychain from 'react-native-keychain';
 import { Alert } from 'react-native';
-import ImagePicker from 'react-native-image-picker';
+import * as ImagePicker from 'react-native-image-picker';
 import {
   pick,
   types,


### PR DESCRIPTION
## **Description:**

`react-native-image-picker` only exports named functions (`launchCamera`, `launchImageLibrary`), not a default export. The current default import resolves to `undefined`, breaking all camera, photo, and video capture in forms.

**Impact:**  
Restores `launchCamera` and `launchImageLibrary` calls across `FormulusMessageHandlers.ts` (photo capture, video recording, image library selection).

Closes #321