### PR TITLE
fix: add x-formulus-version header to portal API requests

### DIFF
--- a/synkronus-portal/package.json
+++ b/synkronus-portal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "synkronus-portal",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/synkronus-portal/src/services/api.ts
+++ b/synkronus-portal/src/services/api.ts
@@ -3,6 +3,7 @@ import type {
   LoginResponse,
   RefreshRequest,
 } from '../types/auth';
+import { PORTAL_VERSION } from '../version';
 
 // Get API base URL from environment or use default
 const getApiBaseUrl = () => {
@@ -31,6 +32,7 @@ async function request<T>(
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+    'x-formulus-version': PORTAL_VERSION,
     ...((options.headers as Record<string, string>) || {}),
   };
 
@@ -216,7 +218,9 @@ export const api = {
     const query = params.toString();
     const url = `${API_BASE_URL}/app-bundle/download/${encodeURIComponent(filePath)}${query ? `?${query}` : ''}`;
 
-    const headers: Record<string, string> = {};
+    const headers: Record<string, string> = {
+      'x-formulus-version': PORTAL_VERSION,
+    };
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
     }

--- a/synkronus-portal/src/version.ts
+++ b/synkronus-portal/src/version.ts
@@ -1,0 +1,6 @@
+/** Portal version from package.json for x-formulus-version header. */
+// Read version from package.json at build time
+// For Vite, we use import.meta.env or a constant that matches package.json
+// This will be replaced at build time or we can use a vite plugin
+// For now, using a constant that should match package.json version
+export const PORTAL_VERSION = '1.0.0';


### PR DESCRIPTION

- Update portal version to 1.0.0 in package.json
- Create version.ts to export PORTAL_VERSION constant
- Add x-formulus-version header to all API requests in api.ts
- Include header in downloadAppBundleFile function
- Portal now sends version header matching Formulus app (1.0.0)
- Enables version handshake for portal web client