### PR TITLE
feat: expose user role in getCurrentUser() for custom web apps

### DIFF
--- a/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
+++ b/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
@@ -8,7 +8,7 @@
  * If you've checked out the monorepo use:
  * cp ..\formulus\src\webview\FormulusInterfaceDefinition.ts .\src\FormulusInterfaceDefinition.ts
  *
- * Current Version: 1.0.17
+ * Current Version: 1.0.18
  */
 
 /**
@@ -458,9 +458,13 @@ export interface FormulusInterface {
 
   /**
    * Get information about the currently authenticated user
-   * @returns {Promise<{username: string, displayName?: string}>} User information
+   * @returns {Promise<{username: string, displayName?: string, role?: 'read-only' | 'read-write' | 'admin'}>} User information including role
    */
-  getCurrentUser(): Promise<{ username: string; displayName?: string }>;
+  getCurrentUser(): Promise<{
+    username: string;
+    displayName?: string;
+    role?: 'read-only' | 'read-write' | 'admin';
+  }>;
 }
 
 /**

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -8,7 +8,7 @@
  * If you've checked out the monorepo use:
  * cp ..\formulus\src\webview\FormulusInterfaceDefinition.ts .\src\FormulusInterfaceDefinition.ts
  *
- * Current Version: 1.0.17
+ * Current Version: 1.0.18
  */
 
 /**
@@ -458,9 +458,13 @@ export interface FormulusInterface {
 
   /**
    * Get information about the currently authenticated user
-   * @returns {Promise<{username: string, displayName?: string}>} User information
+   * @returns {Promise<{username: string, displayName?: string, role?: 'read-only' | 'read-write' | 'admin'}>} User information including role
    */
-  getCurrentUser(): Promise<{ username: string; displayName?: string }>;
+  getCurrentUser(): Promise<{
+    username: string;
+    displayName?: string;
+    role?: 'read-only' | 'read-write' | 'admin';
+  }>;
 }
 
 /**

--- a/formulus/src/webview/FormulusMessageHandlers.types.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.types.ts
@@ -61,7 +61,11 @@ export interface FormulusMessageHandlers {
     whereClause?: string | null;
   }) => Promise<Observation[]>;
   onOpenFormplayer?: (data: FormInitData) => Promise<FormCompletionResult>;
-  onGetCurrentUser?: () => Promise<{ username: string; displayName?: string }>;
+  onGetCurrentUser?: () => Promise<{
+    username: string;
+    displayName?: string;
+    role?: 'read-only' | 'read-write' | 'admin';
+  }>;
   // Called when the Formplayer WebView signals that it has completed initialization
   // via a `formplayerInitialized` message. Primarily used for logging/diagnostics.
   onFormplayerInitialized?: (data: {


### PR DESCRIPTION
### Description
Adds the user's role (`read-only` | `read-write` | `admin`) to the `getCurrentUser()` response so custom web apps can implement role-based access control.

Closes #330