### PR TITLE
feat: Pre-cache GPS location during form fill

### DIFF
--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -37,6 +37,7 @@ import { FormSpec } from '../services'; // FormService will be imported directly
 import { ExtensionService } from '../services/ExtensionService';
 import RNFS from 'react-native-fs';
 import { useAppTheme } from '../contexts/AppThemeContext';
+import { geolocationService } from '../services/GeolocationService';
 
 interface FormplayerModalProps {
   visible: boolean;
@@ -128,7 +129,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         resolveFormOperationByType(currentFormType, completionResult);
       }
 
-      // Call the parent's onClose immediately
+      geolocationService.clearCache();
       onClose();
 
       // Reset closing state after a short delay to prevent rapid re-opening issues
@@ -195,7 +196,9 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       existingObservationData: Record<string, unknown> | null,
       operationId: string | null,
     ) => {
-      // Set internal state for the current form and observation
+      // Start GPS acquisition early so the fix is ready at save time
+      geolocationService.preCacheLocation();
+
       setCurrentFormType(formType.id);
       setCurrentObservationId(observationId);
       setCurrentObservationData(existingObservationData);

--- a/formulus/src/database/FormObservationRepository.ts
+++ b/formulus/src/database/FormObservationRepository.ts
@@ -42,23 +42,21 @@ export class FormObservationRepository implements LocalRepoInterface {
         .toString(36)
         .substring(2, 9)}`;
 
-      // Attempt to capture geolocation (non-blocking)
+      // Use pre-cached GPS when available, fall back to fresh capture
       let geolocation = null;
       try {
-        geolocation =
-          await geolocationService.getCurrentLocationForObservation();
+        geolocation = geolocationService.getCachedLocation();
+        if (!geolocation) {
+          geolocation =
+            await geolocationService.getCurrentLocationForObservation();
+        }
         if (geolocation) {
-          console.debug('Captured geolocation for observation:', id);
           ToastService.showGeolocationCaptured();
         } else {
-          console.debug('No geolocation available for observation:', id);
           ToastService.showGeolocationUnavailable();
         }
       } catch (geoError) {
-        console.warn(
-          'Failed to capture geolocation for observation:',
-          geoError,
-        );
+        console.warn('Failed to capture geolocation:', geoError);
         ToastService.showGeolocationUnavailable();
       }
 

--- a/formulus/src/database/repositories/WatermelonDBRepo.ts
+++ b/formulus/src/database/repositories/WatermelonDBRepo.ts
@@ -35,23 +35,21 @@ export class WatermelonDBRepo implements LocalRepoInterface {
     try {
       console.log('Saving observation:', input);
 
-      // Attempt to capture geolocation (non-blocking)
+      // Use pre-cached GPS when available, fall back to fresh capture
       let geolocation = null;
       try {
-        geolocation =
-          await geolocationService.getCurrentLocationForObservation();
+        geolocation = geolocationService.getCachedLocation();
+        if (!geolocation) {
+          geolocation =
+            await geolocationService.getCurrentLocationForObservation();
+        }
         if (geolocation) {
-          console.debug('Captured geolocation for observation');
           ToastService.showGeolocationCaptured();
         } else {
-          console.debug('No geolocation available for observation');
           ToastService.showGeolocationUnavailable();
         }
       } catch (geoError) {
-        console.warn(
-          'Failed to capture geolocation for observation:',
-          geoError,
-        );
+        console.warn('Failed to capture geolocation:', geoError);
         ToastService.showGeolocationUnavailable();
       }
 

--- a/formulus/src/services/GeolocationService.ts
+++ b/formulus/src/services/GeolocationService.ts
@@ -16,16 +16,17 @@ import { RESULTS } from 'react-native-permissions';
 export class GeolocationService {
   private static instance: GeolocationService;
 
-  // Configuration for geolocation
   private config: GeolocationConfig = {
     enableHighAccuracy: true,
-    timeout: 10000, // 10 seconds
-    maximumAge: 10000, // 10 seconds - use cached location if very recent
+    timeout: 10000,
+    maximumAge: 10000,
   };
 
-  private constructor() {
-    // No continuous tracking - we get location on demand
-  }
+  private cachedLocation: ObservationGeolocation | null = null;
+  private cachedAt: number = 0;
+  private static readonly CACHE_MAX_AGE_MS = 120_000; // 2 minutes
+
+  private constructor() {}
 
   public static getInstance(): GeolocationService {
     if (!GeolocationService.instance) {
@@ -122,6 +123,34 @@ export class GeolocationService {
         watchId = null;
       }
     };
+  }
+
+  /** Fire-and-forget: start acquiring GPS so the result is cached for later. */
+  public preCacheLocation(): void {
+    this.getCurrentLocationForObservation()
+      .then(location => {
+        if (location) {
+          this.cachedLocation = location;
+          this.cachedAt = Date.now();
+        }
+      })
+      .catch(() => {});
+  }
+
+  /** Return cached location if fresh enough, otherwise null. */
+  public getCachedLocation(): ObservationGeolocation | null {
+    if (
+      this.cachedLocation &&
+      Date.now() - this.cachedAt < GeolocationService.CACHE_MAX_AGE_MS
+    ) {
+      return this.cachedLocation;
+    }
+    return null;
+  }
+
+  public clearCache(): void {
+    this.cachedLocation = null;
+    this.cachedAt = 0;
   }
 
   /**


### PR DESCRIPTION
## Description

- This moves GPS acquisition from save-time to form-open-time so users don't wait after tapping Submit.
- `saveObservation()` was calling `getCurrentLocationForObservation()` synchronously — up to 10s of blocking while GPS locks on. Bad UX, especially in low-signal areas.
Closes #347 

### How
- **`GeolocationService.ts`** - New `preCacheLocation()` fires GPS request on form open; `getCachedLocation()` returns cached fix if < 2 min old; `clearCache()` resets on form close.
- **`WatermelonDBRepo.ts` / `FormObservationRepository.ts`** - `saveObservation()` checks cache first, falls back to fresh capture only if cache is empty/expired.
- **`FormplayerModal.tsx`** - Calls `preCacheLocation()` in `initializeForm()`, `clearCache()` in `performClose()`.

### Behavior
| Before | After |
|--------|-------|
| Submit → wait up to 10s for GPS → save | Form opens → GPS acquired in background → Submit → instant save |

Falls back gracefully to a fresh capture if the cache expires (form open > 2 min).