### PR TITLE
fix(synkronus-portal): handle expired sessions and change-password auth

### DIFF
--- a/synkronus-portal/src/pages/Dashboard.tsx
+++ b/synkronus-portal/src/pages/Dashboard.tsx
@@ -1000,6 +1000,13 @@ export function Dashboard() {
                     <HiPlus /> Create User
                   </Button>
                   <Button
+                    variant="secondary"
+                    onPress={handleOpenChangePasswordModal}
+                    disabled={loading}
+                    className="change-password-button">
+                    <HiKey /> Change my password
+                  </Button>
+                  <Button
                     variant="neutral"
                     onPress={loadUsers}
                     disabled={loading}

--- a/synkronus-portal/src/services/api.ts
+++ b/synkronus-portal/src/services/api.ts
@@ -59,8 +59,21 @@ async function request<T>(
         errorMessage = response.statusText || errorMessage;
       }
 
+      // Session expiration handling for any non-login 401
+      if (response.status === 401 && endpoint !== '/auth/login') {
+        // Clear stored auth and force a reload so ProtectedRoute shows Login
+        localStorage.removeItem('token');
+        localStorage.removeItem('refreshToken');
+        localStorage.removeItem('user');
+        localStorage.removeItem('expiresAt');
+        // Best-effort redirect to root; ProtectedRoute will render Login
+        window.location.href = '/';
+        throw new Error('Your session has expired. Please log in again.');
+      }
+
       // Provide more specific error messages
       if (response.status === 401) {
+        // For login or explicit auth failures, keep a clear auth error
         errorMessage = errorMessage || 'Invalid username or password';
       } else if (response.status === 0 || response.status >= 500) {
         errorMessage = 'Server error: Please check if the API is running';
@@ -238,6 +251,17 @@ export const api = {
       } catch {
         errorMessage = response.statusText || errorMessage;
       }
+
+      // Handle expired/invalid session here as well
+      if (response.status === 401) {
+        localStorage.removeItem('token');
+        localStorage.removeItem('refreshToken');
+        localStorage.removeItem('user');
+        localStorage.removeItem('expiresAt');
+        window.location.href = '/';
+        throw new Error('Your session has expired. Please log in again.');
+      }
+
       throw new Error(errorMessage);
     }
 

--- a/synkronus/internal/handlers/user.go
+++ b/synkronus/internal/handlers/user.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/opendataensemble/synkronus/internal/models"
+	"github.com/opendataensemble/synkronus/pkg/middleware/auth"
 	"github.com/opendataensemble/synkronus/pkg/user"
 )
 
@@ -130,13 +131,13 @@ func (h *Handler) ChangePasswordHandler(w http.ResponseWriter, r *http.Request) 
 		SendErrorResponse(w, http.StatusBadRequest, nil, "Missing required fields")
 		return
 	}
-	// Get username from context (set by auth middleware)
-	username, ok := r.Context().Value("username").(string)
-	if !ok || username == "" {
+	// Get user from context (set by auth middleware)
+	u := auth.GetUserFromContext(r.Context())
+	if u == nil || u.Username == "" {
 		SendErrorResponse(w, http.StatusUnauthorized, nil, "Unauthorized")
 		return
 	}
-	err := h.userService.ChangePassword(r.Context(), username, req.CurrentPassword, req.NewPassword)
+	err := h.userService.ChangePassword(r.Context(), u.Username, req.CurrentPassword, req.NewPassword)
 	if err != nil {
 		SendErrorResponse(w, http.StatusUnauthorized, err, err.Error())
 		return

--- a/synkronus/internal/handlers/user_test.go
+++ b/synkronus/internal/handlers/user_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opendataensemble/synkronus/internal/handlers/mocks"
 	"github.com/opendataensemble/synkronus/internal/models"
 	"github.com/opendataensemble/synkronus/pkg/logger"
+	"github.com/opendataensemble/synkronus/pkg/middleware/auth"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -198,10 +199,7 @@ func TestChangePasswordHandler(t *testing.T) {
 			r := httptest.NewRequest(http.MethodPost, "/users/change-password", bytes.NewReader(body))
 			ctx := r.Context()
 			if tc.username != "" {
-				// Using string as context key is required for test compatibility with the handler
-				//revive:disable-next-line:context-keys-type
-				//nolint:gocritic,golint,staticcheck,revive
-				ctx = context.WithValue(ctx, "username", tc.username) //nolint:staticcheck
+				ctx = context.WithValue(ctx, auth.UserKey, &models.User{Username: tc.username, Role: models.RoleReadOnly})
 			}
 			r = r.WithContext(ctx)
 			w := httptest.NewRecorder()


### PR DESCRIPTION
# Pull Request Title

fix(synkronus-portal): handle expired sessions and change-password auth

## Description

This PR fixes password-change behavior for non-admin users and ensures the Synkronus portal UI stays in sync with real authentication state.

- Replaced the ad-hoc `"username"` context lookup in `ChangePasswordHandler` with `auth.GetUserFromContext`, using the user injected by the auth middleware.
- Updated the change-password handler test to set the user in context via `auth.UserKey` instead of a raw `"username"` string.
- Added a **Change Password** / **Change my password** button in the Dashboard (including for admins under the Users tab) wired to the existing change-password flow.
- Enhanced the portal API error handling so that 401 responses (for non-login requests and bundle downloads) are treated as **session expiration**:
  - Clears stored auth (token, refreshToken, user, expiresAt).
  - Redirects to `/`, allowing `ProtectedRoute` to render the Login screen with a clear “session expired, please log in again” experience.

## Type of Change

- [x] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [x] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [ ] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [x] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [x] **Other:** synkronus-portal (web portal)

---

## Related Issue(s)

**Closes/Fixes/Resolves:** <!-- e.g., Closes #NNN; fill in the actual IDs -->
- Fixes #486
- Addresses stale “logged-in” portal UI when the underlying JWT has expired.

---

## Testing

- [x] Unit tests added/updated
  - Updated `TestChange