### PR TITLE
feat: enable dollar-data references in AJV for cross-field validation

### DIFF
--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -777,6 +777,7 @@ function App() {
     const instance = new Ajv({
       allErrors: true,
       strict: false, // Allow custom keywords like x-formulus-validation
+      $data: true,
     });
     addErrors(instance);
     addFormats(instance);


### PR DESCRIPTION
## **Description:**

Adds `$data: true` to the AJV configuration in the formplayer. This enables JSON Schema keywords like `const` and `enum` to reference values from other form fields at validation time.

This allows cross-field validation e.g. ensuring a scanned QR code (`sticker`) in the form, matches an injected value as the form opens and blocks finalization when they don't match.