### PR TITLE
ci(formulus-android): add Gradle cache and --build-cache to speed up PR APK builds

### DIFF
--- a/.github/workflows/formulus-android.yml
+++ b/.github/workflows/formulus-android.yml
@@ -72,9 +72,23 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      # Use workspace-relative path so we can cache Gradle home (deps + build cache)
+      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Restore Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .gradle/caches
+            .gradle/wrapper/dists
+          key: gradle-android-${{ runner.os }}-${{ hashFiles('formulus/android/**/*.gradle', 'formulus/android/**/*.gradle.kts', 'formulus/android/gradle/wrapper/gradle-wrapper.properties', 'formulus/android/gradle.properties', 'formulus/package-lock.json') }}
+          restore-keys: |
+            gradle-android-${{ runner.os }}-
 
       - name: Download formplayer assets artifact
         uses: actions/download-artifact@v7
@@ -148,12 +162,12 @@ jobs:
       - name: Build debug APK (PR)
         if: github.event_name == 'pull_request'
         working-directory: formulus/android
-        run: ./gradlew assembleDebug --no-daemon
+        run: ./gradlew assembleDebug --no-daemon --build-cache
 
       - name: Build release APK (main/dev/release)
         if: github.event_name != 'pull_request'
         working-directory: formulus/android
-        run: ./gradlew assembleRelease --no-daemon
+        run: ./gradlew assembleRelease --no-daemon --build-cache
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/formulus-android.yml
+++ b/.github/workflows/formulus-android.yml
@@ -21,6 +21,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NODE_VERSION: '24'
 
@@ -72,23 +76,9 @@ jobs:
     permissions:
       contents: write
 
-    env:
-      # Use workspace-relative path so we can cache Gradle home (deps + build cache)
-      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Restore Gradle cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            .gradle/caches
-            .gradle/wrapper/dists
-          key: gradle-android-${{ runner.os }}-${{ hashFiles('formulus/android/**/*.gradle', 'formulus/android/**/*.gradle.kts', 'formulus/android/gradle/wrapper/gradle-wrapper.properties', 'formulus/android/gradle.properties', 'formulus/package-lock.json') }}
-          restore-keys: |
-            gradle-android-${{ runner.os }}-
 
       - name: Download formplayer assets artifact
         uses: actions/download-artifact@v7
@@ -130,6 +120,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
 
       - name: Make Gradle wrapper executable
         working-directory: formulus/android
@@ -162,12 +153,12 @@ jobs:
       - name: Build debug APK (PR)
         if: github.event_name == 'pull_request'
         working-directory: formulus/android
-        run: ./gradlew assembleDebug --no-daemon --build-cache
+        run: ./gradlew assembleDebug --no-daemon
 
       - name: Build release APK (main/dev/release)
         if: github.event_name != 'pull_request'
         working-directory: formulus/android
-        run: ./gradlew assembleRelease --no-daemon --build-cache
+        run: ./gradlew assembleRelease --no-daemon
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
# Pull Request Title

<!-- PR Title must follow Conventional Commits format: <type>(<scope>): <subject> -->

## Description

<!-- Provide a clear description of what changed and why -->

## Type of Change

- [ ] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [ ] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:** <!-- Please specify -->

---

## Related Issue(s)

<!-- Use keywords: Closes #123, Fixes #456, Resolves #789 -->

**Closes/Fixes/Resolves:** <!-- e.g., Closes #123 -->

---

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manually tested
- [ ] Tested on multiple platforms (if applicable)
- [ ] Not applicable

---

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:**

---

## Documentation Updates

- [ ] Documentation has been updated
- [ ] Documentation update is not required

---

## Checklist

- [ ] Code follows project style guidelines
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**
