### PR TITLE
feat(formulus): Settings hierarchy in More drawer

### DIFF
--- a/formulus/src/components/MenuDrawer.tsx
+++ b/formulus/src/components/MenuDrawer.tsx
@@ -124,12 +124,16 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({
   /** Nested App Settings (themes only). */
   const [appSettingsOpen, setAppSettingsOpen] = useState<boolean>(false);
 
-  // Collapse nested App Settings when main Settings closes
-  useEffect(() => {
-    if (!settingsOpen) {
+  /** Toggle Settings; when closing, collapse nested App Settings (no setState in useEffect — CI react-hooks/set-state-in-effect). */
+  const toggleSettingsOpen = () => {
+    if (settingsOpen) {
       setAppSettingsOpen(false);
+      setSettingsOpen(false);
+    } else {
+      setSettingsOpen(true);
     }
-  }, [settingsOpen]);
+  };
+
   // Backdrop covers the full height; bottom nav is rendered above this layer
   // by the tab navigator, so its buttons remain clickable.
   const bottomPadding = 0;
@@ -297,7 +301,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({
                 <TouchableOpacity
                   style={styles.appSettingsHeader}
                   activeOpacity={0.8}
-                  onPress={() => setSettingsOpen(open => !open)}>
+                  onPress={toggleSettingsOpen}>
                   <View style={styles.appSettingsTitleRow}>
                     <Icon name="cog" size={24} color={textColor} />
                     <Text

--- a/formulus/src/components/MenuDrawer.tsx
+++ b/formulus/src/components/MenuDrawer.tsx
@@ -119,7 +119,17 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({
     ? withAlpha(themeColors.surface as string, CONTAINER_ALPHA)
     : withAlpha(colors.neutral[900] as string, 0.02);
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  /** Top-level Settings (Server Settings + App Settings). */
+  const [settingsOpen, setSettingsOpen] = useState<boolean>(false);
+  /** Nested App Settings (themes only). */
   const [appSettingsOpen, setAppSettingsOpen] = useState<boolean>(false);
+
+  // Collapse nested App Settings when main Settings closes
+  useEffect(() => {
+    if (!settingsOpen) {
+      setAppSettingsOpen(false);
+    }
+  }, [settingsOpen]);
   // Backdrop covers the full height; bottom nav is rendered above this layer
   // by the tab navigator, so its buttons remain clickable.
   const bottomPadding = 0;
@@ -281,13 +291,13 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({
           )}
 
           <ScrollView style={styles.menuList}>
-            {/* App Settings dropdown with Themes section, divided by thin lines */}
+            {/* Settings: Server Settings (login/server URL) + App Settings (themes) */}
             <View style={styles.menuItem}>
               <View style={styles.themeContent}>
                 <TouchableOpacity
                   style={styles.appSettingsHeader}
                   activeOpacity={0.8}
-                  onPress={() => setAppSettingsOpen(open => !open)}>
+                  onPress={() => setSettingsOpen(open => !open)}>
                   <View style={styles.appSettingsTitleRow}>
                     <Icon name="cog" size={24} color={textColor} />
                     <Text
@@ -296,74 +306,127 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({
                         styles.appSettingsLabel,
                         { color: textColor },
                       ]}>
-                      App Settings
+                      Settings
                     </Text>
                     <Icon
-                      name={appSettingsOpen ? 'chevron-up' : 'chevron-down'}
+                      name={settingsOpen ? 'chevron-up' : 'chevron-down'}
                       size={20}
                       color={textColor}
                       style={styles.appSettingsChevron}
                     />
                   </View>
                 </TouchableOpacity>
-                {appSettingsOpen && (
-                  <View
-                    style={[
-                      styles.themesCardOuter,
-                      {
-                        borderColor: menuModalBorderColor,
-                        backgroundColor: cardOuterBg,
-                      },
-                    ]}>
-                    <View
-                      style={[
-                        styles.themesCardInner,
-                        { backgroundColor: cardInnerBg },
-                      ]}>
-                      <Text style={[styles.themesTitle, { color: textColor }]}>
-                        Themes
+                {settingsOpen && (
+                  <View style={styles.settingsNestedBlock}>
+                    {/* Server Settings: same destination as bottom Login */}
+                    <TouchableOpacity
+                      style={styles.serverSettingsRow}
+                      activeOpacity={0.8}
+                      onPress={() => {
+                        onClose();
+                        onNavigate('Settings');
+                      }}>
+                      <Icon name="server-network" size={22} color={textColor} />
+                      <Text
+                        style={[
+                          styles.menuLabel,
+                          styles.nestedSettingsLabel,
+                          { color: textColor },
+                        ]}>
+                        Server Settings
                       </Text>
-                      <View style={styles.themeOptionsColumn}>
-                        {(['system', 'dark', 'light'] as ThemeMode[]).map(
-                          mode => (
-                            <TouchableOpacity
-                              key={mode}
-                              style={[
-                                styles.themeChip,
-                                {
-                                  borderColor:
-                                    themeMode === mode
-                                      ? (themeColors.primary as string)
-                                      : isDark
-                                        ? (themeChipBorderColorDark as string)
-                                        : (colors.neutral[400] as string),
-                                },
-                              ]}
-                              activeOpacity={0.8}
-                              onPress={() => setThemeMode(mode)}>
-                              <Text
-                                style={[
-                                  styles.themeChipLabel,
-                                  {
-                                    color:
-                                      themeMode === mode
-                                        ? (themeColors.primary as string)
-                                        : isDark
-                                          ? (colors.neutral[200] as string)
-                                          : (colors.neutral[700] as string),
-                                  },
-                                ]}>
-                                {mode === 'system'
-                                  ? 'System'
-                                  : mode === 'dark'
-                                    ? 'Dark'
-                                    : 'Light'}
-                              </Text>
-                            </TouchableOpacity>
-                          ),
-                        )}
+                      <Icon
+                        name="chevron-right"
+                        size={20}
+                        color={textColor}
+                        style={styles.nestedChevronRight}
+                      />
+                    </TouchableOpacity>
+                    <MenuDivider color={menuModalBorderColor} />
+                    {/* App Settings: nested dropdown for themes only */}
+                    <TouchableOpacity
+                      style={styles.appSettingsSubHeader}
+                      activeOpacity={0.8}
+                      onPress={() => setAppSettingsOpen(open => !open)}>
+                      <View style={styles.appSettingsTitleRow}>
+                        <Icon name="palette" size={22} color={textColor} />
+                        <Text
+                          style={[
+                            styles.menuLabel,
+                            styles.nestedSettingsLabel,
+                            { color: textColor },
+                          ]}>
+                          App Settings
+                        </Text>
+                        <Icon
+                          name={appSettingsOpen ? 'chevron-up' : 'chevron-down'}
+                          size={20}
+                          color={textColor}
+                          style={styles.appSettingsChevron}
+                        />
                       </View>
-                    </View>
+                    </TouchableOpacity>
+                    {appSettingsOpen && (
+                      <View
+                        style={[
+                          styles.themesCardOuter,
+                          {
+                            borderColor: menuModalBorderColor,
+                            backgroundColor: cardOuterBg,
+                          },
+                        ]}>
+                        <View
+                          style={[
+                            styles.themesCardInner,
+                            { backgroundColor: cardInnerBg },
+                          ]}>
+                          <Text
+                            style={[styles.themesTitle, { color: textColor }]}>
+                            Themes
+                          </Text>
+                          <View style={styles.themeOptionsColumn}>
+                            {(['system', 'dark', 'light'] as ThemeMode[]).map(
+                              mode => (
+                                <TouchableOpacity
+                                  key={mode}
+                                  style={[
+                                    styles.themeChip,
+                                    {
+                                      borderColor:
+                                        themeMode === mode
+                                          ? (themeColors.primary as string)
+                                          : isDark
+                                            ? (themeChipBorderColorDark as string)
+                                            : (colors.neutral[400] as string),
+                                    },
+                                  ]}
+                                  activeOpacity={0.8}
+                                  onPress={() => setThemeMode(mode)}>
+                                  <Text
+                                    style={[
+                                      styles.themeChipLabel,
+                                      {
+                                        color:
+                                          themeMode === mode
+                                            ? (themeColors.primary as string)
+                                            : isDark
+                                              ? (colors.neutral[200] as string)
+                                              : (colors.neutral[700] as string),
+                                      },
+                                    ]}>
+                                    {mode === 'system'
+                                      ? 'System'
+                                      : mode === 'dark'
+                                        ? 'Dark'
+                                        : 'Light'}
+                                  </Text>
+                                </TouchableOpacity>
+                              ),
+                            )}
+                          </View>
+                        </View>
+                      </View>
+                    )}
                   </View>
                 )}
               </View>
@@ -548,6 +611,32 @@ const styles = StyleSheet.create({
   },
   appSettingsChevron: {
     marginLeft: odeSpacing.xs,
+  },
+  settingsNestedBlock: {
+    marginTop: odeSpacing.sm,
+    borderRadius: odeRadius.inner,
+    overflow: 'hidden',
+  },
+  serverSettingsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: odeSpacing.sm,
+    paddingVertical: odeSpacing.sm,
+    paddingHorizontal: odeSpacing.xs,
+  },
+  appSettingsSubHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: odeSpacing.sm,
+    paddingHorizontal: odeSpacing.xs,
+    marginTop: odeSpacing.xs,
+  },
+  nestedSettingsLabel: {
+    flex: 1,
+    marginLeft: 0,
+  },
+  nestedChevronRight: {
+    marginLeft: 'auto',
   },
   sectionLabel: {
     marginTop: odeSpacing.sm,


### PR DESCRIPTION
# Description

* Renamed top-level from "**App Settings**" to "**Settings**".
* Added "**Server Settings**" row.
* Moved theme System/Light/Dark under nested "**App Settings**" dropdown.

## Behavior
1. **Before**: The **More** drawer had a single **App Settings** dropdown; opening it showed **Themes** (System / Light / Dark) only.

<p align="center">
<img src="https://github.com/user-attachments/assets/a43b248a-ca10-4037-a84f-7908d6cd612a" width="260"/>
</p>


2. **After**: 
The top-level label is now **Settings**:
- Opening it shows; 
a) **Server Settings**: Clicking on it opens the same screen as the bottom Login which is server URL & credentials
b)**App Settings**: The nested dropdown with Themes unchanged inside.

<table>
<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/48f9b2be-f584-4c8e-9079-be591528bda1" width="260"/>
</td>
<td align="center">
<img src="https://github.com/user-attachments/assets/84c3f83a-b455-4aa7-8c4c-5bffabf35c5f" width="260"/>
</td>
<td align="center">
<img src="https://github.com/user-attachments/assets/e7e8a41d-2a2c-4fad-a96a-9b2105f83007" width="260"/>
</td>
</tr>
</table>

Solves #494 
