### PR TITLE
fix: add armeabi-v7a to supported architectures for 32-bit Android de…

### DIFF
--- a/formulus/android/gradle.properties
+++ b/formulus/android/gradle.properties
@@ -24,9 +24,8 @@ android.useAndroidX=true
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-# Default to arm64-v8a only for faster builds and to avoid CMake issues on Windows
-# To build for all architectures, change to: armeabi-v7a,arm64-v8a,x86,x86_64
-reactNativeArchitectures=arm64-v8a
+# Include armeabi-v7a so the APK runs on both 32-bit and 64-bit ARM devices
+reactNativeArchitectures=armeabi-v7a,arm64-v8a
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in


### PR DESCRIPTION
## **Description:**

`reactNativeArchitectures` was set to `arm64-v8a` only, making the APK incompatible with 32-bit ARM phones. The app installs on 64-bit tablets but fails on older/budget phones that run `armeabi-v7a`.

**Change:**
```
- reactNativeArchitectures=arm64-v8a
+ reactNativeArchitectures=armeabi-v7a,arm64-v8a
```

**Impact:**  
Restores APK installation on all ARM Android devices. APK size will increase slightly due to the additional architecture.

Closes #322 