### PR TITLE
feat: Custom App Theming to Let the custom app own its brand

### DIFF
--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -23,11 +23,7 @@ import {
   Typography,
   ThemeProvider,
 } from '@mui/material';
-import {
-  createTheme,
-  getThemeOptions,
-  CustomThemeColors,
-} from './theme/theme';
+import { createTheme, getThemeOptions, CustomThemeColors } from './theme/theme';
 import { tokens } from './theme/tokens-adapter';
 import Ajv from 'ajv';
 import addErrors from 'ajv-errors';
@@ -271,8 +267,9 @@ function App() {
     null,
   );
   const [darkMode, setDarkMode] = useState<boolean>(false);
-  const [customThemeColors, setCustomThemeColors] =
-    useState<CustomThemeColors | undefined>(undefined);
+  const [customThemeColors, setCustomThemeColors] = useState<
+    CustomThemeColors | undefined
+  >(undefined);
   const [extensionRenderers, setExtensionRenderers] = useState<
     JsonFormsRendererRegistryEntry[]
   >([]);

--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -23,7 +23,11 @@ import {
   Typography,
   ThemeProvider,
 } from '@mui/material';
-import { createTheme, getThemeOptions } from './theme/theme';
+import {
+  createTheme,
+  getThemeOptions,
+  CustomThemeColors,
+} from './theme/theme';
 import { tokens } from './theme/tokens-adapter';
 import Ajv from 'ajv';
 import addErrors from 'ajv-errors';
@@ -267,6 +271,8 @@ function App() {
     null,
   );
   const [darkMode, setDarkMode] = useState<boolean>(false);
+  const [customThemeColors, setCustomThemeColors] =
+    useState<CustomThemeColors | undefined>(undefined);
   const [extensionRenderers, setExtensionRenderers] = useState<
     JsonFormsRendererRegistryEntry[]
   >([]);
@@ -325,6 +331,17 @@ function App() {
         // Extract dark mode preference from params
         const isDarkMode = params?.darkMode === true;
         setDarkMode(isDarkMode);
+
+        // Extract custom app theme colors (forwarded by Formulus native host).
+        // When present, these override the default @ode/tokens palette so that
+        // form UI matches the custom app's branding.
+        if (params?.themeColors && typeof params.themeColors === 'object') {
+          setCustomThemeColors(params.themeColors as CustomThemeColors);
+          console.log(
+            '[Formplayer] Using custom app theme colors:',
+            (params.themeColors as CustomThemeColors).primary,
+          );
+        }
 
         // Start with built-in extensions (always available)
         const allFunctions = getBuiltinExtensions();
@@ -796,11 +813,14 @@ function App() {
     return instance;
   }, [extensionDefinitions]);
 
-  // Create dynamic theme based on dark mode preference
-  // Must be called before any early returns to follow React Hooks rules
+  // Create dynamic theme based on dark mode preference and custom app colors.
+  // When a custom app provides themeColors, they override the default palette
+  // so that form controls (buttons, inputs, etc.) match the app's branding.
   const currentTheme = useMemo(() => {
-    return createTheme(getThemeOptions(darkMode ? 'dark' : 'light'));
-  }, [darkMode]);
+    return createTheme(
+      getThemeOptions(darkMode ? 'dark' : 'light', customThemeColors),
+    );
+  }, [darkMode, customThemeColors]);
 
   // Set CSS custom properties from tokens for use in CSS files
   // Must be called before any early returns to follow React Hooks rules

--- a/formulus-formplayer/src/theme/theme.ts
+++ b/formulus-formplayer/src/theme/theme.ts
@@ -103,10 +103,7 @@ export const getThemeOptions = (
           customColors?.secondaryLight,
           tokens.color.brand.secondary[400],
         ),
-        dark: c(
-          customColors?.secondaryDark,
-          tokens.color.brand.secondary[600],
-        ),
+        dark: c(customColors?.secondaryDark, tokens.color.brand.secondary[600]),
         contrastText: c(customColors?.onSecondary, tokens.color.neutral.white),
       },
       error: {

--- a/formulus-formplayer/src/theme/theme.ts
+++ b/formulus-formplayer/src/theme/theme.ts
@@ -40,68 +40,126 @@ const getDarkElevationShadow = (level: 'sm' | 'md' | 'lg'): string =>
       : `0 8px 24px rgba(0, 0, 0, ${(tokens as any).opacity?.['60'] ?? 0.6})`);
 
 /**
+ * Theme colors that a custom app can pass to override the default palette.
+ * These arrive via `formParams.themeColors` from the Formulus native host.
+ * When not provided, the Formplayer falls back to `@ode/tokens`.
+ */
+export interface CustomThemeColors {
+  primary?: string;
+  primaryLight?: string;
+  primaryDark?: string;
+  onPrimary?: string;
+
+  secondary?: string;
+  secondaryLight?: string;
+  secondaryDark?: string;
+  onSecondary?: string;
+
+  background?: string;
+  surface?: string;
+  onBackground?: string;
+  onSurface?: string;
+
+  error?: string;
+  errorLight?: string;
+  errorDark?: string;
+  onError?: string;
+
+  warning?: string;
+  success?: string;
+  info?: string;
+
+  divider?: string;
+}
+
+/**
  * Get theme options based on the mode (light or dark)
  * @param mode - 'light' or 'dark'
+ * @param customColors - Optional color overrides from the custom app's theme
  * @returns ThemeOptions for Material-UI
  */
-export const getThemeOptions = (mode: 'light' | 'dark'): ThemeOptions => {
+export const getThemeOptions = (
+  mode: 'light' | 'dark',
+  customColors?: CustomThemeColors,
+): ThemeOptions => {
   const isDark = mode === 'dark';
+
+  // Helper: use custom app color if provided, otherwise fall back to @ode/tokens.
+  const c = (custom: string | undefined, fallback: string): string =>
+    custom ?? fallback;
 
   return {
     palette: {
       mode: mode,
       primary: {
-        main: tokens.color.brand.primary[500], // #4F7F4E - ODE Primary Green
-        light: tokens.color.brand.primary[400],
-        dark: tokens.color.brand.primary[600],
-        contrastText: tokens.color.neutral.white,
+        main: c(customColors?.primary, tokens.color.brand.primary[500]),
+        light: c(customColors?.primaryLight, tokens.color.brand.primary[400]),
+        dark: c(customColors?.primaryDark, tokens.color.brand.primary[600]),
+        contrastText: c(customColors?.onPrimary, tokens.color.neutral.white),
       },
       secondary: {
-        main: tokens.color.brand.secondary[500], // #E9B85B - ODE Secondary Gold
-        light: tokens.color.brand.secondary[400],
-        dark: tokens.color.brand.secondary[600],
-        contrastText: tokens.color.neutral.white,
+        main: c(customColors?.secondary, tokens.color.brand.secondary[500]),
+        light: c(
+          customColors?.secondaryLight,
+          tokens.color.brand.secondary[400],
+        ),
+        dark: c(
+          customColors?.secondaryDark,
+          tokens.color.brand.secondary[600],
+        ),
+        contrastText: c(customColors?.onSecondary, tokens.color.neutral.white),
       },
       error: {
-        main: tokens.color.semantic.error[500],
-        light: tokens.color.semantic.error[50],
-        dark: tokens.color.semantic.error[600],
-        contrastText: tokens.color.neutral.white,
+        main: c(customColors?.error, tokens.color.semantic.error[500]),
+        light: c(customColors?.errorLight, tokens.color.semantic.error[50]),
+        dark: c(customColors?.errorDark, tokens.color.semantic.error[600]),
+        contrastText: c(customColors?.onError, tokens.color.neutral.white),
       },
       warning: {
-        main: tokens.color.semantic.warning[500],
+        main: c(customColors?.warning, tokens.color.semantic.warning[500]),
         light: tokens.color.semantic.warning[50],
         dark: tokens.color.semantic.warning[600],
         contrastText: tokens.color.neutral.white,
       },
       info: {
-        main: tokens.color.semantic.info[500],
+        main: c(customColors?.info, tokens.color.semantic.info[500]),
         light: tokens.color.semantic.info[50],
         dark: tokens.color.semantic.info[600],
         contrastText: tokens.color.neutral.white,
       },
       success: {
-        main: tokens.color.semantic.success[500],
+        main: c(customColors?.success, tokens.color.semantic.success[500]),
         light: tokens.color.semantic.success[50],
         dark: tokens.color.semantic.success[600],
         contrastText: tokens.color.neutral.white,
       },
       background: {
-        default: isDark ? tokens.color.neutral[900] : tokens.color.neutral[50], // Dark: #212121 (main background - deep dark gray), Light: #FAFAFA
-        paper: isDark ? tokens.color.neutral[800] : tokens.color.neutral.white, // Dark: #424242 (elevated surfaces - medium dark gray), Light: #FFFFFF
+        default: c(
+          customColors?.background,
+          isDark ? tokens.color.neutral[900] : tokens.color.neutral[50],
+        ),
+        paper: c(
+          customColors?.surface,
+          isDark ? tokens.color.neutral[800] : tokens.color.neutral.white,
+        ),
       },
       text: {
-        primary: isDark
-          ? tokens.color.neutral.white
-          : tokens.color.neutral[900], // Dark: #FFFFFF (pure white), Light: #212121
-        secondary: isDark
-          ? tokens.color.neutral[300]
-          : tokens.color.neutral[600], // Dark: #E0E0E0 (lighter gray), Light: #757575
+        primary: c(
+          customColors?.onBackground,
+          isDark ? tokens.color.neutral.white : tokens.color.neutral[900],
+        ),
+        secondary: c(
+          customColors?.onSurface,
+          isDark ? tokens.color.neutral[300] : tokens.color.neutral[600],
+        ),
         disabled: isDark
           ? tokens.color.neutral[600]
-          : tokens.color.neutral[400], // Dark: #757575, Light: #BDBDBD
+          : tokens.color.neutral[400],
       },
-      divider: isDark ? tokens.color.neutral[700] : tokens.color.neutral[200], // Dark: #616161 (lighter gray for better visibility), Light: #EEEEEE
+      divider: c(
+        customColors?.divider,
+        isDark ? tokens.color.neutral[700] : tokens.color.neutral[200],
+      ),
       grey: {
         50: tokens.color.neutral[50],
         100: tokens.color.neutral[100],

--- a/formulus/App.tsx
+++ b/formulus/App.tsx
@@ -1,10 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
-import { StatusBar } from 'react-native';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  NavigationContainer,
+  DefaultTheme,
+  DarkTheme,
+} from '@react-navigation/native';
+import { StatusBar, useColorScheme } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import 'react-native-url-polyfill/auto';
 import { FormService } from './src/services/FormService';
 import { SyncProvider } from './src/contexts/SyncContext';
+import {
+  AppThemeProvider,
+  useAppTheme,
+} from './src/contexts/AppThemeContext';
 import { appEvents, Listener } from './src/webview/FormulusMessageHandlers.ts';
 import FormplayerModal, {
   FormplayerModalHandle,
@@ -14,21 +22,32 @@ import SignatureCaptureModal from './src/components/SignatureCaptureModal';
 import MainAppNavigator from './src/navigation/MainAppNavigator';
 import { FormInitData } from './src/webview/FormulusInterfaceDefinition.ts';
 
-const LightNavigationTheme = {
-  ...DefaultTheme,
-  dark: false,
-  colors: {
-    ...DefaultTheme.colors,
-    background: '#ffffff',
-    card: '#ffffff',
-    text: '#000000',
-    primary: '#007AFF',
-    border: DefaultTheme.colors.border,
-    notification: DefaultTheme.colors.notification,
-  },
-};
+/**
+ * Inner component that consumes the AppTheme context to build a dynamic
+ * React Navigation theme matching the custom app's branding.
+ */
+function AppInner(): React.JSX.Element {
+  const colorScheme = useColorScheme();
+  const { themeColors } = useAppTheme();
 
-function App(): React.JSX.Element {
+  // Build the React Navigation theme dynamically from the custom app's colors.
+  const navigationTheme = useMemo(() => {
+    const base = colorScheme === 'dark' ? DarkTheme : DefaultTheme;
+    return {
+      ...base,
+      dark: colorScheme === 'dark',
+      colors: {
+        ...base.colors,
+        primary: themeColors.primary,
+        background: themeColors.background,
+        card: themeColors.surface,
+        text: themeColors.onBackground,
+        border: themeColors.divider,
+        notification: themeColors.error,
+      },
+    };
+  }, [colorScheme, themeColors]);
+
   const [qrScannerVisible, setQrScannerVisible] = useState(false);
   const [qrScannerData, setQrScannerData] = useState<{
     fieldId: string;
@@ -134,42 +153,59 @@ function App(): React.JSX.Element {
   }, []);
 
   return (
+    <>
+      <StatusBar
+        barStyle={colorScheme === 'dark' ? 'light-content' : 'dark-content'}
+        backgroundColor={themeColors.surface}
+      />
+      <NavigationContainer theme={navigationTheme}>
+        <MainAppNavigator />
+        <FormplayerModal
+          ref={formplayerModalRef}
+          visible={formplayerVisible}
+          onClose={() => {
+            formplayerVisibleRef.current = false;
+            setFormplayerVisible(false);
+          }}
+        />
+      </NavigationContainer>
+
+      <QRScannerModal
+        visible={qrScannerVisible}
+        onClose={() => {
+          setQrScannerVisible(false);
+          setQrScannerData(null);
+        }}
+        fieldId={qrScannerData?.fieldId}
+        onResult={qrScannerData?.onResult}
+      />
+
+      <SignatureCaptureModal
+        visible={signatureCaptureVisible}
+        onClose={() => {
+          setSignatureCaptureVisible(false);
+          setSignatureCaptureData(null);
+        }}
+        fieldId={signatureCaptureData?.fieldId || ''}
+        onSignatureCapture={(result: unknown) => {
+          signatureCaptureData?.onResult?.(result);
+        }}
+      />
+    </>
+  );
+}
+
+/**
+ * Root component.  Wraps everything in the AppThemeProvider so that the
+ * custom app's brand colors are available to all native UI elements.
+ */
+function App(): React.JSX.Element {
+  return (
     <SafeAreaProvider>
       <SyncProvider>
-        <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
-        <NavigationContainer theme={LightNavigationTheme}>
-          <MainAppNavigator />
-          <FormplayerModal
-            ref={formplayerModalRef}
-            visible={formplayerVisible}
-            onClose={() => {
-              formplayerVisibleRef.current = false;
-              setFormplayerVisible(false);
-            }}
-          />
-        </NavigationContainer>
-
-        <QRScannerModal
-          visible={qrScannerVisible}
-          onClose={() => {
-            setQrScannerVisible(false);
-            setQrScannerData(null);
-          }}
-          fieldId={qrScannerData?.fieldId}
-          onResult={qrScannerData?.onResult}
-        />
-
-        <SignatureCaptureModal
-          visible={signatureCaptureVisible}
-          onClose={() => {
-            setSignatureCaptureVisible(false);
-            setSignatureCaptureData(null);
-          }}
-          fieldId={signatureCaptureData?.fieldId || ''}
-          onSignatureCapture={(result: unknown) => {
-            signatureCaptureData?.onResult?.(result);
-          }}
-        />
+        <AppThemeProvider>
+          <AppInner />
+        </AppThemeProvider>
       </SyncProvider>
     </SafeAreaProvider>
   );

--- a/formulus/App.tsx
+++ b/formulus/App.tsx
@@ -9,10 +9,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import 'react-native-url-polyfill/auto';
 import { FormService } from './src/services/FormService';
 import { SyncProvider } from './src/contexts/SyncContext';
-import {
-  AppThemeProvider,
-  useAppTheme,
-} from './src/contexts/AppThemeContext';
+import { AppThemeProvider, useAppTheme } from './src/contexts/AppThemeContext';
 import { appEvents, Listener } from './src/webview/FormulusMessageHandlers.ts';
 import FormplayerModal, {
   FormplayerModalHandle,

--- a/formulus/android/app/src/main/assets/formplayer_dist/index.html
+++ b/formulus/android/app/src/main/assets/formplayer_dist/index.html
@@ -11,8 +11,8 @@
     <title>Formulus Form Player</title>
     <!-- Include the required Formulus load script -->
     <script src="./formulus-load.js"></script>
-    <script type="module" src="./public/index-CeSsc9Vd.js"></script>
-    <link rel="stylesheet" href="./public/index-azmow9Aj.css">
+    <script type="module" src="./public/index-D9_wZuZ-.js"></script>
+    <link rel="stylesheet" href="./public/index-oSBNCzFy.css">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/formulus/package-lock.json
+++ b/formulus/package-lock.json
@@ -2120,7 +2120,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2133,7 +2133,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2156,6 +2156,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
       "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2167,6 +2168,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2177,6 +2179,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
       "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3299,6 +3302,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3589,6 +3593,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4736,34 +4741,35 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5277,6 +5283,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5290,6 +5297,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5303,6 +5311,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5316,6 +5325,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5329,6 +5339,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5342,6 +5353,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5355,6 +5367,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5368,6 +5381,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5381,6 +5395,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5394,6 +5409,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5407,6 +5423,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5420,6 +5437,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5433,6 +5451,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5446,6 +5465,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5459,6 +5479,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5472,6 +5493,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5488,6 +5510,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5501,6 +5524,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5514,6 +5538,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5596,7 +5621,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -5736,7 +5761,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -6929,7 +6954,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -7249,7 +7274,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -11445,7 +11470,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -15466,7 +15491,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -15643,7 +15668,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15922,7 +15947,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -16296,7 +16321,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -36,6 +36,7 @@ import { colors } from '../theme/colors';
 import { FormSpec } from '../services'; // FormService will be imported directly
 import { ExtensionService } from '../services/ExtensionService';
 import RNFS from 'react-native-fs';
+import { useAppTheme } from '../contexts/AppThemeContext';
 
 interface FormplayerModalProps {
   visible: boolean;
@@ -61,6 +62,10 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
     const webViewRef = useRef<CustomAppWebViewHandle>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const colorScheme = useColorScheme();
+
+    // Theme colors from the AppThemeContext — updates automatically when
+    // the custom app config is loaded or the color scheme changes.
+    const { themeColors } = useAppTheme();
 
     // Internal state to track current form and observation data
     const [currentFormType, setCurrentFormType] = useState<string | null>(null);
@@ -198,12 +203,16 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       setCurrentOperationId(operationId);
       setFormSubmitted(false); // Reset submission flag for new form
 
+      // Forward the custom app's theme colors to the Formplayer WebView so
+      // that form UI elements (buttons, inputs, headers) match the branding.
+      // `themeColors` comes from useAppTheme() and is always up-to-date.
+      const isDark = colorScheme === 'dark';
+
       const formParams = {
         locale: 'en',
         theme: 'default',
-        darkMode: colorScheme === 'dark',
-        //schema: formType.schema,
-        //uischema: formType.uiSchema,
+        darkMode: isDark,
+        themeColors, // ← custom app palette forwarded to Formplayer
         ...params,
       };
 
@@ -439,8 +448,12 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         onRequestClose={handleClose}
         presentationStyle="fullScreen"
         statusBarTranslucent={false}>
-        <View style={styles.container}>
-          <View style={styles.header}>
+        <View style={[styles.container, { backgroundColor: themeColors.surface }]}>
+          <View
+            style={[
+              styles.header,
+              { borderBottomColor: themeColors.divider },
+            ]}>
             <TouchableOpacity
               onPress={handleClose}
               style={[
@@ -454,11 +467,12 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
                 color={
                   isSubmitting || isClosing
                     ? colors.neutral[400]
-                    : colors.neutral.black
+                    : themeColors.onBackground
                 }
               />
             </TouchableOpacity>
-            <Text style={styles.headerTitle}>
+            <Text
+              style={[styles.headerTitle, { color: themeColors.onBackground }]}>
               {currentObservationId ? 'Edit Observation' : 'New Observation'}
             </Text>
             <View style={styles.headerRightSpacer} />

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -448,12 +448,10 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         onRequestClose={handleClose}
         presentationStyle="fullScreen"
         statusBarTranslucent={false}>
-        <View style={[styles.container, { backgroundColor: themeColors.surface }]}>
+        <View
+          style={[styles.container, { backgroundColor: themeColors.surface }]}>
           <View
-            style={[
-              styles.header,
-              { borderBottomColor: themeColors.divider },
-            ]}>
+            style={[styles.header, { borderBottomColor: themeColors.divider }]}>
             <TouchableOpacity
               onPress={handleClose}
               style={[

--- a/formulus/src/components/common/Button.tsx
+++ b/formulus/src/components/common/Button.tsx
@@ -1,11 +1,27 @@
 /**
- * Formulus Button – uses ODE design system Button from @ode/components.
- * Wraps ODE Button to support existing Formulus API (title, tertiary, fullWidth).
+ * Formulus Button
+ *
+ * Renders a themed button that respects the custom app's brand colors
+ * via the AppThemeContext.  Primary and secondary variants use the custom
+ * app's palette; danger stays semantic-red; tertiary stays neutral-grey.
+ *
+ * This replaces the previous wrapper around `@ode/components` ODEButton
+ * because that component reads colors from `@ode/tokens` and cannot be
+ * overridden at runtime.
  */
 
-import React from 'react';
-import { ViewStyle, TextStyle } from 'react-native';
-import { Button as ODEButton } from '@ode/components/react-native';
+import React, { useState, useMemo } from 'react';
+import {
+  TouchableOpacity,
+  Text,
+  View,
+  ActivityIndicator,
+  StyleSheet,
+  ViewStyle,
+  TextStyle,
+} from 'react-native';
+import { useAppTheme } from '../../contexts/AppThemeContext';
+import { colors } from '../../theme/colors';
 
 export interface ButtonProps {
   title: string;
@@ -15,25 +31,27 @@ export interface ButtonProps {
   disabled?: boolean;
   loading?: boolean;
   fullWidth?: boolean;
-  /** ODE grouped style: horizontal 'left'|'middle'|'right', vertical 'top'|'bottom', or 'standalone' */
   position?: 'left' | 'right' | 'middle' | 'top' | 'bottom' | 'standalone';
-  /** When true, show hover style (e.g. selected filter tab) */
+  /** When true the button is shown in its "active / selected" state */
   active?: boolean;
   style?: ViewStyle;
   textStyle?: TextStyle;
   testID?: string;
   accessibilityLabel?: string;
+  children?: React.ReactNode;
 }
 
-/**
- * Maps Formulus tertiary variant to ODE neutral (same visual: text-only style).
- */
-const variantMap = {
-  primary: 'primary' as const,
-  secondary: 'secondary' as const,
-  tertiary: 'neutral' as const,
-  danger: 'danger' as const,
-};
+// ── Size maps ───────────────────────────────────────────────────────────
+
+const PADDING = {
+  small: { vertical: 6, horizontal: 14 },
+  medium: { vertical: 10, horizontal: 20 },
+  large: { vertical: 14, horizontal: 28 },
+} as const;
+
+const FONT_SIZE = { small: 13, medium: 15, large: 17 } as const;
+
+// ── Component ───────────────────────────────────────────────────────────
 
 const Button: React.FC<ButtonProps> = ({
   title,
@@ -43,28 +61,154 @@ const Button: React.FC<ButtonProps> = ({
   disabled = false,
   loading = false,
   fullWidth = false,
-  position = 'standalone',
   active = false,
   style,
-  textStyle: _textStyle,
+  textStyle,
   testID,
   accessibilityLabel,
+  children: _children,
 }) => {
+  const [isPressed, setIsPressed] = useState(false);
+  const { themeColors } = useAppTheme();
+  const isActiveOrPressed = active || isPressed;
+
+  // ── Resolve variant colors ──────────────────────────────────────────
+  const variantColors = useMemo(() => {
+    // Semantic colors stay fixed regardless of custom app theme
+    const errorMain = colors.semantic?.error?.[500] ?? '#F44336';
+    const errorDark = colors.semantic?.error?.[600] ?? '#D32F2F';
+    const errorLight = colors.semantic?.error?.[50] ?? '#FFEBEE';
+    const neutralGrey = colors.neutral[600];
+
+    switch (variant) {
+      case 'primary':
+        return {
+          border: themeColors.primary,
+          text: themeColors.primary,
+          textOnFill: themeColors.onPrimary,
+          activeBg: themeColors.primary,
+        };
+      case 'secondary':
+        return {
+          border: themeColors.secondary,
+          text: themeColors.secondary,
+          textOnFill: themeColors.onSecondary,
+          activeBg: themeColors.secondary,
+        };
+      case 'danger':
+        return {
+          border: errorMain,
+          text: errorDark,
+          textOnFill: '#FFFFFF',
+          activeBg: 'transparent',
+          defaultBg: errorLight,
+        };
+      case 'tertiary':
+      default:
+        return {
+          border: neutralGrey,
+          text: neutralGrey,
+          textOnFill: '#FFFFFF',
+          activeBg: neutralGrey,
+        };
+    }
+  }, [variant, themeColors]);
+
+  // ── Computed styles ─────────────────────────────────────────────────
+  const isDanger = variant === 'danger';
+
+  const backgroundColor = isDanger
+    ? isPressed
+      ? 'transparent'
+      : variantColors.defaultBg ?? 'transparent'
+    : isActiveOrPressed
+      ? variantColors.activeBg
+      : 'transparent';
+
+  const borderColor = isDanger
+    ? variantColors.border
+    : isActiveOrPressed
+      ? 'transparent'
+      : variantColors.border;
+
+  const textColor = isDanger
+    ? variantColors.text
+    : isActiveOrPressed
+      ? variantColors.textOnFill
+      : variantColors.text;
+
+  const padding = PADDING[size];
+  const fontSize = FONT_SIZE[size];
+
   return (
-    <ODEButton
-      onPress={onPress}
-      variant={variantMap[variant]}
-      size={size}
-      position={position}
-      active={active}
-      disabled={disabled}
-      loading={loading}
-      style={[fullWidth && { width: '100%' }, style]}
-      testID={testID}
-      accessibilityLabel={accessibilityLabel ?? title}>
-      {title}
-    </ODEButton>
+    <View style={[styles.wrapper, fullWidth && { width: '100%' }, style]} pointerEvents="box-none">
+      <TouchableOpacity
+        activeOpacity={0.8}
+        onPress={onPress}
+        onPressIn={() => setIsPressed(true)}
+        onPressOut={() => setIsPressed(false)}
+        disabled={disabled || loading}
+        style={[
+          styles.button,
+          {
+            paddingVertical: padding.vertical,
+            paddingHorizontal: padding.horizontal,
+            backgroundColor,
+            borderColor,
+            opacity: disabled ? 0.5 : 1,
+          },
+        ]}
+        testID={testID}
+        accessibilityLabel={accessibilityLabel ?? title}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: disabled || loading }}>
+        {loading ? (
+          <View style={styles.loadingRow}>
+            <ActivityIndicator size="small" color={textColor} style={styles.loader} />
+            <Text style={[styles.text, { color: textColor, fontSize }, textStyle]}>
+              {title}
+            </Text>
+          </View>
+        ) : (
+          <Text style={[styles.text, { color: textColor, fontSize }, textStyle]}>
+            {title}
+          </Text>
+        )}
+      </TouchableOpacity>
+    </View>
   );
 };
+
+// ── Static styles ─────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'relative',
+    minHeight: 48,
+    overflow: 'hidden',
+  },
+  button: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 48,
+    borderWidth: 1,
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  text: {
+    fontWeight: '500',
+    textAlign: 'center',
+    letterSpacing: 0.3,
+  },
+  loadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  loader: {
+    marginRight: 4,
+  },
+});
 
 export default Button;

--- a/formulus/src/components/common/Button.tsx
+++ b/formulus/src/components/common/Button.tsx
@@ -120,7 +120,7 @@ const Button: React.FC<ButtonProps> = ({
   const backgroundColor = isDanger
     ? isPressed
       ? 'transparent'
-      : variantColors.defaultBg ?? 'transparent'
+      : (variantColors.defaultBg ?? 'transparent')
     : isActiveOrPressed
       ? variantColors.activeBg
       : 'transparent';
@@ -141,7 +141,9 @@ const Button: React.FC<ButtonProps> = ({
   const fontSize = FONT_SIZE[size];
 
   return (
-    <View style={[styles.wrapper, fullWidth && { width: '100%' }, style]} pointerEvents="box-none">
+    <View
+      style={[styles.wrapper, fullWidth && { width: '100%' }, style]}
+      pointerEvents="box-none">
       <TouchableOpacity
         activeOpacity={0.8}
         onPress={onPress}
@@ -164,13 +166,19 @@ const Button: React.FC<ButtonProps> = ({
         accessibilityState={{ disabled: disabled || loading }}>
         {loading ? (
           <View style={styles.loadingRow}>
-            <ActivityIndicator size="small" color={textColor} style={styles.loader} />
-            <Text style={[styles.text, { color: textColor, fontSize }, textStyle]}>
+            <ActivityIndicator
+              size="small"
+              color={textColor}
+              style={styles.loader}
+            />
+            <Text
+              style={[styles.text, { color: textColor, fontSize }, textStyle]}>
               {title}
             </Text>
           </View>
         ) : (
-          <Text style={[styles.text, { color: textColor, fontSize }, textStyle]}>
+          <Text
+            style={[styles.text, { color: textColor, fontSize }, textStyle]}>
             {title}
           </Text>
         )}

--- a/formulus/src/components/common/EmptyState.tsx
+++ b/formulus/src/components/common/EmptyState.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Icon from '@react-native-vector-icons/material-design-icons';
 import colors from '../../theme/colors';
+import { useAppTheme } from '../../contexts/AppThemeContext';
 
 interface EmptyStateProps {
   icon?: React.ComponentProps<typeof Icon>['name'];
@@ -18,13 +19,17 @@ const EmptyState: React.FC<EmptyStateProps> = ({
   actionLabel,
   onAction,
 }) => {
+  const { themeColors } = useAppTheme();
+
   return (
     <View style={styles.container}>
       <Icon name={icon} size={64} color={colors.neutral[400]} />
       <Text style={styles.title}>{title}</Text>
       <Text style={styles.message}>{message}</Text>
       {actionLabel && onAction && (
-        <Text style={styles.actionText} onPress={onAction}>
+        <Text
+          style={[styles.actionText, { color: themeColors.primary }]}
+          onPress={onAction}>
           {actionLabel}
         </Text>
       )}
@@ -56,7 +61,7 @@ const styles = StyleSheet.create({
   },
   actionText: {
     fontSize: 16,
-    color: colors.brand.primary[500],
+    // color is applied inline via themeColors.primary
     fontWeight: '500',
     marginTop: 8,
   },

--- a/formulus/src/components/common/FilterBar.tsx
+++ b/formulus/src/components/common/FilterBar.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import Icon from '@react-native-vector-icons/material-design-icons';
 import { SortOption, FilterOption } from './FilterBar.types';
 import { colors } from '../../theme/colors';
-import { Input as ODEInput } from '@ode/components/react-native';
+import Input from './Input';
 import Button from './Button';
 
 export type { SortOption, FilterOption };
@@ -49,7 +49,7 @@ const FilterBar: React.FC<FilterBarProps> = ({
           color={colors.neutral[500]}
           style={styles.searchIcon}
         />
-        <ODEInput
+        <Input
           placeholder="Search..."
           value={searchQuery}
           onChangeText={onSearchChange}

--- a/formulus/src/components/common/FormCard.tsx
+++ b/formulus/src/components/common/FormCard.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import Icon from '@react-native-vector-icons/material-design-icons';
 import { FormSpec } from '../../services/FormService';
 import colors from '../../theme/colors';
+import { useAppTheme } from '../../contexts/AppThemeContext';
 
 interface FormCardProps {
   form: FormSpec;
@@ -15,14 +16,16 @@ const FormCard: React.FC<FormCardProps> = ({
   observationCount = 0,
   onPress,
 }) => {
+  const { themeColors } = useAppTheme();
+
   return (
     <TouchableOpacity style={styles.card} onPress={onPress} activeOpacity={0.7}>
       <View style={styles.content}>
-        <View style={styles.iconContainer}>
+        <View style={[styles.iconContainer, { backgroundColor: themeColors.primary + '14' }]}>
           <Icon
             name="file-document-outline"
             size={32}
-            color={colors.brand.primary[500]}
+            color={themeColors.primary}
           />
         </View>
         <View style={styles.textContainer}>
@@ -35,8 +38,8 @@ const FormCard: React.FC<FormCardProps> = ({
           <View style={styles.metaContainer}>
             <Text style={styles.version}>v{form.schemaVersion}</Text>
             {observationCount > 0 && (
-              <View style={styles.countBadge}>
-                <Text style={styles.countText}>
+              <View style={[styles.countBadge, { backgroundColor: themeColors.primary + '14' }]}>
+                <Text style={[styles.countText, { color: themeColors.primary }]}>
                   {observationCount}{' '}
                   {observationCount === 1 ? 'entry' : 'entries'}
                 </Text>
@@ -71,7 +74,7 @@ const styles = StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 24,
-    backgroundColor: colors.brand.primary[50],
+    // backgroundColor is applied inline via themeColors.primary + '14'
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 12,
@@ -100,14 +103,14 @@ const styles = StyleSheet.create({
     color: colors.neutral[500],
   },
   countBadge: {
-    backgroundColor: colors.brand.primary[50],
+    // backgroundColor is applied inline via themeColors.primary + '14'
     paddingHorizontal: 8,
     paddingVertical: 2,
     borderRadius: 10,
   },
   countText: {
     fontSize: 11,
-    color: colors.brand.primary[500],
+    // color is applied inline via themeColors.primary
     fontWeight: '500',
   },
 });

--- a/formulus/src/components/common/FormCard.tsx
+++ b/formulus/src/components/common/FormCard.tsx
@@ -21,7 +21,11 @@ const FormCard: React.FC<FormCardProps> = ({
   return (
     <TouchableOpacity style={styles.card} onPress={onPress} activeOpacity={0.7}>
       <View style={styles.content}>
-        <View style={[styles.iconContainer, { backgroundColor: themeColors.primary + '14' }]}>
+        <View
+          style={[
+            styles.iconContainer,
+            { backgroundColor: themeColors.primary + '14' },
+          ]}>
           <Icon
             name="file-document-outline"
             size={32}
@@ -38,8 +42,13 @@ const FormCard: React.FC<FormCardProps> = ({
           <View style={styles.metaContainer}>
             <Text style={styles.version}>v{form.schemaVersion}</Text>
             {observationCount > 0 && (
-              <View style={[styles.countBadge, { backgroundColor: themeColors.primary + '14' }]}>
-                <Text style={[styles.countText, { color: themeColors.primary }]}>
+              <View
+                style={[
+                  styles.countBadge,
+                  { backgroundColor: themeColors.primary + '14' },
+                ]}>
+                <Text
+                  style={[styles.countText, { color: themeColors.primary }]}>
                   {observationCount}{' '}
                   {observationCount === 1 ? 'entry' : 'entries'}
                 </Text>

--- a/formulus/src/components/common/FormTypeSelector.tsx
+++ b/formulus/src/components/common/FormTypeSelector.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import Icon from '@react-native-vector-icons/material-design-icons';
 import colors from '../../theme/colors';
+import { useAppTheme } from '../../contexts/AppThemeContext';
 
 interface FormTypeOption {
   id: string;
@@ -28,6 +29,7 @@ const FormTypeSelector: React.FC<FormTypeSelectorProps> = ({
   onSelect,
   placeholder = 'All Forms',
 }) => {
+  const { themeColors } = useAppTheme();
   const [modalVisible, setModalVisible] = useState(false);
 
   const selectedOption = options.find(opt => opt.id === selectedId);
@@ -73,7 +75,7 @@ const FormTypeSelector: React.FC<FormTypeSelectorProps> = ({
                 <TouchableOpacity
                   style={[
                     styles.optionItem,
-                    selectedId === item.id && styles.optionItemSelected,
+                    selectedId === item.id && { backgroundColor: themeColors.primary + '14' },
                   ]}
                   onPress={() => {
                     onSelect(item.id);
@@ -82,7 +84,7 @@ const FormTypeSelector: React.FC<FormTypeSelectorProps> = ({
                   <Text
                     style={[
                       styles.optionText,
-                      selectedId === item.id && styles.optionTextSelected,
+                      selectedId === item.id && { color: themeColors.primary, fontWeight: '600' },
                     ]}>
                     {item.name}
                   </Text>
@@ -90,7 +92,7 @@ const FormTypeSelector: React.FC<FormTypeSelectorProps> = ({
                     <Icon
                       name="check"
                       size={20}
-                      color={colors.brand.primary[500]}
+                      color={themeColors.primary}
                     />
                   )}
                 </TouchableOpacity>
@@ -163,17 +165,12 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: colors.neutral[100],
   },
-  optionItemSelected: {
-    backgroundColor: colors.brand.primary[50],
-  },
+  // optionItemSelected styles are now applied inline via themeColors
   optionText: {
     fontSize: 16,
     color: colors.neutral[900],
   },
-  optionTextSelected: {
-    color: colors.brand.primary[500],
-    fontWeight: '600',
-  },
+  // optionTextSelected styles are now applied inline via themeColors
 });
 
 export default FormTypeSelector;

--- a/formulus/src/components/common/FormTypeSelector.tsx
+++ b/formulus/src/components/common/FormTypeSelector.tsx
@@ -75,7 +75,9 @@ const FormTypeSelector: React.FC<FormTypeSelectorProps> = ({
                 <TouchableOpacity
                   style={[
                     styles.optionItem,
-                    selectedId === item.id && { backgroundColor: themeColors.primary + '14' },
+                    selectedId === item.id && {
+                      backgroundColor: themeColors.primary + '14',
+                    },
                   ]}
                   onPress={() => {
                     onSelect(item.id);
@@ -84,16 +86,15 @@ const FormTypeSelector: React.FC<FormTypeSelectorProps> = ({
                   <Text
                     style={[
                       styles.optionText,
-                      selectedId === item.id && { color: themeColors.primary, fontWeight: '600' },
+                      selectedId === item.id && {
+                        color: themeColors.primary,
+                        fontWeight: '600',
+                      },
                     ]}>
                     {item.name}
                   </Text>
                   {selectedId === item.id && (
-                    <Icon
-                      name="check"
-                      size={20}
-                      color={themeColors.primary}
-                    />
+                    <Icon name="check" size={20} color={themeColors.primary} />
                   )}
                 </TouchableOpacity>
               )}

--- a/formulus/src/components/common/Input.tsx
+++ b/formulus/src/components/common/Input.tsx
@@ -1,4 +1,124 @@
 /**
- * Re-export ODE Input from @ode/components for token-driven styling.
+ * Formulus Input
+ *
+ * Wraps a standard TextInput with styling that respects the custom app's
+ * theme via AppThemeContext.  The focus border uses the app's primary color
+ * instead of the hardcoded ODE green from @ode/tokens.
  */
-export { Input as default } from '@ode/components/react-native';
+
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  ViewStyle,
+} from 'react-native';
+import { useAppTheme } from '../../contexts/AppThemeContext';
+import { colors } from '../../theme/colors';
+
+export interface InputProps {
+  label?: string;
+  placeholder?: string;
+  value?: string;
+  onChangeText?: (text: string) => void;
+  error?: string;
+  disabled?: boolean;
+  required?: boolean;
+  secureTextEntry?: boolean;
+  style?: ViewStyle;
+  testID?: string;
+}
+
+const Input: React.FC<InputProps> = ({
+  label,
+  placeholder,
+  value,
+  onChangeText,
+  error,
+  disabled = false,
+  required = false,
+  secureTextEntry = false,
+  style,
+  testID,
+}) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const { themeColors } = useAppTheme();
+
+  const borderColor = error
+    ? colors.semantic?.error?.[500] ?? '#F44336'
+    : isFocused
+      ? themeColors.primary
+      : colors.neutral[400];
+
+  const borderWidth = isFocused ? 2 : 1;
+
+  return (
+    <View style={[styles.container, style]} testID={testID}>
+      {label && (
+        <Text style={styles.label}>
+          {label}
+          {required && <Text style={styles.required}> *</Text>}
+        </Text>
+      )}
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        placeholder={placeholder}
+        placeholderTextColor={colors.neutral[400]}
+        editable={!disabled}
+        secureTextEntry={secureTextEntry}
+        style={[
+          styles.input,
+          {
+            borderColor,
+            borderWidth,
+            backgroundColor: disabled ? colors.neutral[100] : colors.neutral.white,
+          },
+        ]}
+        testID={testID ? `${testID}-input` : undefined}
+        accessibilityLabel={label || placeholder}
+        accessibilityState={{ disabled, invalid: !!error } as any}
+      />
+      {error && (
+        <Text style={styles.error} role="alert">
+          {error}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+    width: '100%',
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: colors.neutral[900],
+    marginBottom: 8,
+  },
+  required: {
+    color: colors.semantic?.error?.[500] ?? '#F44336',
+  },
+  input: {
+    width: '100%',
+    padding: 16,
+    fontSize: 16,
+    lineHeight: 24,
+    minHeight: 56,
+    borderRadius: 6,
+    color: colors.neutral[900],
+  },
+  error: {
+    marginTop: 4,
+    fontSize: 14,
+    color: colors.semantic?.error?.[500] ?? '#F44336',
+  },
+});
+
+export default Input;

--- a/formulus/src/components/common/Input.tsx
+++ b/formulus/src/components/common/Input.tsx
@@ -7,13 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  TextInput,
-  StyleSheet,
-  ViewStyle,
-} from 'react-native';
+import { View, Text, TextInput, StyleSheet, ViewStyle } from 'react-native';
 import { useAppTheme } from '../../contexts/AppThemeContext';
 import { colors } from '../../theme/colors';
 
@@ -46,7 +40,7 @@ const Input: React.FC<InputProps> = ({
   const { themeColors } = useAppTheme();
 
   const borderColor = error
-    ? colors.semantic?.error?.[500] ?? '#F44336'
+    ? (colors.semantic?.error?.[500] ?? '#F44336')
     : isFocused
       ? themeColors.primary
       : colors.neutral[400];
@@ -75,12 +69,14 @@ const Input: React.FC<InputProps> = ({
           {
             borderColor,
             borderWidth,
-            backgroundColor: disabled ? colors.neutral[100] : colors.neutral.white,
+            backgroundColor: disabled
+              ? colors.neutral[100]
+              : colors.neutral.white,
           },
         ]}
         testID={testID ? `${testID}-input` : undefined}
         accessibilityLabel={label || placeholder}
-        accessibilityState={{ disabled, invalid: !!error } as any}
+        accessibilityState={{ disabled }}
       />
       {error && (
         <Text style={styles.error} role="alert">

--- a/formulus/src/components/common/ObservationCard.tsx
+++ b/formulus/src/components/common/ObservationCard.tsx
@@ -4,6 +4,7 @@ import Icon from '@react-native-vector-icons/material-design-icons';
 import { Observation } from '../../database/models/Observation';
 import colors from '../../theme/colors';
 import Button from './Button';
+import { useAppTheme } from '../../contexts/AppThemeContext';
 
 interface ObservationCardProps {
   observation: Observation;
@@ -20,6 +21,7 @@ const ObservationCard: React.FC<ObservationCardProps> = ({
   onEdit,
   onDelete,
 }) => {
+  const { themeColors } = useAppTheme();
   const isSynced =
     observation.syncedAt &&
     observation.syncedAt.getTime() > new Date('1980-01-01').getTime();
@@ -60,7 +62,11 @@ const ObservationCard: React.FC<ObservationCardProps> = ({
           />
         </View>
         <View style={styles.textContainer}>
-          {formName && <Text style={styles.formName}>{formName}</Text>}
+          {formName && (
+            <Text style={[styles.formName, { color: themeColors.primary }]}>
+              {formName}
+            </Text>
+          )}
           <Text style={styles.id} numberOfLines={1}>
             ID: {observation.observationId.substring(0, 20)}...
           </Text>
@@ -144,7 +150,7 @@ const styles = StyleSheet.create({
   formName: {
     fontSize: 14,
     fontWeight: '600',
-    color: colors.brand.primary[500],
+    // color is applied inline via themeColors.primary
     marginBottom: 4,
   },
   id: {

--- a/formulus/src/components/common/StatusTabs.tsx
+++ b/formulus/src/components/common/StatusTabs.tsx
@@ -32,7 +32,10 @@ const StatusTabs: React.FC<StatusTabsProps> = ({
             key={tab.id}
             style={[
               styles.tab,
-              isActive && { borderBottomWidth: 2, borderBottomColor: themeColors.primary },
+              isActive && {
+                borderBottomWidth: 2,
+                borderBottomColor: themeColors.primary,
+              },
             ]}
             onPress={() => onTabChange(tab.id)}
             activeOpacity={0.7}>

--- a/formulus/src/components/common/StatusTabs.tsx
+++ b/formulus/src/components/common/StatusTabs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import colors from '../../theme/colors';
+import { useAppTheme } from '../../contexts/AppThemeContext';
 
 export interface StatusTab {
   id: string;
@@ -20,6 +21,8 @@ const StatusTabs: React.FC<StatusTabsProps> = ({
   activeTab,
   onTabChange,
 }) => {
+  const { themeColors } = useAppTheme();
+
   return (
     <View style={styles.container}>
       {tabs.map(tab => {
@@ -27,7 +30,10 @@ const StatusTabs: React.FC<StatusTabsProps> = ({
         return (
           <TouchableOpacity
             key={tab.id}
-            style={[styles.tab, isActive && styles.tabActive]}
+            style={[
+              styles.tab,
+              isActive && { borderBottomWidth: 2, borderBottomColor: themeColors.primary },
+            ]}
             onPress={() => onTabChange(tab.id)}
             activeOpacity={0.7}>
             {tab.icon && (
@@ -38,7 +44,11 @@ const StatusTabs: React.FC<StatusTabsProps> = ({
                 ]}
               />
             )}
-            <Text style={[styles.tabLabel, isActive && styles.tabLabelActive]}>
+            <Text
+              style={[
+                styles.tabLabel,
+                isActive && { color: themeColors.primary, fontWeight: '600' },
+              ]}>
               {tab.label}
             </Text>
           </TouchableOpacity>
@@ -63,10 +73,7 @@ const styles = StyleSheet.create({
     marginRight: 24,
     paddingVertical: 4,
   },
-  tabActive: {
-    borderBottomWidth: 2,
-    borderBottomColor: colors.brand.primary[500],
-  },
+  // tabActive styles are now applied inline via themeColors.primary
   dot: {
     width: 8,
     height: 8,
@@ -78,10 +85,7 @@ const styles = StyleSheet.create({
     color: colors.neutral[600],
     fontWeight: '500',
   },
-  tabLabelActive: {
-    color: colors.brand.primary[500],
-    fontWeight: '600',
-  },
+  // tabLabelActive styles are now applied inline via themeColors.primary
 });
 
 export default StatusTabs;

--- a/formulus/src/contexts/AppThemeContext.tsx
+++ b/formulus/src/contexts/AppThemeContext.tsx
@@ -1,0 +1,120 @@
+/**
+ * AppThemeContext
+ *
+ * React context that provides the custom app's theme colors to every
+ * component in the tree.  It loads the `app.config.json` from the custom
+ * app bundle at startup and re-loads whenever the bundle is updated.
+ *
+ * Usage:
+ *   // Wrap the app root:
+ *   <AppThemeProvider>
+ *     <NavigationContainer>…</NavigationContainer>
+ *   </AppThemeProvider>
+ *
+ *   // Consume in any component:
+ *   const { themeColors, reloadTheme } = useAppTheme();
+ */
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useColorScheme } from 'react-native';
+import AppConfigService from '../services/AppConfigService';
+import { ThemeColors } from '../types/AppConfig';
+
+// ── Context shape ──────────────────────────────────────────────────────
+
+interface AppThemeContextValue {
+  /** Resolved theme colors for the current color scheme (light / dark). */
+  themeColors: ThemeColors;
+  /** Whether the initial config load has completed. */
+  isReady: boolean;
+  /** Force-reload the config (e.g. after a new app bundle is extracted). */
+  reloadTheme: () => Promise<void>;
+}
+
+const AppThemeContext = createContext<AppThemeContextValue | undefined>(
+  undefined,
+);
+
+// ── Provider ───────────────────────────────────────────────────────────
+
+interface AppThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export const AppThemeProvider: React.FC<AppThemeProviderProps> = ({
+  children,
+}) => {
+  const colorScheme = useColorScheme();
+  const mode = colorScheme === 'dark' ? 'dark' : 'light';
+
+  // A counter that bumps every time the config is (re-)loaded so that
+  // consumers re-derive themeColors even though the object reference
+  // inside AppConfigService changed.
+  const [configVersion, setConfigVersion] = useState(0);
+  const [isReady, setIsReady] = useState(false);
+
+  // Initial config load on mount.
+  useEffect(() => {
+    (async () => {
+      try {
+        await AppConfigService.getInstance().loadConfig();
+      } catch (err) {
+        console.warn('[AppThemeProvider] Initial config load failed:', err);
+      } finally {
+        setConfigVersion(v => v + 1);
+        setIsReady(true);
+      }
+    })();
+  }, []);
+
+  // Called by HomeScreen (or anyone) after a new bundle is extracted.
+  const reloadTheme = useCallback(async () => {
+    try {
+      await AppConfigService.getInstance().loadConfig(/* force */ true);
+    } catch (err) {
+      console.warn('[AppThemeProvider] Config reload failed:', err);
+    }
+    setConfigVersion(v => v + 1);
+  }, []);
+
+  // Re-derive colors whenever the color scheme changes OR the config is
+  // reloaded (configVersion bumps).
+  const themeColors = useMemo(() => {
+    // configVersion is captured so eslint is happy — the actual value is
+    // not used; it just forces recomputation.
+    void configVersion;
+    return AppConfigService.getInstance().getThemeColors(mode);
+  }, [mode, configVersion]);
+
+  const value = useMemo<AppThemeContextValue>(
+    () => ({ themeColors, isReady, reloadTheme }),
+    [themeColors, isReady, reloadTheme],
+  );
+
+  return (
+    <AppThemeContext.Provider value={value}>
+      {children}
+    </AppThemeContext.Provider>
+  );
+};
+
+// ── Hook ───────────────────────────────────────────────────────────────
+
+/**
+ * Access the custom app's resolved theme colors from any component.
+ * Must be used inside an `<AppThemeProvider>`.
+ */
+export function useAppTheme(): AppThemeContextValue {
+  const ctx = useContext(AppThemeContext);
+  if (!ctx) {
+    throw new Error('useAppTheme must be used within an <AppThemeProvider>');
+  }
+  return ctx;
+}

--- a/formulus/src/navigation/MainAppNavigator.tsx
+++ b/formulus/src/navigation/MainAppNavigator.tsx
@@ -6,12 +6,16 @@ import WelcomeScreen from '../screens/WelcomeScreen';
 import ObservationDetailScreen from '../screens/ObservationDetailScreen';
 import { MainAppStackParamList } from '../types/NavigationTypes';
 import { serverConfigService } from '../services/ServerConfigService';
-import { colors } from '../theme/colors';
+import { useAppTheme } from '../contexts/AppThemeContext';
 
 const Stack = createStackNavigator<MainAppStackParamList>();
 
 const MainAppNavigator: React.FC = () => {
   const [isConfigured, setIsConfigured] = useState<boolean | null>(null);
+
+  // Theme colors come from AppThemeContext — they update automatically
+  // when the custom app's config is loaded or the color scheme changes.
+  const { themeColors } = useAppTheme();
 
   useEffect(() => {
     const checkConfiguration = async () => {
@@ -38,9 +42,9 @@ const MainAppNavigator: React.FC = () => {
   return (
     <Stack.Navigator
       screenOptions={{
-        headerStyle: { backgroundColor: colors.neutral.white },
-        headerTintColor: colors.neutral.black,
-        headerTitleStyle: { color: colors.neutral.black },
+        headerStyle: { backgroundColor: themeColors.surface },
+        headerTintColor: themeColors.onBackground,
+        headerTitleStyle: { color: themeColors.onBackground },
       }}
       initialRouteName={isConfigured ? 'MainApp' : 'Welcome'}>
       <Stack.Screen

--- a/formulus/src/navigation/MainTabNavigator.tsx
+++ b/formulus/src/navigation/MainTabNavigator.tsx
@@ -12,6 +12,7 @@ import HelpScreen from '../screens/HelpScreen';
 import MoreScreen from '../screens/MoreScreen';
 import { colors } from '../theme/colors';
 import { MainTabParamList } from '../types/NavigationTypes';
+import { useAppTheme } from '../contexts/AppThemeContext';
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
 
@@ -45,16 +46,20 @@ const MainTabNavigator: React.FC = () => {
   const baseTabBarHeight = 60;
   const tabBarHeight = baseTabBarHeight + insets.bottom;
 
+  // Theme colors come from AppThemeContext — they update automatically
+  // when the custom app's config is loaded or the color scheme changes.
+  const { themeColors } = useAppTheme();
+
   return (
     <Tab.Navigator
       screenOptions={{
         headerShown: false,
-        tabBarActiveTintColor: colors.brand.primary[500],
+        tabBarActiveTintColor: themeColors.primary,
         tabBarInactiveTintColor: colors.neutral[500],
         tabBarStyle: {
-          backgroundColor: colors.neutral.white,
+          backgroundColor: themeColors.surface,
           borderTopWidth: 1,
-          borderTopColor: colors.ui.gray.light,
+          borderTopColor: themeColors.divider,
           paddingBottom: Math.max(insets.bottom, 4),
           paddingTop: 4,
           height: tabBarHeight,

--- a/formulus/src/screens/AboutScreen.tsx
+++ b/formulus/src/screens/AboutScreen.tsx
@@ -68,7 +68,11 @@ const AboutScreen: React.FC = () => {
             hear your feedback and welcome contributions.
           </Text>
           <Text
-            style={[styles.cardText, styles.link, { color: themeColors.primary }]}
+            style={[
+              styles.cardText,
+              styles.link,
+              { color: themeColors.primary },
+            ]}
             onPress={() =>
               Linking.openURL('https://forum.opendataensemble.org')
             }

--- a/formulus/src/screens/AboutScreen.tsx
+++ b/formulus/src/screens/AboutScreen.tsx
@@ -10,9 +10,11 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import colors from '../theme/colors';
 import { appVersionService } from '../services/AppVersionService';
+import { useAppTheme } from '../contexts/AppThemeContext';
 import logo from '../../assets/images/logo.png';
 
 const AboutScreen: React.FC = () => {
+  const { themeColors } = useAppTheme();
   const [version, setVersion] = useState<string>('');
 
   useEffect(() => {
@@ -66,7 +68,7 @@ const AboutScreen: React.FC = () => {
             hear your feedback and welcome contributions.
           </Text>
           <Text
-            style={[styles.cardText, styles.link]}
+            style={[styles.cardText, styles.link, { color: themeColors.primary }]}
             onPress={() =>
               Linking.openURL('https://forum.opendataensemble.org')
             }
@@ -150,7 +152,7 @@ const styles = StyleSheet.create({
     lineHeight: 20,
   },
   link: {
-    color: colors.brand.primary[500],
+    // color is applied inline via themeColors.primary
     marginTop: 12,
     fontWeight: '600',
   },

--- a/formulus/src/screens/FormsScreen.tsx
+++ b/formulus/src/screens/FormsScreen.tsx
@@ -15,8 +15,10 @@ import { openFormplayerFromNative } from '../webview/FormulusMessageHandlers';
 import { useFocusEffect } from '@react-navigation/native';
 import colors from '../theme/colors';
 import { FormSpec } from '../services';
+import { useAppTheme } from '../contexts/AppThemeContext';
 
 const FormsScreen: React.FC = () => {
+  const { themeColors } = useAppTheme();
   const { forms, loading, error, refresh, getObservationCount } = useForms();
   const [refreshing, setRefreshing] = useState<boolean>(false);
 
@@ -65,7 +67,7 @@ const FormsScreen: React.FC = () => {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={colors.brand.primary[500]} />
+          <ActivityIndicator size="large" color={themeColors.primary} />
           <Text style={styles.loadingText}>Loading forms...</Text>
         </View>
       </SafeAreaView>

--- a/formulus/src/screens/HelpScreen.tsx
+++ b/formulus/src/screens/HelpScreen.tsx
@@ -20,7 +20,11 @@ const HelpScreen: React.FC = () => {
             We would love to hear your feedback and welcome contributions.
           </Text>
           <Text
-            style={[styles.cardText, styles.link, { color: themeColors.primary }]}
+            style={[
+              styles.cardText,
+              styles.link,
+              { color: themeColors.primary },
+            ]}
             onPress={() =>
               Linking.openURL('https://forum.opendataensemble.org')
             }

--- a/formulus/src/screens/HelpScreen.tsx
+++ b/formulus/src/screens/HelpScreen.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { View, Text, StyleSheet, ScrollView, Linking } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import colors from '../theme/colors';
+import { useAppTheme } from '../contexts/AppThemeContext';
 
 const HelpScreen: React.FC = () => {
+  const { themeColors } = useAppTheme();
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.header}>
@@ -18,7 +20,7 @@ const HelpScreen: React.FC = () => {
             We would love to hear your feedback and welcome contributions.
           </Text>
           <Text
-            style={[styles.cardText, styles.link]}
+            style={[styles.cardText, styles.link, { color: themeColors.primary }]}
             onPress={() =>
               Linking.openURL('https://forum.opendataensemble.org')
             }
@@ -103,7 +105,7 @@ const styles = StyleSheet.create({
     lineHeight: 20,
   },
   link: {
-    color: colors.brand.primary[500],
+    // color is applied inline via themeColors.primary
     marginTop: 12,
     fontWeight: '600',
   },

--- a/formulus/src/screens/HomeScreen.tsx
+++ b/formulus/src/screens/HomeScreen.tsx
@@ -14,6 +14,7 @@ import CustomAppWebView, {
 } from '../components/CustomAppWebView';
 import { colors } from '../theme/colors';
 import { appEvents, Listener } from '../webview/FormulusMessageHandlers';
+import { useAppTheme } from '../contexts/AppThemeContext';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const HomeScreen = ({ navigation }: { navigation: any }) => {
@@ -21,6 +22,7 @@ const HomeScreen = ({ navigation }: { navigation: any }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [webViewKey, setWebViewKey] = useState(0);
   const customAppRef = useRef<CustomAppWebViewHandle>(null);
+  const { reloadTheme } = useAppTheme();
 
   useFocusEffect(
     React.useCallback(() => {
@@ -72,6 +74,11 @@ const HomeScreen = ({ navigation }: { navigation: any }) => {
         console.log('[HomeScreen] Using placeholder URI:', placeholderUri);
         setLocalUri(placeholderUri);
       } else {
+        // (Re-)load the custom app's config so that all native UI elements
+        // (tab bar, headers, modals) update to match the app's branding.
+        // This triggers a context update → re-render across all consumers.
+        await reloadTheme();
+
         const customAppUri = `file://${filePath}`;
         console.log('[HomeScreen] Using custom app URI:', customAppUri);
         setLocalUri(customAppUri);

--- a/formulus/src/screens/ObservationDetailScreen.tsx
+++ b/formulus/src/screens/ObservationDetailScreen.tsx
@@ -16,6 +16,7 @@ import { openFormplayerFromNative } from '../webview/FormulusMessageHandlers';
 import { useNavigation } from '@react-navigation/native';
 import colors from '../theme/colors';
 import { Button } from '../components/common';
+import { useAppTheme } from '../contexts/AppThemeContext';
 
 interface ObservationDetailScreenProps {
   route: {
@@ -30,6 +31,7 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
 }) => {
   const { observationId } = route.params;
   const navigation = useNavigation();
+  const { themeColors } = useAppTheme();
   const [observation, setObservation] = useState<Observation | null>(null);
   const [formName, setFormName] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
@@ -129,12 +131,14 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
   };
 
   const renderDataField = (key: string, value: unknown, level: number = 0) => {
+    const fieldKeyStyle = [styles.fieldKey, { color: themeColors.primary }];
+
     if (value === null || value === undefined) {
       return (
         <View
           key={key}
           style={[styles.fieldContainer, { paddingLeft: level * 16 }]}>
-          <Text style={styles.fieldKey}>{key}:</Text>
+          <Text style={fieldKeyStyle}>{key}:</Text>
           <Text style={styles.fieldValue}>null</Text>
         </View>
       );
@@ -145,7 +149,7 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
         <View
           key={key}
           style={[styles.fieldContainer, { paddingLeft: level * 16 }]}>
-          <Text style={styles.fieldKey}>{key}:</Text>
+          <Text style={fieldKeyStyle}>{key}:</Text>
           {Object.entries(value).map(([k, v]) =>
             renderDataField(k, v, level + 1),
           )}
@@ -158,7 +162,7 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
         <View
           key={key}
           style={[styles.fieldContainer, { paddingLeft: level * 16 }]}>
-          <Text style={styles.fieldKey}>{key}:</Text>
+          <Text style={fieldKeyStyle}>{key}:</Text>
           {value.map((item, index) => (
             <View key={index} style={styles.arrayItem}>
               {typeof item === 'object' && item !== null
@@ -176,7 +180,7 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
       <View
         key={key}
         style={[styles.fieldContainer, { paddingLeft: level * 16 }]}>
-        <Text style={styles.fieldKey}>{key}:</Text>
+        <Text style={fieldKeyStyle}>{key}:</Text>
         <Text style={styles.fieldValue}>{String(value)}</Text>
       </View>
     );
@@ -186,7 +190,7 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={colors.brand.primary[500]} />
+          <ActivityIndicator size="large" color={themeColors.primary} />
           <Text style={styles.loadingText}>Loading observation...</Text>
         </View>
       </SafeAreaView>
@@ -217,7 +221,7 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
         <TouchableOpacity
           onPress={() => navigation.goBack()}
           style={styles.backButton}>
-          <Icon name="arrow-left" size={24} color={colors.brand.primary[500]} />
+          <Icon name="arrow-left" size={24} color={themeColors.primary} />
         </TouchableOpacity>
         <Text style={styles.headerTitle}>Observation Details</Text>
         <View style={styles.headerActions}>
@@ -451,7 +455,7 @@ const styles = StyleSheet.create({
   fieldKey: {
     fontSize: 14,
     fontWeight: '600',
-    color: colors.brand.primary[500],
+    // color is applied inline via themeColors.primary
     marginBottom: 4,
   },
   fieldValue: {

--- a/formulus/src/screens/ObservationsScreen.tsx
+++ b/formulus/src/screens/ObservationsScreen.tsx
@@ -9,7 +9,7 @@ import {
   Alert,
   TouchableOpacity,
 } from 'react-native';
-import { Input as ODEInput } from '@ode/components/react-native';
+import { Input as ODEInput } from '../components/common';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Icon from '@react-native-vector-icons/material-design-icons';
 import { useObservations } from '../hooks/useObservations';
@@ -27,6 +27,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { MainAppStackParamList } from '../types/NavigationTypes';
 import { Observation } from '../database/models/Observation';
 import colors from '../theme/colors';
+import { useAppTheme } from '../contexts/AppThemeContext';
 
 type ObservationsScreenNavigationProp = StackNavigationProp<
   MainAppStackParamList,
@@ -34,6 +35,7 @@ type ObservationsScreenNavigationProp = StackNavigationProp<
 >;
 
 const ObservationsScreen: React.FC = () => {
+  const { themeColors } = useAppTheme();
   const navigation = useNavigation<ObservationsScreenNavigationProp>();
   const observationsHook = useObservations();
   const {
@@ -172,7 +174,7 @@ const ObservationsScreen: React.FC = () => {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={colors.brand.primary[500]} />
+          <ActivityIndicator size="large" color={themeColors.primary} />
           <Text style={styles.loadingText}>Loading observations...</Text>
         </View>
       </SafeAreaView>
@@ -211,7 +213,7 @@ const ObservationsScreen: React.FC = () => {
           <Icon
             name={showSearch ? 'close' : 'magnify'}
             size={24}
-            color={colors.brand.primary[500]}
+            color={themeColors.primary}
           />
         </TouchableOpacity>
       </View>

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -10,7 +10,7 @@ import {
   Alert,
   AlertButton,
 } from 'react-native';
-import { Input as ODEInput } from '@ode/components/react-native';
+import { Input as ODEInput } from '../components/common';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
@@ -25,6 +25,7 @@ import { MainTabParamList } from '../types/NavigationTypes';
 import { colors } from '../theme/colors';
 import Icon from '@react-native-vector-icons/material-design-icons';
 import { ToastService } from '../services/ToastService';
+import { useAppTheme } from '../contexts/AppThemeContext';
 import { serverSwitchService } from '../services/ServerSwitchService';
 import { syncService } from '../services/SyncService';
 import { Button } from '../components/common';
@@ -37,6 +38,7 @@ type SettingsScreenNavigationProp = BottomTabNavigationProp<
 
 const SettingsScreen = () => {
   const navigation = useNavigation<SettingsScreenNavigationProp>();
+  const { themeColors } = useAppTheme();
   const [serverUrl, setServerUrl] = useState('');
   const [initialServerUrl, setInitialServerUrl] = useState('');
   const [username, setUsername] = useState('');
@@ -310,14 +312,14 @@ const SettingsScreen = () => {
 
   if (isLoading) {
     return (
-      <View style={[styles.container, styles.centered]}>
-        <ActivityIndicator size="large" color={colors.brand.primary[500]} />
+      <View style={[styles.container, { backgroundColor: themeColors.primary }, styles.centered]}>
+        <ActivityIndicator size="large" color={themeColors.onPrimary} />
       </View>
     );
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={['top']}>
+    <SafeAreaView style={[styles.container, { backgroundColor: themeColors.primary }]} edges={['top']}>
       <View style={styles.header}>
         <View style={styles.logoContainer}>
           <Image source={Logo} style={styles.logo} resizeMode="contain" />
@@ -350,7 +352,7 @@ const SettingsScreen = () => {
               <Icon
                 name="qrcode-scan"
                 size={24}
-                color={colors.brand.primary[500]}
+                color={themeColors.primary}
               />
             </TouchableOpacity>
           </View>
@@ -392,7 +394,7 @@ const SettingsScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.brand.primary[500],
+    // backgroundColor is applied inline via themeColors.primary
   },
   centered: {
     justifyContent: 'center',
@@ -421,7 +423,7 @@ const styles = StyleSheet.create({
   },
   version: {
     fontSize: 12,
-    color: colors.brand.primary[200],
+    color: 'rgba(255, 255, 255, 0.7)',
     marginTop: 4,
   },
   card: {

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -312,14 +312,21 @@ const SettingsScreen = () => {
 
   if (isLoading) {
     return (
-      <View style={[styles.container, { backgroundColor: themeColors.primary }, styles.centered]}>
+      <View
+        style={[
+          styles.container,
+          { backgroundColor: themeColors.primary },
+          styles.centered,
+        ]}>
         <ActivityIndicator size="large" color={themeColors.onPrimary} />
       </View>
     );
   }
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: themeColors.primary }]} edges={['top']}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: themeColors.primary }]}
+      edges={['top']}>
       <View style={styles.header}>
         <View style={styles.logoContainer}>
           <Image source={Logo} style={styles.logo} resizeMode="contain" />
@@ -349,11 +356,7 @@ const SettingsScreen = () => {
               style={styles.qrButton}
               onPress={() => setShowQRScanner(true)}
               accessibilityLabel="Scan QR code">
-              <Icon
-                name="qrcode-scan"
-                size={24}
-                color={themeColors.primary}
-              />
+              <Icon name="qrcode-scan" size={24} color={themeColors.primary} />
             </TouchableOpacity>
           </View>
         </View>

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -364,8 +364,10 @@ const SyncScreen = () => {
             style={[
               styles.statusCard,
               !syncState.isActive &&
-                (pendingObservations > 0 || pendingUploads.count > 0) &&
-                { borderWidth: 2, borderColor: themeColors.primaryLight },
+                (pendingObservations > 0 || pendingUploads.count > 0) && {
+                  borderWidth: 2,
+                  borderColor: themeColors.primaryLight,
+                },
             ]}
             onPress={() => {
               if (
@@ -492,12 +494,26 @@ const SyncScreen = () => {
         </View>
 
         {syncState.isActive && syncState.progress && (
-          <View style={[styles.progressCard, { backgroundColor: themeColors.primary + '14', borderLeftColor: themeColors.primary }]}>
+          <View
+            style={[
+              styles.progressCard,
+              {
+                backgroundColor: themeColors.primary + '14',
+                borderLeftColor: themeColors.primary,
+              },
+            ]}>
             <View style={styles.progressHeader}>
               <Icon name="sync" size={20} color={themeColors.primary} />
-              <Text style={[styles.progressTitle, { color: themeColors.primary }]}>{getProgressTitle()}</Text>
+              <Text
+                style={[styles.progressTitle, { color: themeColors.primary }]}>
+                {getProgressTitle()}
+              </Text>
             </View>
-            <View style={[styles.progressBar, { backgroundColor: themeColors.primary + '33' }]}>
+            <View
+              style={[
+                styles.progressBar,
+                { backgroundColor: themeColors.primary + '33' },
+              ]}>
               <Animated.View
                 style={[
                   styles.progressFill,
@@ -568,16 +584,9 @@ const SyncScreen = () => {
             onPress={handleCustomAppUpdate}
             disabled={syncState.isActive || (!updateAvailable && !isAdmin)}>
             {isUpdateButtonActive ? (
-              <ActivityIndicator
-                size="small"
-                color={themeColors.primary}
-              />
+              <ActivityIndicator size="small" color={themeColors.primary} />
             ) : (
-              <Icon
-                name="download"
-                size={20}
-                color={themeColors.primary}
-              />
+              <Icon name="download" size={20} color={themeColors.primary} />
             )}
             <Text style={[styles.actionButtonText, styles.secondaryButtonText]}>
               {isUpdateButtonActive ? 'Updating...' : 'Update App Bundle'}

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -21,10 +21,12 @@ import { databaseService } from '../database/DatabaseService';
 import { getUserInfo } from '../api/synkronus/Auth';
 import colors from '../theme/colors';
 import { Button } from '../components/common';
+import { useAppTheme } from '../contexts/AppThemeContext';
 
 type ActiveOperation = 'sync' | 'update' | 'sync_then_update' | null;
 
 const SyncScreen = () => {
+  const { themeColors } = useAppTheme();
   const syncContextValue = useSyncContext();
   const {
     syncState,
@@ -259,7 +261,7 @@ const SyncScreen = () => {
 
   const status = getStatusText();
   const statusColor = syncState.isActive
-    ? colors.brand.primary[500]
+    ? themeColors.primary
     : syncState.error
       ? colors.semantic.error[500]
       : pendingObservations > 0 || pendingUploads.count > 0
@@ -363,7 +365,7 @@ const SyncScreen = () => {
               styles.statusCard,
               !syncState.isActive &&
                 (pendingObservations > 0 || pendingUploads.count > 0) &&
-                styles.statusCardClickable,
+                { borderWidth: 2, borderColor: themeColors.primaryLight },
             ]}
             onPress={() => {
               if (
@@ -490,16 +492,17 @@ const SyncScreen = () => {
         </View>
 
         {syncState.isActive && syncState.progress && (
-          <View style={styles.progressCard}>
+          <View style={[styles.progressCard, { backgroundColor: themeColors.primary + '14', borderLeftColor: themeColors.primary }]}>
             <View style={styles.progressHeader}>
-              <Icon name="sync" size={20} color={colors.brand.primary[500]} />
-              <Text style={styles.progressTitle}>{getProgressTitle()}</Text>
+              <Icon name="sync" size={20} color={themeColors.primary} />
+              <Text style={[styles.progressTitle, { color: themeColors.primary }]}>{getProgressTitle()}</Text>
             </View>
-            <View style={styles.progressBar}>
+            <View style={[styles.progressBar, { backgroundColor: themeColors.primary + '33' }]}>
               <Animated.View
                 style={[
                   styles.progressFill,
                   {
+                    backgroundColor: themeColors.primary,
                     width: animatedProgress.interpolate({
                       inputRange: [0, 100],
                       outputRange: ['0%', '100%'],
@@ -567,13 +570,13 @@ const SyncScreen = () => {
             {isUpdateButtonActive ? (
               <ActivityIndicator
                 size="small"
-                color={colors.brand.primary[500]}
+                color={themeColors.primary}
               />
             ) : (
               <Icon
                 name="download"
                 size={20}
-                color={colors.brand.primary[500]}
+                color={themeColors.primary}
               />
             )}
             <Text style={[styles.actionButtonText, styles.secondaryButtonText]}>
@@ -635,10 +638,7 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     elevation: 3,
   },
-  statusCardClickable: {
-    borderWidth: 2,
-    borderColor: colors.brand.primary[200],
-  },
+  // statusCardClickable styles are now applied inline via themeColors
   statusCardHeader: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -756,12 +756,11 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   progressCard: {
-    backgroundColor: colors.brand.primary[50],
+    // bg and border colors are overridden inline via themeColors
     borderRadius: 12,
     padding: 16,
     marginBottom: 16,
     borderLeftWidth: 4,
-    borderLeftColor: colors.brand.primary[500],
   },
   progressHeader: {
     flexDirection: 'row',
@@ -772,18 +771,18 @@ const styles = StyleSheet.create({
   progressTitle: {
     fontSize: 16,
     fontWeight: '600',
-    color: colors.brand.primary[500],
+    // color is applied inline via themeColors.primary
   },
   progressBar: {
     height: 8,
-    backgroundColor: colors.brand.primary[200],
+    // backgroundColor is applied inline via themeColors
     borderRadius: 4,
     marginBottom: 8,
     overflow: 'hidden',
   },
   progressFill: {
     height: '100%',
-    backgroundColor: colors.brand.primary[500],
+    // backgroundColor is applied inline via themeColors.primary
     borderRadius: 4,
   },
   progressText: {

--- a/formulus/src/services/AppConfigService.ts
+++ b/formulus/src/services/AppConfigService.ts
@@ -1,0 +1,153 @@
+/**
+ * AppConfigService
+ *
+ * Singleton service that reads, parses, and caches the custom app's
+ * `app.config.json` file. Other native components (tab bar, headers,
+ * FormplayerModal) use this service to retrieve the custom app's theme
+ * colors so that the entire UI matches the brand.
+ *
+ * Usage:
+ *   const service = AppConfigService.getInstance();
+ *   await service.loadConfig();            // call once at startup
+ *   const colors = service.getThemeColors('light');
+ */
+
+import RNFS from 'react-native-fs';
+import { AppConfig, ThemeColors } from '../types/AppConfig';
+import { colors as odeColors } from '../theme/colors';
+
+/** Path where the custom app bundle is extracted on the device. */
+const APP_CONFIG_PATH = `${RNFS.DocumentDirectoryPath}/app/app.config.json`;
+
+/**
+ * Build a fallback ThemeColors object from the ODE design tokens.
+ * Used when no custom app config is available so that the app still
+ * looks correct with the default ODE branding.
+ */
+function getOdeFallbackColors(mode: 'light' | 'dark'): ThemeColors {
+  const isDark = mode === 'dark';
+  return {
+    primary: odeColors.brand.primary[500],
+    primaryLight: odeColors.brand.primary[400],
+    primaryDark: odeColors.brand.primary[600],
+    onPrimary: odeColors.neutral.white,
+
+    secondary: odeColors.brand.secondary[500],
+    secondaryLight: odeColors.brand.secondary[400],
+    secondaryDark: odeColors.brand.secondary[600],
+    onSecondary: odeColors.neutral.white,
+
+    background: isDark ? odeColors.neutral[900] : odeColors.neutral[50],
+    surface: isDark ? odeColors.neutral[800] : odeColors.neutral.white,
+    onBackground: isDark ? odeColors.neutral.white : odeColors.neutral[900],
+    onSurface: isDark ? odeColors.neutral[300] : odeColors.neutral[600],
+
+    error: odeColors.semantic.error[500],
+    errorLight: odeColors.semantic.error[50],
+    errorDark: odeColors.semantic.error[600],
+    onError: odeColors.neutral.white,
+
+    warning: odeColors.semantic.warning[500],
+    success: odeColors.semantic.success[500],
+    info: odeColors.semantic.info[500],
+
+    divider: isDark ? odeColors.neutral[700] : odeColors.neutral[200],
+  };
+}
+
+class AppConfigService {
+  private static instance: AppConfigService;
+  private config: AppConfig | null = null;
+  private loaded = false;
+
+  private constructor() {}
+
+  /** Get the singleton instance. */
+  static getInstance(): AppConfigService {
+    if (!AppConfigService.instance) {
+      AppConfigService.instance = new AppConfigService();
+    }
+    return AppConfigService.instance;
+  }
+
+  /**
+   * Load and parse app.config.json from the custom app bundle.
+   * Safe to call multiple times — subsequent calls are no-ops unless
+   * `force` is true.
+   */
+  async loadConfig(force = false): Promise<void> {
+    if (this.loaded && !force) {
+      return;
+    }
+
+    try {
+      const exists = await RNFS.exists(APP_CONFIG_PATH);
+      if (!exists) {
+        console.log(
+          '[AppConfigService] No app.config.json found — using ODE defaults.',
+        );
+        this.config = null;
+        this.loaded = true;
+        return;
+      }
+
+      const raw = await RNFS.readFile(APP_CONFIG_PATH, 'utf8');
+      const parsed: AppConfig = JSON.parse(raw);
+
+      // Basic validation
+      if (!parsed.theme?.light || !parsed.theme?.dark) {
+        console.warn(
+          '[AppConfigService] app.config.json is missing theme.light or theme.dark — ignoring.',
+        );
+        this.config = null;
+      } else {
+        this.config = parsed;
+        console.log(
+          `[AppConfigService] Loaded config for "${parsed.name}" v${parsed.version}`,
+        );
+      }
+    } catch (err) {
+      console.warn('[AppConfigService] Failed to load app.config.json:', err);
+      this.config = null;
+    }
+
+    this.loaded = true;
+  }
+
+  /** Whether a custom app config has been successfully loaded. */
+  hasConfig(): boolean {
+    return this.config !== null;
+  }
+
+  /** Get the raw AppConfig (or null if none loaded). */
+  getConfig(): AppConfig | null {
+    return this.config;
+  }
+
+  /** Get the custom app name, or "Formulus" as the default. */
+  getAppName(): string {
+    return this.config?.name ?? 'Formulus';
+  }
+
+  /**
+   * Get the theme colors for the requested mode.
+   * Returns the custom app colors if available, otherwise ODE defaults.
+   */
+  getThemeColors(mode: 'light' | 'dark'): ThemeColors {
+    if (this.config) {
+      return this.config.theme[mode];
+    }
+    return getOdeFallbackColors(mode);
+  }
+
+  /**
+   * Reset internal state (useful for testing or when a new app bundle is
+   * downloaded and extracted).
+   */
+  reset(): void {
+    this.config = null;
+    this.loaded = false;
+  }
+}
+
+export default AppConfigService;

--- a/formulus/src/types/AppConfig.ts
+++ b/formulus/src/types/AppConfig.ts
@@ -1,0 +1,87 @@
+/**
+ * AppConfig Types
+ *
+ * Defines the shape of app.config.json — the configuration file that each
+ * custom app ships to declare its brand identity (colors, name, version, etc.).
+ *
+ * Formulus reads this file at startup and uses it to tint native UI elements
+ * (tab bar, headers, modals) and to forward theme colors to the Formplayer
+ * WebView so that forms match the custom app's look and feel.
+ */
+
+/**
+ * Color tokens for a single mode (light or dark).
+ *
+ * These follow Material Design 3 color roles so that any component can pick
+ * the right semantic color without knowing the actual hex value.
+ */
+export interface ThemeColors {
+  /** Brand primary color */
+  primary: string;
+  /** Lighter variant of primary */
+  primaryLight: string;
+  /** Darker variant of primary */
+  primaryDark: string;
+  /** Text/icon color that sits on top of primary surfaces */
+  onPrimary: string;
+
+  /** Brand secondary color */
+  secondary: string;
+  /** Lighter variant of secondary */
+  secondaryLight: string;
+  /** Darker variant of secondary */
+  secondaryDark: string;
+  /** Text/icon color that sits on top of secondary surfaces */
+  onSecondary: string;
+
+  /** Main background color */
+  background: string;
+  /** Elevated surface color (cards, sheets) */
+  surface: string;
+  /** Text/icon color on background */
+  onBackground: string;
+  /** Text/icon color on surface */
+  onSurface: string;
+
+  /** Error color */
+  error: string;
+  /** Lighter variant of error */
+  errorLight: string;
+  /** Darker variant of error */
+  errorDark: string;
+  /** Text/icon color on error surfaces */
+  onError: string;
+
+  /** Warning color */
+  warning: string;
+  /** Success color */
+  success: string;
+  /** Info color */
+  info: string;
+
+  /** Divider / border color */
+  divider: string;
+}
+
+/**
+ * Theme block inside app.config.json.
+ * Contains separate palettes for light and dark mode.
+ */
+export interface AppTheme {
+  light: ThemeColors;
+  dark: ThemeColors;
+}
+
+/**
+ * Root shape of app.config.json.
+ */
+export interface AppConfig {
+  /** Optional JSON-schema reference (for editor auto-complete) */
+  $schema?: string;
+  /** Human-readable app name (e.g. "Ento", "AnthroCollect") */
+  name: string;
+  /** Semantic version of the custom app */
+  version: string;
+  /** Theme definition with light and dark palettes */
+  theme: AppTheme;
+}

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -992,11 +992,11 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
           );
         }
 
-        return {
-          username: credentials.username,
-          displayName: credentials.username,
+          return {
+            username: credentials.username,
+            displayName: credentials.username,
           role,
-        };
+          };
       } catch (error) {
         console.error(
           'FormulusMessageHandlers: Failed to get current user:',

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -992,11 +992,11 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
           );
         }
 
-          return {
-            username: credentials.username,
-            displayName: credentials.username,
+        return {
+          username: credentials.username,
+          displayName: credentials.username,
           role,
-          };
+        };
       } catch (error) {
         console.error(
           'FormulusMessageHandlers: Failed to get current user:',

--- a/formulus/tsconfig.json
+++ b/formulus/tsconfig.json
@@ -13,6 +13,7 @@
     "**/ios/**",
     "**/node_modules/**",
     "**/__tests__/**",
+    "**/dist/**",
     "**/babel.config.js",
     "**/metro.config.js",
     "**/jest.config.js",


### PR DESCRIPTION
# Description

## Summary

This PR makes the **custom application the brand owner**. When a custom app (e.g. Ento, AnthroCollect) is loaded into Formulus, every native screen, navigation bar, button, input, and the Formplayer form renderer all adopt the custom app's color palette — instead of showing the default ODE green.

If no custom app is installed, Formulus falls back to its default ODE design tokens, so nothing breaks.

Closes #293 

---

## Problem

Previously, Formulus hardcoded `colors.brand.primary[500]` (ODE green) throughout:

- Bottom tab bar active tint
- Stack navigator headers
- All `Button` components (via `@ode/components` which reads `@ode/tokens`)
- `Input` focus border
- Activity indicators, progress bars, status badges, links
- The Formplayer WebView MUI theme

This meant every custom app looked "green" regardless of its own brand colors — creating a disjointed user experience.

---

## Solution

### Architecture

```
┌─────────────────────────────────────────────────────┐
│  Custom App Bundle (e.g. Ento)                      │
│  ├── index.html                                     │
│  ├── assets/                                        │
│  └── app.config.json  ◄── NEW: brand palette here   │
└──────────────┬──────────────────────────────────────┘
               │  extracted to device storage
               ▼
┌─────────────────────────────────────────────────────┐
│  Formulus (React Native)                            │
│                                                     │
│  AppConfigService  reads app.config.json            │
│       │                                             │
│       ▼                                             │
│  AppThemeContext  provides themeColors to all        │
│       │          components via useAppTheme()        │
│       │                                             │
│       ├──► NavigationContainer theme                │
│       ├──► MainTabNavigator (tab bar)               │
│       ├──► MainAppNavigator (headers)               │
│       ├──► All screens (indicators, links, badges)  │
│       ├──► Button component (border, fill, text)    │
│       ├──► Input component (focus border)           │
│       └──► FormplayerModal (header, passes colors)  │
│                 │                                   │
│                 ▼                                   │
│  ┌─────────────────────────────────────────────┐    │
│  │  Formplayer (WebView / MUI)                 │    │
│  │  Receives themeColors in FormInitData.params │    │
│  │  Uses them as CustomThemeColors overrides    │    │
│  │  Falls back to @ode/tokens if not provided  │    │
│  └─────────────────────────────────────────────┘    │
└─────────────────────────────────────────────────────┘
```

### The Theme Contract: `app.config.json`

Custom apps ship a single `app.config.json` in their bundle root. It declares the app name, version, and a full light + dark color palette using **Material Design 3 color roles**:

```json
{
  "$schema": "https://ode.dev/schemas/app-config-v1.json",
  "name": "Ento",
  "version": "1.0.0",
  "theme": {
    "light": {
      "primary": "#006874",
      "primaryLight": "#4F9BA3",
      "primaryDark": "#004B52",
      "onPrimary": "#FFFFFF",
      "secondary": "#4A6267",
      "secondaryLight": "#6F8C91",
      "secondaryDark": "#2D4B4F",
      "onSecondary": "#FFFFFF",
      "background": "#FAFDFD",
      "surface": "#FFFFFF",
      "onBackground": "#191C1D",
      "onSurface": "#3F4948",
      "error": "#BA1A1A",
      "errorLight": "#FF5449",
      "errorDark": "#93000A",
      "onError": "#FFFFFF",
      "warning": "#8C5000",
      "success": "#006E26",
      "info": "#006874",
      "divider": "#E0E0E0"
    },
    "dark": { "..." : "..." }
  }
}
```

### Color Roles Reference

| Role | Purpose | Example usage |
|------|---------|---------------|
| `primary` | Brand color — buttons, active tabs, links, progress bars | Tab bar active tint, Button border/fill |
| `primaryLight` | Lighter variant for subtle highlights | Progress bar track, selected item bg |
| `primaryDark` | Darker variant for emphasis | Clickable card borders |
| `onPrimary` | Text/icons sitting on primary-colored surfaces | Button text when filled |
| `secondary` | Supporting brand color | Secondary buttons |
| `onSecondary` | Text/icons on secondary surfaces | Secondary button text when filled |
| `background` | Main screen background | NavigationContainer background |
| `surface` | Elevated surfaces (cards, headers, tab bar) | Tab bar bg, modal header, status bar |
| `onBackground` | Primary text color on background | Header titles, body text |
| `onSurface` | Secondary text color on surfaces | Subtitles, captions |
| `error` / `errorLight` / `errorDark` | Semantic error states | Error badges, danger button borders |
| `onError` | Text on error surfaces | Error badge text |
| `warning` / `success` / `info` | Semantic status colors | Sync status, observation badges |
| `divider` | Borders, separators | Tab bar top border, section dividers |

---

## New Files

| File | Purpose |
|------|---------|
| `formulus/src/types/AppConfig.ts` | TypeScript interfaces: `ThemeColors`, `AppTheme`, `AppConfig` |
| `formulus/src/services/AppConfigService.ts` | Singleton that reads + caches `app.config.json` from the device; falls back to ODE tokens |
| `formulus/src/contexts/AppThemeContext.tsx` | React context + provider + `useAppTheme()` hook that makes `themeColors` available everywhere |

---

## Modified Files

### Formulus Native App

| File | What changed |
|------|-------------|
| `formulus/App.tsx` | Wrapped app with `<AppThemeProvider>`. `NavigationContainer` theme is now derived from `useAppTheme()` instead of hardcoded `LightNavigationTheme`. |
| `formulus/src/navigation/MainTabNavigator.tsx` | `tabBarActiveTintColor`, `backgroundColor`, `borderTopColor` now come from `themeColors`. |
| `formulus/src/navigation/MainAppNavigator.tsx` | Stack header styles (`headerStyle`, `headerTintColor`, `headerTitleStyle`) now come from `themeColors`. |
| `formulus/src/components/FormplayerModal.tsx` | Modal header uses `themeColors`. Passes `themeColors` to Formplayer via `formParams`. |
| `formulus/src/screens/HomeScreen.tsx` | Calls `reloadTheme()` from context after detecting a custom app bundle, ensuring theme propagates. |
| `formulus/src/webview/FormulusMessageHandlers.ts` | Includes `themeColors` in `FormInitData.params` sent to Formplayer. |

### Screens — replaced every `colors.brand.primary[...]` reference

| Screen | What was green → now themed |
|--------|---------------------------|
| `SettingsScreen.tsx` | Container background, QR icon, loading spinner |
| `SyncScreen.tsx` | Active status color, progress card (bg, border, title, bar, fill), sync icon, update button icon/spinner, clickable card border |
| `FormsScreen.tsx` | Loading spinner |
| `ObservationsScreen.tsx` | Loading spinner, search icon |
| `ObservationDetailScreen.tsx` | Loading spinner, back arrow, field key labels |
| `HelpScreen.tsx` | Forum link color |
| `AboutScreen.tsx` | Forum link color |

### Common Components — replaced every `colors.brand.primary[...]` reference

| Component | What was green → now themed |
|-----------|---------------------------|
| `Button.tsx` | **Fully rewritten.** No longer wraps `@ode/components` ODEButton (which hardcodes ODE green from `@ode/tokens`). Now renders its own themed button using `useAppTheme()`. Primary and secondary variants use the custom app's palette; danger stays semantic red; tertiary stays neutral grey. |
| `Input.tsx` | **Fully rewritten.** No longer re-exports `@ode/components` ODEInput. Focus border now uses `themeColors.primary` instead of hardcoded ODE green. |
| `FormCard.tsx` | Icon container bg, icon color, count badge bg, count text color |
| `StatusTabs.tsx` | Active tab underline, active tab label color |
| `ObservationCard.tsx` | Form name label color |
| `FormTypeSelector.tsx` | Selected option bg, selected text color, checkmark icon |
| `EmptyState.tsx` | Action link text color |
| `FilterBar.tsx` | Import changed from `@ode/components` to local themed `Input` |

### Formplayer (WebView)

| File | What changed |
|------|-------------|
| `formulus-formplayer/src/theme/theme.ts` | Added `CustomThemeColors` interface. `getThemeOptions()` now accepts optional `customColors` param. Uses a `c(custom, fallback)` helper so every palette value prefers the custom app's color, falling back to `@ode/tokens`. |
| `formulus-formplayer/src/App.tsx` | Extracts `themeColors` from `params` during form initialization. Passes them to `getThemeOptions()` when creating the MUI theme. |

---

## How It Works — Step by Step

1. **Custom app ships `app.config.json`** in its bundle (alongside `index.html`).
2. **Bundle is downloaded** to the device via Sync and extracted to `DocumentDirectory/app/`.
3. **`HomeScreen` detects the bundle**, calls `reloadTheme()` from `AppThemeContext`.
4. **`AppThemeProvider` loads `app.config.json`** via `AppConfigService`, parses the theme, and stores it in React context.
5. **Every component** that calls `useAppTheme()` re-renders with the new `themeColors`.
6. **When a form is opened**, `FormplayerModal` passes `themeColors` in the `FormInitData.params` to the Formplayer WebView.
7. **Formplayer's `App.tsx`** extracts the colors and feeds them to `getThemeOptions()`, which overrides the MUI theme palette.

---

## Fallback Behavior

| Scenario | What happens |
|----------|-------------|
| No `app.config.json` in bundle | `AppConfigService` returns ODE default colors from `@ode/tokens`. Everything looks like standard ODE green. |
| `app.config.json` exists but `theme.light` or `theme.dark` is missing | Config is ignored, ODE defaults are used. Warning logged. |
| `app.config.json` is malformed JSON | Config is ignored, ODE defaults are used. Warning logged. |
| Formplayer receives no `themeColors` in params | `getThemeOptions()` gets `undefined` for `customColors`, every `c(undefined, fallback)` returns the `@ode/tokens` fallback. |

---

## What Custom App Authors Need To Do

1. **Create `app.config.json`** in the app's `public/` directory (so it's included in the build output).
2. **Define all 22 color roles** for both `light` and `dark` modes.
3. **(Optional)** Update the app's own MUI theme to read from the same `app.config.json` for internal consistency.

That's it. No changes needed in the app's JavaScript, no CSS variables to inject, no build tool changes.

---

## Testing

- [x] Loaded Ento bundle → all Formulus screens show Ento's teal palette
- [x] Loaded AnthroCollect bundle → all Formulus screens show Terra Cotta palette
- [x] No custom app installed → Formulus shows default ODE green
- [x] Bottom tab bar adopts custom app's primary color
- [x] Settings screen header uses custom app's primary color
- [x] All buttons (Sync, Edit, Login, etc.) use custom app's primary color
- [x] Input focus borders use custom app's primary color
- [x] Progress bars, spinners, badges all use custom app's colors
- [x] Formplayer forms render with custom app's palette
- [x] Danger buttons remain semantic red regardless of custom app theme
- [x] Dark mode color scheme is respected
