### PR TITLE
feat(formulus): aligning headers …

### DIFF
--- a/formulus/src/screens/AboutScreen.tsx
+++ b/formulus/src/screens/AboutScreen.tsx
@@ -65,24 +65,27 @@ const AboutScreen: React.FC = () => {
               borderBottomColor: themeColors.divider as string,
             },
           ]}>
-          <Text
-            style={[styles.title, { color: themeColors.onPrimary as string }]}>
-            About
-          </Text>
+          <View style={styles.logoContainer}>
+            <View
+              style={[
+                styles.logoWrapper,
+                { borderColor: themeColors.onPrimary as string },
+              ]}>
+              <Image source={logo} style={styles.logo} resizeMode="contain" />
+            </View>
+            <Text
+              style={[
+                styles.title,
+                { color: themeColors.onPrimary as string },
+              ]}>
+              About
+            </Text>
+          </View>
         </View>
 
         <ScrollView
           style={styles.scrollTransparent}
           contentContainerStyle={styles.content}>
-          <View style={styles.brandRow}>
-            <View style={styles.logoWrapper}>
-              <Image source={logo} style={styles.logo} resizeMode="contain" />
-            </View>
-            <Text style={[styles.appName, { color: themeColors.onSurface }]}>
-              ODE
-            </Text>
-          </View>
-
           <View style={cardStyle}>
             <Text style={[styles.cardTitle, { color: sectionColor }]}>
               Formulus
@@ -170,35 +173,30 @@ const styles = StyleSheet.create({
     marginBottom: odeSpacing.xs,
     textAlign: 'left',
   },
+  logoContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+  },
   content: {
     padding: odeSpacing.md,
     paddingBottom: odeSpacing.xl,
   },
-  brandRow: {
-    alignItems: 'center',
-    marginBottom: odeSpacing.md,
-    gap: odeSpacing.xs,
-  },
   logoWrapper: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
     borderWidth: 1,
-    borderColor: colors.brand.primary[500] as string,
     justifyContent: 'center',
     alignItems: 'center',
+    marginRight: 12,
     overflow: 'hidden',
     backgroundColor: 'transparent',
   },
   logo: {
-    width: 56,
-    height: 56,
+    width: 40,
+    height: 40,
     backgroundColor: 'transparent',
-  },
-  appName: {
-    fontSize: odeTypography.sectionTitle,
-    fontWeight: '700',
-    textAlign: 'center',
   },
   version: {
     marginTop: odeSpacing.xxs,

--- a/formulus/src/screens/HelpScreen.tsx
+++ b/formulus/src/screens/HelpScreen.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   Linking,
   Pressable,
+  Image,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import colors from '../theme/colors';
@@ -18,6 +19,7 @@ import {
   odeRadius,
   odeScreenHeaderHeight,
 } from '../theme/odeDesign';
+import logo from '../../assets/images/logo.png';
 
 const FORUM_URL = 'https://forum.opendataensemble.org';
 
@@ -48,10 +50,22 @@ const HelpScreen: React.FC = () => {
               borderBottomColor: themeColors.divider as string,
             },
           ]}>
-          <Text
-            style={[styles.title, { color: themeColors.onPrimary as string }]}>
-            Help & Support
-          </Text>
+          <View style={styles.logoContainer}>
+            <View
+              style={[
+                styles.logoWrapper,
+                { borderColor: themeColors.onPrimary as string },
+              ]}>
+              <Image source={logo} style={styles.logo} resizeMode="contain" />
+            </View>
+            <Text
+              style={[
+                styles.title,
+                { color: themeColors.onPrimary as string },
+              ]}>
+              Help & Support
+            </Text>
+          </View>
         </View>
 
         <ScrollView
@@ -133,6 +147,27 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: odeSpacing.xs,
     textAlign: 'left',
+  },
+  logoContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+  },
+  logoWrapper: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    borderWidth: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+    overflow: 'hidden',
+    backgroundColor: 'transparent',
+  },
+  logo: {
+    width: 40,
+    height: 40,
+    backgroundColor: 'transparent',
   },
   content: {
     padding: odeSpacing.md,

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -374,7 +374,7 @@ const SettingsScreen = () => {
               <Image source={Logo} style={styles.logo} resizeMode="contain" />
             </View>
             <Text style={[styles.brandName, { color: themeColors.onPrimary }]}>
-              ODE
+              Settings
             </Text>
           </View>
         </View>


### PR DESCRIPTION
# Summary

- Added the app logo to the **About** and **Help & Support** header sections to match the **Settings** header style.
- Removed the duplicate logo/ODE block from the About screen content area.
- Renamed the Settings header title from "ODE" to "Settings".