### PR TITLE
fix(formulus): sync screen shows correct pending status 

### DIFF
--- a/formulus/src/database/repositories/WatermelonDBRepo.ts
+++ b/formulus/src/database/repositories/WatermelonDBRepo.ts
@@ -477,14 +477,16 @@ export class WatermelonDBRepo implements LocalRepoInterface {
   }
 
   /**
-   * Get pending changes from the local database
-   * @returns Promise resolving to an array of pending changes
+   * Get pending changes from the local database (unsynced or updated after last sync).
+   * Includes new, updated, and soft-deleted records so sync can push them to the server.
+   * synced_at can be null or 0 when never synced depending on storage.
    */
   getPendingChanges(): Promise<Observation[]> {
     return this.observationsCollection
       .query(
         Q.or(
           Q.where('synced_at', Q.eq(null)),
+          Q.where('synced_at', 0),
           Q.where('updated_at', Q.gt(Q.column('synced_at'))),
         ),
       )

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -11,6 +11,7 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useFocusEffect } from '@react-navigation/native';
 import Icon from '@react-native-vector-icons/material-design-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { formatRelativeTime } from '../utils/dateUtils';
@@ -313,6 +314,14 @@ const SyncScreen = () => {
     updatePendingObservations,
     updateProgress,
   ]);
+
+  // Refresh pending count whenever the Sync screen gains focus so it stays in sync after creating observations
+  useFocusEffect(
+    useCallback(() => {
+      updatePendingUploads();
+      updatePendingObservations();
+    }, [updatePendingUploads, updatePendingObservations]),
+  );
 
   useEffect(() => {
     if (!syncState.progress || !syncState.isActive) {


### PR DESCRIPTION
## Description

Fixes the sync screen showing "All synced" when there are unsynced observations ([#517](https://github.com/OpenDataEnsemble/ode/issues/517)).

**Problem:** After creating an observation and opening the Sync tab, the app could still show "All synced" and 0 pending. The count sometimes updated only later.

**Cause:**
1. Pending count was only updated on initial mount, not when returning to the Sync screen.
2. New observations can have `synced_at` stored as `0` instead of `null`; the pending query only checked for `null`.

**Changes:**
- **SyncScreen:** Use `useFocusEffect` to run `updatePendingUploads()` and `updatePendingObservations()` whenever the Sync screen gains focus, so the status and counts stay correct after creating observations or switching tabs.
- **WatermelonDBRepo.getPendingChanges():** Add `Q.where('synced_at', 0)` next to the existing `Q.eq(null)` so never-synced observations are included whether the DB stores `synced_at` as null or 0. Comment updated to describe what “pending” includes.

## Type of Change

- [x] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [x] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:**

---

## Related Issue(s)

**Closes/Fixes/Resolves:** Closes #517

---

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
- [ ] Tested on multiple platforms (if applicable)
- [ ] Not applicable

---

## Breaking Changes

- [ ] This PR introduces breaking changes
- [x] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:** N/A

---

## Documentation Updates

- [ ] Documentation has been updated
- [x] Documentation update is not required

---

## Checklist

- [x] Code follows project style guidelines
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [x] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**