### PR TITLE
fix: close zip file handle before saving bundle.zip

### DIFF
--- a/synkronus/pkg/appbundle/versioning.go
+++ b/synkronus/pkg/appbundle/versioning.go
@@ -39,7 +39,7 @@ func (s *Service) PushBundle(ctx context.Context, zipReader io.Reader) (*Manifes
 	if err != nil {
 		return nil, fmt.Errorf("failed to open zip file: %w", err)
 	}
-	defer zipFile.Close()
+	// Note: We'll close zipFile explicitly before copying tempZipFile to bundle.zip
 
 	// Validate the bundle structure
 	if err := s.validateBundleStructure(&zipFile.Reader); err != nil {
@@ -122,6 +122,9 @@ func (s *Service) PushBundle(ctx context.Context, zipReader io.Reader) (*Manifes
 		srcFile.Close()
 		dstFile.Close()
 	}
+
+	// Close the zip reader before copying the temp file
+	zipFile.Close()
 
 	// Save the original zip to the version directory for direct download
 	if _, err := tempZipFile.Seek(0, 0); err != nil {


### PR DESCRIPTION
## Fix: Close zip file handle before saving bundle.zip

### Problem
The `/app-bundle/download-zip` endpoint returns 404 when mobile apps try to download app bundles. The `bundle.zip` file is not being saved during bundle upload.
Closes #356

### Root Cause
In `PushBundle`, `defer zipFile.Close()` keeps the zip file handle open when copying the temp file to `bundle.zip`. The open handle blocks the copy, causing it to fail silently, so `bundle.zip` is never created.

### Solution
- Removed `defer zipFile.Close()` at line 42
- Added explicit `zipFile.Close()` at line 127, before saving `bundle.zip`

This ensures the zip file handle is closed before copying, allowing `bundle.zip` to be saved successfully.

### Changes
- `pkg/appbundle/versioning.go`: Close zip file handle explicitly before saving bundle.zip

### Testing
- Fix tested locally and confirmed working
- `bundle.zip` is now successfully created in version directories
- Download endpoint works correctly

### Impact
- **Severity**: High -blocks app bundle updates for all users
- **Affected**: All servers running code from Feb 11, 2026 or later
- **Breaking**: No -this is a bug fix