### PR TITLE
fix: 426 by ensuring Synkronus build version is valid semver

### DIFF
--- a/synkronus/Dockerfile
+++ b/synkronus/Dockerfile
@@ -20,8 +20,8 @@ COPY . .
 
 # Build the application with version from build arg
 # Version is automatically derived from git tags in CI and passed as build arg
-# Defaults to "dev" for local builds without tags
-ARG SYNKRONUS_VERSION=dev
+# Defaults to a semantic version for local builds without tags (middleware requires semver)
+ARG SYNKRONUS_VERSION=1.0.0
 ENV CGO_ENABLED=0 GOOS=linux
 RUN echo "Building Synkronus with version: ${SYNKRONUS_VERSION}" && \
     go build -a -ldflags="-w -s -X github.com/opendataensemble/synkronus/pkg/version.version=${SYNKRONUS_VERSION}" -o synkronus ./cmd/synkronus

--- a/synkronus/docker-compose.example.yml
+++ b/synkronus/docker-compose.example.yml
@@ -35,7 +35,10 @@ services:
     # Use pre-built image from GitHub Container Registry
     image: ghcr.io/opendataensemble/synkronus:latest
     # Or build locally for development:
-    # build: .
+    # build:
+    #   context: .
+    #   args:
+    #     SYNKRONUS_VERSION: ${SYNKRONUS_VERSION:-1.0.0}
     expose:
       - "8080"
     # Only expose port directly if not using nginx:


### PR DESCRIPTION
## Description

Fixes `426 Upgrade Required` errors caused by Synkronus reporting a non-semver build version (`dev`).  
Sets a semver default in [synkronus/Dockerfile](cci:7://file:///Users/Apple/Desktop/ode-workspace/ode/synkronus/Dockerfile:0:0-0:0) and documents how to pass `SYNKRONUS_VERSION` via [docker-compose.example.yml](cci:7://file:///Users/Apple/Desktop/ode-workspace/ode/synkronus/docker-compose.example.yml:0:0-0:0) when building locally.