### PR TITLE
feat(formulus): placeholder copy + post-login redirect to Sync

### DIFF
--- a/formulus/android/app/src/main/assets/webview/placeholder_app.html
+++ b/formulus/android/app/src/main/assets/webview/placeholder_app.html
@@ -162,7 +162,7 @@
     <div class="placeholder-card">
       <h1 class="placeholder-title">Your Custom<br>App</h1>
       <p class="placeholder-subtitle" id="subtitle-text">
-        Login and Sync to load your forms
+        <strong>Login</strong> and <strong>Update App Bundle</strong> to load your forms
       </p>
       <button
         type="button"
@@ -202,17 +202,27 @@
       }
 
       var loginBtn = document.getElementById('login-btn');
+      var subtitleEl = document.getElementById('subtitle-text');
+
+      /** Logged-out copy: bold Login + Update App Bundle. Logged-in copy: bold Update App Bundle only. */
+      var SUBTITLE_LOGIN =
+        '<strong>Login</strong> and <strong>Update App Bundle</strong> to load your forms';
+      var SUBTITLE_UPDATE =
+        '<strong>Update App Bundle</strong> to load your forms';
 
       function setButtonMode(mode) {
         if (!loginBtn) return;
         if (mode === 'sync') {
-          loginBtn.textContent = 'Sync Now';
-          loginBtn.setAttribute('aria-label', 'Sync to load forms');
+          // Logged in: button goes to Sync screen to update app bundle
+          loginBtn.textContent = 'Update Now';
+          loginBtn.setAttribute('aria-label', 'Update App Bundle to load forms');
           loginBtn.onclick = navigateToSync;
+          if (subtitleEl) subtitleEl.innerHTML = SUBTITLE_UPDATE;
         } else {
           loginBtn.textContent = 'Login Now';
           loginBtn.setAttribute('aria-label', 'Login to load forms');
           loginBtn.onclick = navigateToLogin;
+          if (subtitleEl) subtitleEl.innerHTML = SUBTITLE_LOGIN;
         }
       }
 

--- a/formulus/assets/webview/placeholder_app.html
+++ b/formulus/assets/webview/placeholder_app.html
@@ -162,7 +162,7 @@
     <div class="placeholder-card">
       <h1 class="placeholder-title">Your Custom<br>App</h1>
       <p class="placeholder-subtitle" id="subtitle-text">
-        Login and Sync to load your forms
+        <strong>Login</strong> and <strong>Update App Bundle</strong> to load your forms
       </p>
       <button
         type="button"
@@ -202,17 +202,27 @@
       }
 
       var loginBtn = document.getElementById('login-btn');
+      var subtitleEl = document.getElementById('subtitle-text');
+
+      /** Logged-out copy: bold Login + Update App Bundle. Logged-in copy: bold Update App Bundle only. */
+      var SUBTITLE_LOGIN =
+        '<strong>Login</strong> and <strong>Update App Bundle</strong> to load your forms';
+      var SUBTITLE_UPDATE =
+        '<strong>Update App Bundle</strong> to load your forms';
 
       function setButtonMode(mode) {
         if (!loginBtn) return;
         if (mode === 'sync') {
-          loginBtn.textContent = 'Sync Now';
-          loginBtn.setAttribute('aria-label', 'Sync to load forms');
+          // Logged in: button goes to Sync screen to update app bundle
+          loginBtn.textContent = 'Update Now';
+          loginBtn.setAttribute('aria-label', 'Update App Bundle to load forms');
           loginBtn.onclick = navigateToSync;
+          if (subtitleEl) subtitleEl.innerHTML = SUBTITLE_UPDATE;
         } else {
           loginBtn.textContent = 'Login Now';
           loginBtn.setAttribute('aria-label', 'Login to load forms');
           loginBtn.onclick = navigateToLogin;
+          if (subtitleEl) subtitleEl.innerHTML = SUBTITLE_LOGIN;
         }
       }
 

--- a/formulus/src/components/CustomAppWebView.tsx
+++ b/formulus/src/components/CustomAppWebView.tsx
@@ -32,7 +32,7 @@ interface CustomAppWebViewProps {
   appName?: string; // To identify the source of logs
   onLoadEndProp?: () => void; // Propagate WebView's onLoadEnd event
   onCanGoBackChange?: (canGoBack: boolean) => void; // Notify parent when WebView back-navigability changes
-  /** Called when placeholder posts formulusNavigateToSync (e.g. "Login Now" button). */
+  /** Called when placeholder posts formulusNavigateToSync (e.g. "Update Now" → Sync screen). */
   onNavigateToSync?: () => void;
   /** Called when placeholder posts formulusNavigateToSettings (Login Now → login/settings screen). */
   onNavigateToSettings?: () => void;

--- a/formulus/src/screens/HomeScreen.tsx
+++ b/formulus/src/screens/HomeScreen.tsx
@@ -150,7 +150,7 @@ const HomeScreen = ({ navigation }: { navigation: any }) => {
     customAppRef.current.injectJavaScript(js);
   }, [resolvedMode, localUri, isPlaceholder]);
 
-  // The placeholder button should switch between "Login Now" and "Sync Now" appropriately.
+  // The placeholder button switches between "Login Now" and "Update Now" (both flows; Update goes to Sync).
   useFocusEffect(
     React.useCallback(() => {
       if (!isPlaceholder || !customAppRef.current) {

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -233,7 +233,7 @@ const SettingsScreen = () => {
       await Keychain.setGenericPassword(trimmedUsername, trimmedPassword);
       await login(trimmedUsername, trimmedPassword);
       ToastService.showShort('Successfully logged in!');
-      navigation.navigate('Home');
+      navigation.navigate('Sync');
     } catch (error) {
       console.error('Login failed:', error);
       const message = isVersionMismatchError(error)
@@ -287,7 +287,7 @@ const SettingsScreen = () => {
           try {
             await login(settings.username, settings.password);
             ToastService.showShort('Successfully logged in!');
-            navigation.navigate('Home');
+            navigation.navigate('Sync');
           } catch (error) {
             console.error('Auto-login failed:', error);
             const errorMessage =


### PR DESCRIPTION
# PR description


1. **Before**
- Placeholder showed **“Login and Sync to load your forms”** and **"Login Now"** button → Settings. 
- After login, users were automatically sent back to the placeholder with **"Sync Now"** button → Sync.

<p align="center">
<img src="https://github.com/user-attachments/assets/3738a302-2c62-4a84-a9c6-ad1106f0726f" width="260"/>
<img src="https://github.com/user-attachments/assets/20c08195-d095-49cb-afb9-48fb7bb2b1b4" width="260"/>
</p>


2. **After**
- Placeholder shows **“Login and Update App Bundle to load your forms”** and **"Login Now"** button → Settings. 
- After login, users are automatically sent straight to **Sync** (not returned to placeholder). 
- If they, for whatever reason, return to Home/placeholder without updating, the placeholder shows **“Update App Bundle to load your forms”**, and the button is **"Update Now"** (still opens Sync).

<p align="center">
<img src="https://github.com/user-attachments/assets/0cc37c1d-25f7-4324-a2a4-c3520b10b113" width="260"/>
<img src="https://github.com/user-attachments/assets/bba520dc-2fd8-4f5b-8dbb-c7034b2e1f29" width="260"/>
</p>