### PR TITLE
fix(ci): install @ode/components deps in formulus-android workflow

### DIFF
--- a/.github/workflows/formulus-android.yml
+++ b/.github/workflows/formulus-android.yml
@@ -9,12 +9,14 @@ on:
       - 'formulus/**'
       - 'formulus-formplayer/**'
       - 'packages/tokens/**'
+      - 'packages/components/**'
       - '.github/workflows/formulus-android.yml'
   pull_request:
     paths:
       - 'formulus/**'
       - 'formulus-formplayer/**'
       - 'packages/tokens/**'
+      - 'packages/components/**'
       - '.github/workflows/formulus-android.yml'
   release:
     types: [published]
@@ -92,12 +94,18 @@ jobs:
             formulus-formplayer/package.json
             packages/tokens/package-lock.json
             packages/tokens/package.json
+            packages/components/package-lock.json
+            packages/components/package.json
 
       - name: Install and build @ode/tokens
         working-directory: packages/tokens
         run: |
           npm install
           npm run build
+
+      - name: Install @ode/components dependencies
+        working-directory: packages/components
+        run: npm install
 
       - name: Install npm dependencies (formulus)
         working-directory: formulus


### PR DESCRIPTION
## **Description:**

### Problem

The `Build Formulus Android APK` job fails with:

```
error Unable to resolve module @babel/runtime/helpers/interopRequireDefault
from packages/components/src/react-native/index.ts
```

See failed run: https://github.com/OpenDataEnsemble/ode/actions/runs/22077045078/job/63794321875

`formulus` depends on `@ode/components` (`file:../packages/components`), which requires `@babel/runtime`. The CI workflow installs deps for `packages/tokens` and `formulus`, but never for `packages/components` — so Metro can't resolve the import.

## Fix

Add `packages/components` support to `formulus-android.yml`:

- **Trigger paths** include `packages/components/**` so builds re-run on component changes
- **Cache keys** add `packages/components/package-lock.json` and `package.json`
- **New install step** `npm install` in `packages/components/` before `npm ci` in `formulus/`