### PR TITLE
fix(synkronus-cli): normalize API URL (scheme + trailing slash)

### DIFF
--- a/synkronus-cli/internal/auth/auth.go
+++ b/synkronus-cli/internal/auth/auth.go
@@ -6,11 +6,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/OpenDataEnsemble/ode/synkronus-cli/internal/utils"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/spf13/viper"
 )
+
+// normalizeBaseURL trims trailing slashes to avoid double slashes when joining paths.
+func normalizeBaseURL(base string) string {
+	return strings.TrimRight(base, "/")
+}
 
 // TokenResponse represents the response from the authentication endpoint
 type TokenResponse struct {
@@ -28,7 +35,7 @@ type Claims struct {
 
 // Login authenticates with the Synkronus API and returns a token
 func Login(username, password string) (*TokenResponse, error) {
-	apiURL := viper.GetString("api.url")
+	apiURL := normalizeBaseURL(utils.EnsureScheme(viper.GetString("api.url")))
 	loginURL := fmt.Sprintf("%s/auth/login", apiURL)
 
 	// Prepare login request
@@ -90,7 +97,7 @@ func Login(username, password string) (*TokenResponse, error) {
 
 // RefreshToken refreshes the JWT token
 func RefreshToken() (*TokenResponse, error) {
-	apiURL := viper.GetString("api.url")
+	apiURL := normalizeBaseURL(utils.EnsureScheme(viper.GetString("api.url")))
 	refreshURL := fmt.Sprintf("%s/auth/refresh", apiURL)
 	refreshToken := viper.GetString("auth.refresh_token")
 

--- a/synkronus-cli/internal/cmd/health.go
+++ b/synkronus-cli/internal/cmd/health.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/OpenDataEnsemble/ode/synkronus-cli/internal/utils"
@@ -16,7 +17,7 @@ func init() {
 		Short: "Check the health of the Synkronus API",
 		Long:  `Verify connectivity to the Synkronus API server.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			apiURL := viper.GetString("api.url")
+			apiURL := strings.TrimRight(utils.EnsureScheme(viper.GetString("api.url")), "/")
 
 			utils.PrintInfo("Checking API health at %s...", apiURL)
 

--- a/synkronus-cli/internal/utils/url.go
+++ b/synkronus-cli/internal/utils/url.go
@@ -1,0 +1,16 @@
+package utils
+
+import "strings"
+
+// EnsureScheme prepends https:// to the URL if it has no scheme (http:// or https://).
+// Used so users can set api.url to "misha.synkronus.cloud" and the CLI still works.
+func EnsureScheme(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return raw
+	}
+	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") {
+		return raw
+	}
+	return "https://" + raw
+}

--- a/synkronus-cli/pkg/client/client.go
+++ b/synkronus-cli/pkg/client/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/OpenDataEnsemble/ode/synkronus-cli/internal/auth"
+	"github.com/OpenDataEnsemble/ode/synkronus-cli/internal/utils"
 	"github.com/spf13/viper"
 )
 
@@ -65,8 +66,9 @@ type Client struct {
 
 // NewClient creates a new Synkronus API client
 func NewClient() *Client {
+	baseURL := strings.TrimRight(utils.EnsureScheme(viper.GetString("api.url")), "/")
 	return &Client{
-		BaseURL:    viper.GetString("api.url"),
+		BaseURL:    baseURL,
 		APIVersion: viper.GetString("api.version"),
 		HTTPClient: &http.Client{
 			Timeout: time.Second * 30,


### PR DESCRIPTION
## Description

Improves API URL handling so login and other commands work when `api.url` is set without a scheme or with a trailing slash.

- **`normalizeBaseURL`** (in `internal/auth/auth.go`) trims trailing slashes from the base URL so paths like `/auth/login` are not built with a double slash (e.g. `https://host//auth/login`), which was causing 405 responses (fixes **#515**).
- **`EnsureScheme`** (in `internal/utils/url.go`) prepends `https://` when the URL has no scheme, so values like `misha.synkronus.cloud` work without users adding the scheme (fixes **#511**).
- **Usage:** Login, RefreshToken, `NewClient()` (all API calls), and the health check now use these helpers so the same normalized URL is used everywhere.

## Type of Change

- [x] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [ ] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [x] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:**

---

## Related Issue(s)

**Closes/Fixes/Resolves:** Closes #515, Closes #511

---

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
- [ ] Tested on multiple platforms (if applicable)
- [ ] Not applicable

---

## Breaking Changes

- [ ] This PR introduces breaking changes
- [x] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:** N/A

---

## Documentation Updates

- [ ] Documentation has been updated
- [x] Documentation update is not required

---

## Checklist

- [x] Code follows project style guidelines
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [x] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**