### PR TITLE
chore(synkronus-cli): remove deprecated skip-validation flag

### DIFF
--- a/synkronus-cli/README.md
+++ b/synkronus-cli/README.md
@@ -149,9 +149,6 @@ synk app-bundle upload bundle.zip
 # Upload with auto-activation and verbose output
 synk app-bundle upload bundle.zip --activate --verbose
 
-# Upload with validation skipped (not recommended)
-synk app-bundle upload bundle.zip --skip-validation
-
 # Switch to a specific app bundle version (admin only)
 synk app-bundle switch 20250507-123456
 ```

--- a/synkronus-cli/internal/cmd/appbundle.go
+++ b/synkronus-cli/internal/cmd/appbundle.go
@@ -221,8 +221,6 @@ Use the --preview flag to ensure you get the preview version of the app bundle.`
 		Long: `Upload a new app bundle ZIP file to the Synkronus API (admin only).
 
 The bundle will be validated before upload to ensure it has the correct structure.
-Use --skip-validation to bypass validation (not recommended).
-
 After upload, use --activate to automatically activate the new version.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -235,21 +233,16 @@ After upload, use --activate to automatically activate the new version.`,
 			}
 
 			// Get flags
-			skipValidation, _ := cmd.Flags().GetBool("skip-validation")
 			activate, _ := cmd.Flags().GetBool("activate")
 			verbose, _ := cmd.Flags().GetBool("verbose")
 
-			// Validate bundle structure (unless skipped)
-			if !skipValidation {
-				color.Cyan("Validating bundle structure...")
-				if err := validation.ValidateBundle(bundlePath); err != nil {
-					cmd.SilenceUsage = true
-					return fmt.Errorf("bundle validation failed: %w", err)
-				}
-				color.Green("✓ Bundle structure is valid")
-			} else {
-				color.Yellow("⚠ Skipping validation (not recommended)")
+			// Validate bundle structure
+			color.Cyan("Validating bundle structure...")
+			if err := validation.ValidateBundle(bundlePath); err != nil {
+				cmd.SilenceUsage = true
+				return fmt.Errorf("bundle validation failed: %w", err)
 			}
+			color.Green("✓ Bundle structure is valid")
 
 			// Show bundle info
 			if verbose {
@@ -342,7 +335,6 @@ After upload, use --activate to automatically activate the new version.`,
 			return nil
 		},
 	}
-	uploadCmd.Flags().Bool("skip-validation", false, "Skip bundle validation before upload (not recommended)")
 	uploadCmd.Flags().BoolP("activate", "a", false, "Automatically activate the uploaded version")
 	uploadCmd.Flags().BoolP("verbose", "v", false, "Show detailed information about the bundle and manifest")
 	appBundleCmd.AddCommand(uploadCmd)


### PR DESCRIPTION
# Pull Request Title

chore(synkronus-cli): remove deprecated skip-validation flag

## Description

This PR removes the `--skip-validation` flag from the `synk app-bundle upload` command.  
The flag allowed bypassing local bundle validation, but server-side validation still rejected invalid bundles, meaning the documented behavior (invalid bundle appearing in versions list) could never be achieved. For this release, we standardize behavior so that all uploads must pass local validation before being sent to the server.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [x] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [ ] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [x] **synkronus-cli** (Command-line utility)
- [x] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:**

---

## Related Issue(s)

**Closes/Fixes/Resolves:** Closes #492  
(Related to test case #387: Upload App Bundle with `--skip-validation` Flag)

---

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
  - Verified `synk app-bundle upload` still validates and uploads a valid bundle successfully.
  - Verified `synk app-bundle upload` no longer accepts the `--skip-validation` flag.
- [ ] Tested on multiple platforms (if applicable)
- [ ] Not applicable

---

## Breaking Changes

- [x] This PR introduces breaking changes
- [ ] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:**

- The `--skip-validation` flag on `synk app-bundle upload` has been removed.
- Any scripts or documentation that previously used:
  - `synk app-bundle upload bundle.zip --skip-validation`
- Must be updated to:
  - `synk app-bundle upload bundle.zip`
- All bundles must now pass local validation before upload.

---

## Documentation Updates

- [x] Documentation has been updated
  - Removed the `--skip-validation` usage example from `synkronus-cli/README.md`.
- [ ] Documentation update is not required

---

## Checklist

- [x] Code follows project style guidelines
- [x] All existing tests pass (CLI builds successfully)
- [ ] New tests added for new functionality
- [x] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**