### PR TITLE
build(android): add x86 and x86_64 to reactNativeArchitectures 

### DIFF
--- a/formulus/android/gradle.properties
+++ b/formulus/android/gradle.properties
@@ -25,7 +25,7 @@ android.useAndroidX=true
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
 # Include armeabi-v7a so the APK runs on both 32-bit and 64-bit ARM devices
-reactNativeArchitectures=armeabi-v7a,arm64-v8a
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in


### PR DESCRIPTION
## build(android): add x86 and x86_64 to reactNativeArchitectures
### Description
Adds x86 and x86_64 to reactNativeArchitectures in formulus/android/gradle.properties. This lets the app use native x86 binaries on Intel/AMD emulators instead of ARM translation, improving startup time and overall performance on the Android emulator.
### Type of Change
[ ] Bug Fix
[ ] New Feature / Enhancement
[ ] Refactor / Code Cleanup
[ ] Documentation Update
[x] Maintenance / Chore
[ ] Other (please specify):
### Component(s) Affected
[x] formulus (React Native mobile app)
[ ] formulus-formplayer (React web app)
[ ] synkronus (Go backend server)
[ ] synkronus-cli (Command-line utility)
[ ] Documentation
[ ] DevOps / CI/CD
[ ] Other: <!-- Please specify -->
Related Issue(s)
Closes/Fixes/Resolves: N/A
### Testing
[ ] Unit tests added/updated
[ ] Integration tests added/updated
[x] Manually tested
[x] Tested on multiple platforms (if applicable)
[ ] Not applicable
### Breaking Changes
[ ] This PR introduces breaking changes
[x] This PR does NOT introduce breaking changes
If breaking changes, please describe migration steps: N/A
### Documentation Updates
[ ] Documentation has been updated
[x] Documentation update is not required
Checklist
[x] Code follows project style guidelines
[x] All existing tests pass
[ ] New tests added for new functionality
[x] PR title follows Conventional Commits format