### PR TITLE
feat: author-configurable form header title and sticky fields

### DIFF
--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -11,7 +11,7 @@ import {
   RankedTester,
 } from '@jsonforms/core';
 import { useSwipeable } from 'react-swipeable';
-import { Snackbar } from '@mui/material';
+import { Snackbar, Box, Typography } from '@mui/material';
 import { Button } from '@ode/components/react-web';
 import { tokens } from '../theme/tokens-adapter';
 import { useFormContext } from '../App';
@@ -402,20 +402,83 @@ const SwipeLayoutRenderer = ({
     setSnackbarMessage('');
   }, [pendingNavigation, prevVisiblePage, performNavigation]);
 
+  // ----- Header options (author-configurable) -----
+
+  const uiOptions = (uischema as any)?.options || {};
+  const headerTitle: string | undefined =
+    uiOptions.headerTitle || (schema as any)?.title || undefined;
+  const headerFields: string[] = (uiOptions.headerFields || []).slice(0, 2);
+
   // ----- Render -----
 
   return (
     <FormLayout
       header={
-        <FormProgressBar
-          currentPage={visiblePosition}
-          totalScreens={totalVisibleScreens}
-          data={data}
-          schema={schema}
-          uischema={uischema}
-          mode="screens"
-          isOnFinalizePage={isOnFinalizePage}
-        />
+        <>
+          {/* Author-configured form title and sticky fields */}
+          {(headerTitle || headerFields.length > 0) && (
+            <Box sx={{ px: 2, pt: 1, pb: headerFields.length > 0 ? 0 : 0.5 }}>
+              {headerTitle && (
+                <Typography
+                  variant="subtitle2"
+                  sx={{
+                    fontWeight: 700,
+                    fontSize: '0.9rem',
+                    lineHeight: 1.3,
+                    color: 'text.primary',
+                    mb: headerFields.length > 0 ? 0.5 : 0,
+                  }}>
+                  {headerTitle}
+                </Typography>
+              )}
+              {headerFields.length > 0 && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 0.5,
+                    pb: 0.5,
+                  }}>
+                  {headerFields.map((fieldKey: string) => {
+                    const fieldSchema = (schema as any)?.properties?.[fieldKey];
+                    const label = fieldSchema?.title || fieldKey;
+                    const value = data?.[fieldKey];
+                    const displayValue =
+                      value != null && value !== '' ? String(value) : '—';
+                    return (
+                      <Typography
+                        key={fieldKey}
+                        variant="caption"
+                        sx={{
+                          px: 1,
+                          py: 0.25,
+                          borderRadius: 1,
+                          backgroundColor: 'action.hover',
+                          fontSize: '0.75rem',
+                          color:
+                            displayValue === '—'
+                              ? 'text.disabled'
+                              : 'text.primary',
+                          fontWeight: displayValue === '—' ? 400 : 600,
+                        }}>
+                        {label}: {displayValue}
+                      </Typography>
+                    );
+                  })}
+                </Box>
+              )}
+            </Box>
+          )}
+          <FormProgressBar
+            currentPage={visiblePosition}
+            totalScreens={totalVisibleScreens}
+            data={data}
+            schema={schema}
+            uischema={uischema}
+            mode="screens"
+            isOnFinalizePage={isOnFinalizePage}
+          />
+        </>
       }
       previousButton={
         prevVisiblePage !== null

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -85,6 +85,11 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
     // Track if form has been successfully submitted to avoid double resolution
     const [formSubmitted, setFormSubmitted] = useState(false);
 
+    // Author-configurable display name shown in the native header bar
+    const [currentFormDisplayName, setCurrentFormDisplayName] = useState<
+      string | null
+    >(null);
+
     // Add state to track closing process and prevent multiple close attempts
     const [isClosing, setIsClosing] = useState(false);
     const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -198,6 +203,20 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       // Set internal state for the current form and observation
       setCurrentFormType(formType.id);
       setCurrentObservationId(observationId);
+
+      // Resolve display name: ui schema headerTitle > schema title > form spec name
+      const uiSchemaObj = formType.uiSchema as
+        | Record<string, unknown>
+        | undefined;
+      const schemaObj = formType.schema as Record<string, unknown> | undefined;
+      const uiOptions = uiSchemaObj?.options as
+        | Record<string, unknown>
+        | undefined;
+      const displayName =
+        (uiOptions?.headerTitle as string) ||
+        (schemaObj?.title as string) ||
+        formType.name;
+      setCurrentFormDisplayName(displayName);
       setCurrentObservationData(existingObservationData);
       setCurrentParams(params);
       setCurrentOperationId(operationId);
@@ -430,6 +449,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         // Reset form state when modal is closed
         setTimeout(() => {
           setCurrentFormType(null);
+          setCurrentFormDisplayName(null);
           setCurrentObservationId(null);
           setCurrentObservationData(null);
           setIsClosing(false); // Reset closing state when modal is fully closed
@@ -470,8 +490,10 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
               />
             </TouchableOpacity>
             <Text
-              style={[styles.headerTitle, { color: themeColors.onBackground }]}>
-              {currentObservationId ? 'Edit Observation' : 'New Observation'}
+              style={[styles.headerTitle, { color: themeColors.onBackground }]}
+              numberOfLines={1}>
+              {currentFormDisplayName ||
+                (currentObservationId ? 'Edit Observation' : 'New Observation')}
             </Text>
             <View style={styles.headerRightSpacer} />
           </View>


### PR DESCRIPTION
## Author-Configurable Form Header Title & Sticky Fields

Gives form authors control over what displays in the form header replacing the generic "New Observation" with a meaningful title, and optionally pinning 1–2 field values that update live as the user fills the form.
Closes #345
### Usage

Add `options` to the root `SwipeLayout` in your `ui.json`:

```json
{
  "type": "SwipeLayout",
  "options": {
    "headerTitle": "Household Registration",
    "headerFields": ["household_number", "head_name"]
  },
  "elements": [...]
}
```

| Option | Type | Description |
|---|---|---|
| `headerTitle` | `string` | Replaces "New Observation" in the header. Falls back to `schema.title` if not set. |
| `headerFields` | `string[]` | Up to 2 field keys whose current values stick to the header across all pages. Labels are pulled from the schema field `title`. |

Both options are optional existing forms are unaffected.

### What the user sees

```
┌──────────────────────────────────────┐
│ [X]   Household Registration         │  ← headerTitle
├──────────────────────────────────────┤
│  Household #: HH-042  │ Head: João   │  ← headerFields (live-updating)
│  ████████████████░░░░░░░░  62%       │  ← progress bar
├──────────────────────────────────────┤
│  (scrollable form content)           │
```

Before a field is filled, it shows `"—"` as a placeholder.

### Changes

- **`formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx`** - Reads `headerTitle` and `headerFields` from UI schema options; renders title and live field values above the progress bar
- **`formulus/src/components/FormplayerModal.tsx`** - Native header resolves display name from UI schema `headerTitle` → schema `title` → form spec name