### PR TITLE
fix: resolve formplayer not opening from custom applications

### DIFF
--- a/formulus/App.tsx
+++ b/formulus/App.tsx
@@ -4,7 +4,7 @@ import {
   DefaultTheme,
   DarkTheme,
 } from '@react-navigation/native';
-import { StatusBar, useColorScheme } from 'react-native';
+import { StatusBar, useColorScheme, Alert } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import 'react-native-url-polyfill/auto';
 import { FormService } from './src/services/FormService';
@@ -91,34 +91,68 @@ function AppInner(): React.JSX.Element {
     );
 
     const handleOpenFormplayer = async (config: FormInitData) => {
+      // If formplayer is already visible, close it first to allow opening a new form
       if (formplayerVisibleRef.current) {
-        return;
+        console.log(
+          '[App] Formplayer already visible, closing first before opening new form',
+        );
+        formplayerVisibleRef.current = false;
+        setFormplayerVisible(false);
+        // Wait for modal to close before proceeding
+        await new Promise<void>(resolve => setTimeout(() => resolve(), 300));
       }
 
       const { formType, observationId, params, savedData, operationId } =
         config;
-      formplayerVisibleRef.current = true;
-      setFormplayerVisible(true);
 
-      const formService = await FormService.getInstance();
-      const forms = formService.getFormSpecs();
+      try {
+        const formService = await FormService.getInstance();
+        const forms = formService.getFormSpecs();
 
-      if (forms.length === 0) {
-        return;
+        if (forms.length === 0) {
+          Alert.alert(
+            'No Forms Available',
+            'No forms are available. Please sync forms first.',
+          );
+          return;
+        }
+
+        const formSpec = forms.find(form => form.id === formType);
+        if (!formSpec) {
+          Alert.alert(
+            'Form Not Found',
+            `Form "${formType}" not found. Please sync forms first.`,
+          );
+          return;
+        }
+
+        // Set visible state first to mount the modal
+        formplayerVisibleRef.current = true;
+        setFormplayerVisible(true);
+
+        // Wait for modal to mount and WebView to start loading before initializing form
+        // This ensures the WebView ref is available and the modal is visible
+        setTimeout(() => {
+          formplayerModalRef.current?.initializeForm(
+            formSpec,
+            params || null,
+            observationId || null,
+            savedData || null,
+            operationId || null,
+          );
+        }, 200);
+      } catch (error) {
+        console.error('[App] Error opening formplayer:', error);
+        Alert.alert(
+          'Error',
+          `Failed to open form: ${
+            error instanceof Error ? error.message : 'Unknown error'
+          }`,
+        );
+        // Reset state on error
+        formplayerVisibleRef.current = false;
+        setFormplayerVisible(false);
       }
-
-      const formSpec = forms.find(form => form.id === formType);
-      if (!formSpec) {
-        return;
-      }
-
-      formplayerModalRef.current?.initializeForm(
-        formSpec,
-        params || null,
-        observationId || null,
-        savedData || null,
-        operationId || null,
-      );
     };
 
     const handleCloseFormplayer = () => {

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -188,9 +188,14 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       };
     }, []);
 
+    // Track WebView ready state
+    const [webViewReady, setWebViewReady] = useState(false);
+
     // Handle WebView load complete
     const handleWebViewLoad = () => {
-      // WebView ready - no action needed
+      console.log('[FormplayerModal] WebView finished loading');
+      setWebViewReady(true);
+      // WebView is now ready to receive form initialization
     };
 
     // Initialize a form with the given form type and optional existing data
@@ -201,6 +206,13 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       existingObservationData: Record<string, unknown> | null,
       operationId: string | null,
     ) => {
+      // Check if WebView is ready, if not log a warning (retry logic will handle it)
+      if (!webViewReady) {
+        console.warn(
+          '[FormplayerModal] WebView not ready yet, form init will be queued by message handler',
+        );
+      }
+
       // Start GPS acquisition early so the fix is ready at save time
       geolocationService.preCacheLocation();
 
@@ -529,6 +541,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           setCurrentObservationData(null);
           setIsClosing(false); // Reset closing state when modal is fully closed
           setFormSubmitted(false); // Reset submission flag
+          setWebViewReady(false); // Reset WebView ready state
         }, 300); // Small delay to ensure modal is fully closed
       }
     }, [visible, handleSubmission]);


### PR DESCRIPTION
## Description

### Problem
Forms did not open when tapped from custom applications, especially after running `npm run upload:android`. The issue manifested as:
- Forms appearing to do nothing when tapped
- No error messages shown to users
- Forms failing to open if the formplayer modal was already visible

### Root causes
1. Early return guard blocked form opens when the modal was already visible
2. Silent failures with no user feedback when forms were missing or not found
3. Race condition where `initializeForm` was called before the WebView was ready
4. Missing error handling for edge cases

### Solution
- Fixed early return guard to close existing formplayer before opening a new form
- Added user feedback (Alert dialogs) for form lookup errors
- Added 200ms delay before `initializeForm` to ensure modal is mounted
- Improved WebView ready state tracking in `FormplayerModal`
- Added error handling with try-catch in `handleOpenFormplayer`

### Changes
- `formulus/App.tsx`: Fixed form opening logic with proper error handling and user feedback
- `formulus/src/components/FormplayerModal.tsx`: Added WebView ready state tracking

Fixes the issue where forms would not open when tapped from custom applications.