### PR TITLE
fix: server version not persisting from git tags (426 errors)

### DIFF
--- a/.github/workflows/synkronus-docker.yml
+++ b/.github/workflows/synkronus-docker.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0    # Full history so git describe can reach the last tag
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -54,20 +56,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Fetch git tags for version detection
-        run: |
-          # Fetch all tags to ensure git describe works correctly
-          git fetch --tags --quiet || true
-      
       - name: Determine Synkronus version from git
         id: version
         run: |
-          # Version is automatically derived from git tags (standard Go practice)
-          # For releases, use the release tag; otherwise use git describe
+          # fetch-depth: 0 on checkout guarantees all tags are available.
+          # --abbrev=0: output only the nearest tag name (e.g. v1.0.0), never
+          # the commit-distance suffix (v1.0.0-3-gabcdef1). This keeps the
+          # baked-in version stable across every push until a new tag is created.
+          # Fallback "1.0.0" is parseable by parseMajor in case the repo has no tags yet.
           if [ "${{ github.event_name }}" == "release" ]; then
             VERSION="${{ github.event.release.tag_name }}"
           else
-            VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+            VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "1.0.0")
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Building Synkronus with version: ${VERSION}"


### PR DESCRIPTION
The CI was doing a shallow clone (`fetch-depth: 1`) so `git describe` couldn't reach any tags and fell back to a bare commit SHA. That unparseable string got baked into the binary, causing the server's own version check to fail and return **426 on every request**.

**Changes:**
- `fetch-depth: 0` on checkout so all tags are reachable
- `git describe --abbrev=0` to always return the nearest tag (`v1.0.0-alpha.24`) without the commit-distance suffix
- Removed the now-redundant `git fetch --tags` step
- Fallback changed from `"dev"` to `"1.0.0"` (parseable) for repos with no tags