### PR TITLE
feat: Speed Up Settings first-load Spinner

### DIFF
--- a/formulus/src/components/BlurredScreenBackground.tsx
+++ b/formulus/src/components/BlurredScreenBackground.tsx
@@ -63,6 +63,12 @@ const EdgeDarkeningOverlay = () => {
 
 interface BlurredScreenBackgroundProps {
   children: React.ReactNode;
+  /**
+   * Speeds up initial loading screens by skipping expensive blur/SVG work.
+   * Useful when we're showing an ActivityIndicator and haven't rendered
+   * the final content yet.
+   */
+  disableBlur?: boolean;
 }
 
 /**
@@ -73,6 +79,7 @@ interface BlurredScreenBackgroundProps {
  */
 const BlurredScreenBackground: React.FC<BlurredScreenBackgroundProps> = ({
   children,
+  disableBlur = false,
 }) => {
   const { resolvedMode } = useAppTheme();
   const isDark = resolvedMode === 'dark';
@@ -80,9 +87,11 @@ const BlurredScreenBackground: React.FC<BlurredScreenBackgroundProps> = ({
     ? welcomeBgDark
     : welcomeBgLight;
   const overlayColor = isDark ? colors.neutral.black : colors.neutral.white;
-  const blurRadius = isDark
-    ? backgroundConfig.blurRadiusDark
-    : backgroundConfig.blurRadiusLight;
+  const blurRadius = disableBlur
+    ? 0
+    : isDark
+      ? backgroundConfig.blurRadiusDark
+      : backgroundConfig.blurRadiusLight;
 
   return (
     <View style={[styles.root, { backgroundColor: 'transparent' }]}>
@@ -100,7 +109,7 @@ const BlurredScreenBackground: React.FC<BlurredScreenBackgroundProps> = ({
             },
           ]}
         />
-        {isDark && <EdgeDarkeningOverlay />}
+        {!disableBlur && isDark && <EdgeDarkeningOverlay />}
         <View style={styles.contentSlot}>{children}</View>
       </ImageBackground>
     </View>

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -214,13 +214,14 @@ const SettingsScreen = () => {
 
   const loadSettings = async () => {
     try {
-      const savedUrl = await serverConfigService.getServerUrl();
+      const [savedUrl, credentials] = await Promise.all([
+        serverConfigService.getServerUrl(),
+        Keychain.getGenericPassword(),
+      ]);
       if (savedUrl) {
         setServerUrl(savedUrl);
         setInitialServerUrl(savedUrl);
       }
-
-      const credentials = await Keychain.getGenericPassword();
       if (credentials) {
         setUsername(credentials.username);
         setPassword(credentials.password);
@@ -350,7 +351,7 @@ const SettingsScreen = () => {
 
   if (isLoading) {
     return (
-      <BlurredScreenBackground>
+      <BlurredScreenBackground disableBlur>
         <View
           style={[
             styles.container,


### PR DESCRIPTION
## Summary
Settings screen sometimes showed a long loading spinner on first app launch.

## Cause
- `SettingsScreen` waited on AsyncStorage + `Keychain.getGenericPassword()` (secure storage can be slow on first access).
- While loading, it also rendered `BlurredScreenBackground` with image blur + dark-mode overlay, adding extra render cost.

## Fix
- Load server URL and Keychain credentials in parallel (`Promise.all`).
- Disable expensive blur/overlay rendering while `SettingsScreen` is in the loading state.