### PR TITLE
feat(formulus): Filter out soft-deleted observations in WatermelonDBRepo and related hooks/services

### DIFF
--- a/formulus/scripts/syncNativeVersion.js
+++ b/formulus/scripts/syncNativeVersion.js
@@ -93,13 +93,13 @@ function syncNativeVersions() {
     console.log('✓ Native version sync complete');
   } catch (error) {
     console.error('✗ Failed to sync native versions:', error);
-    // eslint-disable-next-line no-undef
+
     process.exit(1);
   }
 }
 
 // Run if executed directly
-// eslint-disable-next-line no-undef
+
 if (import.meta.url === `file://${process.argv[1]}`) {
   syncNativeVersions();
 }

--- a/formulus/src/database/repositories/WatermelonDBRepo.ts
+++ b/formulus/src/database/repositories/WatermelonDBRepo.ts
@@ -206,13 +206,12 @@ export class WatermelonDBRepo implements LocalRepoInterface {
         return [];
       }
 
-      // First, let's check all observations in the database for debugging
-      const allObservations = await this.observationsCollection.query().fetch();
-      console.log(`Total observations in database: ${allObservations.length}`);
-
-      // Query for observations with form_type matching the requested form type
+      // Query for observations with form_type matching and exclude soft-deleted
       const observations = await this.observationsCollection
-        .query(Q.where('form_type', formId))
+        .query(
+          Q.where('form_type', formId),
+          Q.where('deleted', false),
+        )
         .fetch();
 
       return observations.map(observation =>

--- a/formulus/src/database/repositories/WatermelonDBRepo.ts
+++ b/formulus/src/database/repositories/WatermelonDBRepo.ts
@@ -208,10 +208,7 @@ export class WatermelonDBRepo implements LocalRepoInterface {
 
       // Query for observations with form_type matching and exclude soft-deleted
       const observations = await this.observationsCollection
-        .query(
-          Q.where('form_type', formId),
-          Q.where('deleted', false),
-        )
+        .query(Q.where('form_type', formId), Q.where('deleted', false))
         .fetch();
 
       return observations.map(observation =>

--- a/formulus/src/hooks/useObservations.ts
+++ b/formulus/src/hooks/useObservations.ts
@@ -62,7 +62,7 @@ export const useObservations = (): UseObservationsResult => {
   }, [loadObservations]);
 
   const filteredAndSorted = useMemo(() => {
-    let filtered = [...observations];
+    let filtered = observations.filter(obs => !obs.deleted);
 
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();

--- a/formulus/src/services/FormService.ts
+++ b/formulus/src/services/FormService.ts
@@ -280,6 +280,10 @@ export class FormService {
       options.formType,
     );
 
+    if (!options.includeDeleted) {
+      observations = observations.filter(o => !o.deleted);
+    }
+
     if (options.whereClause && options.whereClause.trim()) {
       observations = this.filterObservationsByWhereClause(
         observations,

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -289,8 +289,8 @@ export interface FormulusInterface {
   /**
    * Get observations for a specific form
    * @param {string} formType - The identifier of the formtype
-   * @param {boolean} [isDraft=false] - Whether to include draft observations
-   * @param {boolean} [includeDeleted=false] - Whether to include deleted observations
+   * @param {boolean} [isDraft=false] - Deprecated: drafts are handled only in formplayer; ignored in Formulus
+   * @param {boolean} [includeDeleted=false] - Whether to include deleted observations (default false = exclude)
    * @returns {Promise<FormObservation[]>} Array of form observations
    */
   getObservations(
@@ -305,7 +305,7 @@ export interface FormulusInterface {
    * Age filtering via age_from_dob(data.dob) is handled client-side in formplayer.
    * @param options - Query options
    * @param options.formType - Form type to query
-   * @param options.isDraft - Include drafts (default false)
+   * @param options.isDraft - Deprecated: drafts handled in formplayer; ignored
    * @param options.includeDeleted - Include deleted (default false)
    * @param options.whereClause - SQL-like WHERE clause for filtering (e.g. "data.sex = 'male'")
    * @returns {Promise<FormObservation[]>} Array of filtered observations

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -1056,8 +1056,11 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
       }
 
       const service = await FormService.getInstance();
-      //TODO: Handle deleted etc.
-      return await service.getObservationsByFormType(formTypeString);
+      // Use getObservationsByQuery so includeDeleted is respected (default false = exclude deleted)
+      return await service.getObservationsByQuery({
+        formType: formTypeString,
+        includeDeleted: includeDeleted ?? false,
+      });
     },
     onGetObservationsByQuery: async (payload: {
       options?: {


### PR DESCRIPTION
## Description

Observations are soft-deleted (a `deleted` flag is set); the record stays in the database. List APIs and the UI were not filtering by this flag, so deleted observations still appeared on the Observations screen and in formplayer/choice lists.

**Changes:**

- **WatermelonDBRepo:** `getObservationsByFormType()` now includes `Q.where('deleted', false)` so only non-deleted observations are returned. Removed the temporary debug log that printed total observation count.
- **FormService:** In `getObservationsByQuery()`, when `includeDeleted` is not set, results are filtered to exclude observations with `deleted === true`, so choice lists and formplayer only see active observations by default.
- **useObservations:** The observations list now excludes any observation with `obs.deleted === true` so the Observations screen never shows soft-deleted items.

Delete behavior is unchanged: the record is only updated with `deleted = true`; it is not removed from the database. List and detail screens now consistently hide deleted observations.

## Type of Change

- [x] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [x] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:**

---

## Related Issue(s)

**Closes/Fixes/Resolves:** Closes #495

---

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
- [ ] Tested on multiple platforms (if applicable)
- [ ] Not applicable

---

## Breaking Changes

- [ ] This PR introduces breaking changes
- [x] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:** N/A

---

## Documentation Updates

- [ ] Documentation has been updated
- [x] Documentation update is not required

---

## Checklist

- [x] Code follows project style guidelines
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [x] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**