### PR TITLE
feat: settings screen init

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -92,6 +92,7 @@ The workflow intelligently handles formplayer assets using two jobs:
 
 2. **`build-android` job** (depends on assets job):
    - Downloads the Formplayer assets artifact into `formulus/android/app/src/main/assets/formplayer_dist/`
+   - Runs `npm run vendor:notifee` in `formulus/` to clone the pinned [invertase/notifee](https://github.com/invertase/notifee) commit into `third_party/notifee` (gitignored; required for Gradle `:notifee_core`)
    - Builds the Android APK (debug for PRs, release for main/dev/release events)
 
 Formplayer assets are **not committed to git** and are ignored via `.gitignore`. CI builds always use the assets artifact produced in the same workflow run, ensuring a single, consistent source of truth for each build.

--- a/.github/workflows/formulus-android.yml
+++ b/.github/workflows/formulus-android.yml
@@ -115,6 +115,10 @@ jobs:
         working-directory: formulus
         run: npm ci
 
+      - name: Vendor Notifee Android core (source build; dir is gitignored)
+        working-directory: formulus
+        run: npm run vendor:notifee
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:

--- a/formulus/.gitignore
+++ b/formulus/.gitignore
@@ -42,6 +42,9 @@ android/app/src/main/assets/webview/
 assets/webview/formplayer_dist/
 ios/formplayer_dist/
 
+# Vendored notifee monorepo (npm run vendor:notifee); pin commit in scripts/vendor-notifee-core.mjs
+third_party/notifee/
+
 # node.js
 #
 node_modules/

--- a/formulus/README.md
+++ b/formulus/README.md
@@ -24,6 +24,14 @@ With Metro running, open a new terminal window/pane from the root of your React 
 
 ### Android
 
+Before the first Android build (and after cloning the repo), vendor the **Notifee** native core so Gradle compiles it from source instead of downloading `app.notifee:core` (needed for [F-Droid](https://f-droid.org/) and avoids the `notifee.app` Maven repo):
+
+```sh
+npm run vendor:notifee
+```
+
+Then:
+
 ```sh
 # Using npm
 npm run android
@@ -31,6 +39,8 @@ npm run android
 # OR using Yarn
 yarn android
 ```
+
+See `third_party/README.md` for pinning the vendored commit when you upgrade `@notifee/react-native`.
 
 ### iOS
 

--- a/formulus/android/build.gradle
+++ b/formulus/android/build.gradle
@@ -25,7 +25,6 @@ allprojects {
         google()
         mavenCentral()
         maven { url 'https://www.jitpack.io' }
-        maven { url 'https://notifee.app/maven' }
-        maven { url "$rootDir/../node_modules/@notifee/react-native/android/libs" }
+        // Notifee prebuilt core + notifee.app Maven omitted — Android core is :notifee_core from third_party/notifee (npm run vendor:notifee).
     }
 }

--- a/formulus/android/settings.gradle
+++ b/formulus/android/settings.gradle
@@ -6,5 +6,8 @@ include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')
 include ':watermelondb-jsi'
 project(':watermelondb-jsi').projectDir = new File(rootProject.projectDir, '../node_modules/@nozbe/watermelondb/native/android-jsi')
+// Build app.notifee core from source (see npm run vendor:notifee). Must be before :notifee_react-native.
+include ':notifee_core'
+project(':notifee_core').projectDir = new File(rootProject.projectDir, '../third_party/notifee/android')
 include ':notifee_react-native'
 project(':notifee_react-native').projectDir = new File(rootProject.projectDir, '../node_modules/@notifee/react-native/android')

--- a/formulus/eslint.config.js
+++ b/formulus/eslint.config.js
@@ -58,7 +58,7 @@ export default tseslint.config(
   },
   prettierConfig,
   {
-    files: ['scripts/**/*.js'],
+    files: ['scripts/**/*.{js,mjs}'],
     languageOptions: {
       globals: {
         ...globals.node,

--- a/formulus/package-lock.json
+++ b/formulus/package-lock.json
@@ -2123,7 +2123,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2136,7 +2136,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2159,7 +2159,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
       "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2171,7 +2170,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2182,7 +2180,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
       "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3369,7 +3366,6 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3660,7 +3656,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5207,35 +5202,34 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5766,7 +5760,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5780,7 +5773,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5794,7 +5786,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5808,7 +5799,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5822,7 +5812,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5836,7 +5825,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5850,7 +5838,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5864,7 +5851,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5878,7 +5864,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5892,7 +5877,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5906,7 +5890,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5920,7 +5903,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5934,7 +5916,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5948,7 +5929,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5962,7 +5942,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5976,7 +5955,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5993,7 +5971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6007,7 +5984,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6021,7 +5997,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6104,7 +6079,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -6244,7 +6219,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -7403,7 +7378,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -7723,7 +7698,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -11943,7 +11918,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -15947,7 +15922,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -16142,7 +16117,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -16421,7 +16396,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -16795,7 +16770,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/formulus/package.json
+++ b/formulus/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "preandroid": "npm run vendor:notifee",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint . --max-warnings 9999",
@@ -16,6 +17,7 @@
     "generate:api": "openapi-generator-cli generate -i ../synkronus/openapi/synkronus.yaml -g typescript-axios -o src/api/synkronus/generated --additional-properties=supportsES6=true,useSingleRequestParameter=true,modelPropertyNaming=original",
     "generate_qr": "ts-node --project scripts/tsconfig.json scripts/generateQR.ts",
     "sync:version": "node scripts/syncNativeVersion.js",
+    "vendor:notifee": "node scripts/vendor-notifee-core.mjs",
     "prebuild": "npm run sync:version && npm run generate"
   },
   "dependencies": {

--- a/formulus/scripts/vendor-notifee-core.mjs
+++ b/formulus/scripts/vendor-notifee-core.mjs
@@ -1,0 +1,57 @@
+/**
+ * Vendors invertase/notifee Android core sources into third_party/notifee
+ * so Gradle can compile :notifee_core from source (F-Droid / no app.notifee:core Maven).
+ *
+ * Pinned to the same commit npm published for @notifee/react-native — bump both together.
+ */
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, '..');
+const dest = path.join(repoRoot, 'third_party', 'notifee');
+
+/** Must match https://registry.npmjs.org/@notifee/react-native/<version> → gitHead */
+const NOTIFEE_COMMIT = 'f00a8e2702ea980455362ac18f84080093dcf32d';
+const REMOTE = 'https://github.com/invertase/notifee.git';
+
+function sh(cmd, opts = {}) {
+  execSync(cmd, { stdio: 'inherit', ...opts });
+}
+
+function headAt(destDir) {
+  try {
+    return execSync('git rev-parse HEAD', {
+      cwd: destDir,
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+if (!fs.existsSync(path.join(dest, 'android', 'build.gradle'))) {
+  fs.mkdirSync(dest, { recursive: true });
+  if (!fs.existsSync(path.join(dest, '.git'))) {
+    sh('git init', { cwd: dest });
+    sh(`git remote add origin ${REMOTE}`, { cwd: dest });
+  }
+  console.log(`Fetching notifee@${NOTIFEE_COMMIT} ...`);
+  sh(`git fetch --depth 1 origin ${NOTIFEE_COMMIT}`, { cwd: dest });
+  sh('git checkout FETCH_HEAD', { cwd: dest });
+  console.log('notifee core ready.');
+  process.exit(0);
+}
+
+const head = headAt(dest);
+if (head === NOTIFEE_COMMIT) {
+  console.log(`notifee core already at ${NOTIFEE_COMMIT}`);
+  process.exit(0);
+}
+
+console.log(`Updating notifee ${head || '(unknown)'} → ${NOTIFEE_COMMIT} ...`);
+sh(`git fetch --depth 1 origin ${NOTIFEE_COMMIT}`, { cwd: dest });
+sh('git checkout FETCH_HEAD', { cwd: dest });
+console.log('notifee core ready.');

--- a/formulus/src/components/CustomAppWebView.tsx
+++ b/formulus/src/components/CustomAppWebView.tsx
@@ -16,6 +16,7 @@ import { readFileAssets, MainBundlePath, readFile } from 'react-native-fs';
 import { FormulusWebViewMessageManager } from '../webview/FormulusWebViewHandler';
 import { FormInitData } from '../webview/FormulusInterfaceDefinition';
 import { colors } from '../theme/colors';
+import { loadSettingsHydrationFromStorage } from '../services/SettingsHydrationCache';
 
 export interface CustomAppWebViewHandle {
   reload: () => void;
@@ -252,9 +253,17 @@ const CustomAppWebView = forwardRef<
             onNavigateToSyncRef.current?.();
             return;
           }
-          // Handle placeholder "Login Now" → navigate to Settings (login / server credentials / QR)
+          // Handle placeholder "Login Now" → hydrate settings cache before navigating so
+          // SettingsScreen gets a warm snapshot (same single-flight load as on-screen prefetch).
           if (eventData.type === 'formulusNavigateToSettings') {
-            onNavigateToSettingsRef.current?.();
+            void (async () => {
+              try {
+                await loadSettingsHydrationFromStorage();
+              } catch {
+                // SettingsScreen will load on mount if this fails
+              }
+              onNavigateToSettingsRef.current?.();
+            })();
             return;
           }
 

--- a/formulus/src/components/MenuDrawer.tsx
+++ b/formulus/src/components/MenuDrawer.tsx
@@ -20,6 +20,7 @@ import {
 import tokens from '@ode/tokens/dist/react-native/tokens-resolved';
 import { useAppTheme } from '../contexts/AppThemeContext';
 import Button from './common/Button';
+import { loadSettingsHydrationFromStorage } from '../services/SettingsHydrationCache';
 
 interface MenuItem {
   icon: React.ComponentProps<typeof Icon>['name'];
@@ -116,6 +117,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({
   useEffect(() => {
     if (visible) {
       getUserInfo().then(setUserInfo);
+      void loadSettingsHydrationFromStorage();
     }
   }, [visible]);
 

--- a/formulus/src/navigation/MainAppNavigator.tsx
+++ b/formulus/src/navigation/MainAppNavigator.tsx
@@ -8,6 +8,7 @@ import WelcomeScreen from '../screens/WelcomeScreen';
 import ObservationDetailScreen from '../screens/ObservationDetailScreen';
 import { MainAppStackParamList } from '../types/NavigationTypes';
 import { serverConfigService } from '../services/ServerConfigService';
+import { loadSettingsHydrationFromStorage } from '../services/SettingsHydrationCache';
 import { useAppTheme } from '../contexts/AppThemeContext';
 import { ThemeColors } from '../types/AppConfig';
 import {
@@ -106,6 +107,12 @@ const MainAppNavigator: React.FC = () => {
       checkConfig();
     }, []),
   );
+
+  useEffect(() => {
+    if (isConfigured === true) {
+      void loadSettingsHydrationFromStorage();
+    }
+  }, [isConfigured]);
 
   if (isConfigured === null) {
     return null;

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -29,6 +29,7 @@ import { syncService } from '../services/SyncService';
 import { Button } from '../components/common';
 import BlurredScreenBackground from '../components/BlurredScreenBackground';
 import Logo from '../../assets/images/logo.png';
+import { odeTypography } from '../theme/odeDesign';
 
 type SettingsScreenNavigationProp = BottomTabNavigationProp<
   MainTabParamList,
@@ -462,8 +463,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
   brandName: {
-    fontSize: 32,
-    fontWeight: '700',
+    fontSize: odeTypography.screenTitle,
+    fontWeight: 'bold',
     letterSpacing: 1,
   },
   version: {

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -32,6 +32,11 @@ import {
 } from '../theme/odeDesign';
 import { serverSwitchService } from '../services/ServerSwitchService';
 import { syncService } from '../services/SyncService';
+import {
+  getSettingsHydrationCredentialPair,
+  getSettingsHydrationSnapshot,
+  loadSettingsHydrationFromStorage,
+} from '../services/SettingsHydrationCache';
 import { Button } from '../components/common';
 import BlurredScreenBackground from '../components/BlurredScreenBackground';
 import Logo from '../../assets/images/logo.png';
@@ -50,11 +55,17 @@ const SettingsScreen = () => {
   const sectionHeaderColor = isDark
     ? (colors.neutral[200] as string)
     : (colors.neutral[800] as string);
-  const [serverUrl, setServerUrl] = useState('');
-  const [initialServerUrl, setInitialServerUrl] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [isHydrating, setIsHydrating] = useState(true);
+  const initialSnap = getSettingsHydrationSnapshot();
+  const initialCreds = getSettingsHydrationCredentialPair(initialSnap);
+  const [serverUrl, setServerUrl] = useState(() =>
+    initialSnap.ready ? (initialSnap.serverUrl ?? '') : '',
+  );
+  const [initialServerUrl, setInitialServerUrl] = useState(() =>
+    initialSnap.ready ? (initialSnap.serverUrl ?? '') : '',
+  );
+  const [username, setUsername] = useState(() => initialCreds?.username ?? '');
+  const [password, setPassword] = useState(() => initialCreds?.password ?? '');
+  const [isHydrating, setIsHydrating] = useState(() => !initialSnap.ready);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [showQRScanner, setShowQRScanner] = useState(false);
   const mountedRef = useRef(true);
@@ -67,35 +78,38 @@ const SettingsScreen = () => {
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
+
     const hydrate = async () => {
       try {
-        const [savedUrl, credentials] = await Promise.all([
-          serverConfigService.getServerUrl(),
-          Keychain.getGenericPassword(),
-        ]);
-        if (!mountedRef.current) {
+        const snap = await loadSettingsHydrationFromStorage();
+        if (cancelled || !mountedRef.current) {
           return;
         }
 
-        if (savedUrl) {
-          setInitialServerUrl(savedUrl);
-          setServerUrl(prev => (prev.trim() === '' ? savedUrl : prev));
+        if (snap.ready && snap.serverUrl) {
+          setInitialServerUrl(snap.serverUrl);
+          setServerUrl(prev => (prev.trim() === '' ? snap.serverUrl! : prev));
         }
 
-        if (credentials) {
-          setUsername(prev => (prev.trim() === '' ? credentials.username : prev));
-          setPassword(prev => (prev.trim() === '' ? credentials.password : prev));
+        const creds = getSettingsHydrationCredentialPair(snap);
+        if (creds) {
+          setUsername(prev => (prev.trim() === '' ? creds.username : prev));
+          setPassword(prev => (prev.trim() === '' ? creds.password : prev));
         }
       } catch (error) {
         console.error('Failed to load settings:', error);
       } finally {
-        if (mountedRef.current) {
+        if (!cancelled && mountedRef.current) {
           setIsHydrating(false);
         }
       }
     };
 
     hydrate();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleServerSwitchIfNeeded = useCallback(
@@ -267,6 +281,7 @@ const SettingsScreen = () => {
 
       await Keychain.setGenericPassword(trimmedUsername, trimmedPassword);
       await login(trimmedUsername, trimmedPassword);
+      void loadSettingsHydrationFromStorage();
       ToastService.showShort('Successfully logged in!');
       navigation.navigate('Sync');
     } catch (error) {
@@ -321,6 +336,7 @@ const SettingsScreen = () => {
           );
           try {
             await login(settings.username, settings.password);
+            void loadSettingsHydrationFromStorage();
             ToastService.showShort('Successfully logged in!');
             navigation.navigate('Sync');
           } catch (error) {
@@ -330,6 +346,7 @@ const SettingsScreen = () => {
             ToastService.showLong(`Login failed: ${errorMessage}`);
           }
         } else {
+          void loadSettingsHydrationFromStorage();
           ToastService.showShort('Settings updated successfully');
         }
       } catch (error) {

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
   StyleSheet,
-  ActivityIndicator,
   Image,
   ScrollView,
 } from 'react-native';
@@ -56,14 +55,48 @@ const SettingsScreen = () => {
   const [initialServerUrl, setInitialServerUrl] = useState('');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [isLoading, setIsLoading] = useState(true);
+  const [isHydrating, setIsHydrating] = useState(true);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [showQRScanner, setShowQRScanner] = useState(false);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    Promise.resolve().then(() => {
-      loadSettings();
-    });
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const hydrate = async () => {
+      try {
+        const [savedUrl, credentials] = await Promise.all([
+          serverConfigService.getServerUrl(),
+          Keychain.getGenericPassword(),
+        ]);
+        if (!mountedRef.current) {
+          return;
+        }
+
+        if (savedUrl) {
+          setInitialServerUrl(savedUrl);
+          setServerUrl(prev => (prev.trim() === '' ? savedUrl : prev));
+        }
+
+        if (credentials) {
+          setUsername(prev => (prev.trim() === '' ? credentials.username : prev));
+          setPassword(prev => (prev.trim() === '' ? credentials.password : prev));
+        }
+      } catch (error) {
+        console.error('Failed to load settings:', error);
+      } finally {
+        if (mountedRef.current) {
+          setIsHydrating(false);
+        }
+      }
+    };
+
+    hydrate();
   }, []);
 
   const handleServerSwitchIfNeeded = useCallback(
@@ -200,27 +233,6 @@ const SettingsScreen = () => {
     [initialServerUrl],
   );
 
-  const loadSettings = async () => {
-    try {
-      const [savedUrl, credentials] = await Promise.all([
-        serverConfigService.getServerUrl(),
-        Keychain.getGenericPassword(),
-      ]);
-      if (savedUrl) {
-        setServerUrl(savedUrl);
-        setInitialServerUrl(savedUrl);
-      }
-      if (credentials) {
-        setUsername(credentials.username);
-        setPassword(credentials.password);
-      }
-    } catch (error) {
-      console.error('Failed to load settings:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   const handleLogin = useCallback(async () => {
     let processedUrl = serverUrl.trim();
 
@@ -334,23 +346,8 @@ const SettingsScreen = () => {
   const isButtonDisabled = useMemo(() => {
     const isFieldsEmpty =
       !serverUrl.trim() || !username.trim() || !password.trim();
-    return isFieldsEmpty || isLoggingIn;
-  }, [serverUrl, username, password, isLoggingIn]);
-
-  if (isLoading) {
-    return (
-      <BlurredScreenBackground disableBlur>
-        <View
-          style={[
-            styles.container,
-            styles.centered,
-            { backgroundColor: 'transparent' },
-          ]}>
-          <ActivityIndicator size="large" color={themeColors.primary} />
-        </View>
-      </BlurredScreenBackground>
-    );
-  }
+    return isHydrating || isFieldsEmpty || isLoggingIn;
+  }, [serverUrl, username, password, isHydrating, isLoggingIn]);
 
   return (
     <BlurredScreenBackground>
@@ -536,10 +533,6 @@ const SettingsScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  centered: {
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   header: {
     alignItems: 'flex-start',

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -572,8 +572,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
   brandName: {
-    fontSize: 32,
-    fontWeight: '700',
+    fontSize: odeTypography.screenTitle,
+    fontWeight: 'bold',
     letterSpacing: 1,
   },
   version: {

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -28,7 +28,6 @@ import {
   odeSpacing,
   odeTypography,
   odeBorderWidth,
-  odeRadius,
   odeScreenHeaderHeight,
 } from '../theme/odeDesign';
 import { serverSwitchService } from '../services/ServerSwitchService';
@@ -181,6 +180,7 @@ const SettingsScreen = () => {
                     (async () => {
                       if (syncService.getIsSyncing()) {
                         ToastService.showShort('Sync already in progress...');
+                        resolve(false);
                         return;
                       }
                       const ok = await syncThenReset();
@@ -583,12 +583,6 @@ const styles = StyleSheet.create({
     paddingTop: odeSpacing.md,
     paddingBottom: 40,
   },
-  title: {
-    fontSize: odeTypography.sectionTitle,
-    fontWeight: '600',
-    marginBottom: 20,
-    textAlign: 'center',
-  },
   titleSmall: {
     fontSize: odeTypography.bodySm,
     fontWeight: '600',
@@ -607,21 +601,8 @@ const styles = StyleSheet.create({
   appSettingsSectionHeader: {
     marginTop: odeSpacing.md,
   },
-  appSettingsHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: odeSpacing.sm,
-  },
-  appSettingsTitleRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: odeSpacing.sm,
-  },
   appSettingsLabel: {
     fontSize: odeTypography.body,
-  },
-  appSettingsChevron: {
-    marginLeft: odeSpacing.xxs,
   },
   themesInlineRow: {
     flexDirection: 'row',
@@ -642,38 +623,6 @@ const styles = StyleSheet.create({
   },
   themeIconButton: {
     padding: odeSpacing.xs,
-  },
-  themesCardOuter: {
-    marginTop: odeSpacing.md,
-    borderRadius: odeRadius.card,
-    borderWidth: odeBorderWidth.hairline,
-    overflow: 'hidden',
-    padding: odeSpacing.md,
-  },
-  themesTitle: {
-    fontSize: odeTypography.sectionTitle,
-    fontWeight: '600',
-    textAlign: 'center',
-    marginBottom: odeSpacing.sm,
-  },
-  themeOptionsColumn: {
-    flexDirection: 'column',
-    gap: odeSpacing.sm,
-    alignItems: 'center',
-  },
-  themeChip: {
-    paddingHorizontal: odeSpacing.lg,
-    paddingVertical: odeSpacing.sm,
-    borderRadius: odeRadius.inner,
-    borderWidth: odeBorderWidth.hairline,
-    backgroundColor: 'transparent',
-    minWidth: '70%',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  themeChipLabel: {
-    fontSize: odeTypography.caption,
-    fontWeight: '600',
   },
   inputContainer: {
     marginBottom: 1,

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
   StyleSheet,
-  ActivityIndicator,
   Image,
   ScrollView,
 } from 'react-native';
@@ -44,14 +43,48 @@ const SettingsScreen = () => {
   const [initialServerUrl, setInitialServerUrl] = useState('');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [isLoading, setIsLoading] = useState(true);
+  const [isHydrating, setIsHydrating] = useState(true);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [showQRScanner, setShowQRScanner] = useState(false);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    Promise.resolve().then(() => {
-      loadSettings();
-    });
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const hydrate = async () => {
+      try {
+        const [savedUrl, credentials] = await Promise.all([
+          serverConfigService.getServerUrl(),
+          Keychain.getGenericPassword(),
+        ]);
+        if (!mountedRef.current) {
+          return;
+        }
+
+        if (savedUrl) {
+          setInitialServerUrl(savedUrl);
+          setServerUrl(prev => (prev.trim() === '' ? savedUrl : prev));
+        }
+
+        if (credentials) {
+          setUsername(prev => (prev.trim() === '' ? credentials.username : prev));
+          setPassword(prev => (prev.trim() === '' ? credentials.password : prev));
+        }
+      } catch (error) {
+        console.error('Failed to load settings:', error);
+      } finally {
+        if (mountedRef.current) {
+          setIsHydrating(false);
+        }
+      }
+    };
+
+    hydrate();
   }, []);
 
   const handleServerSwitchIfNeeded = useCallback(
@@ -188,26 +221,6 @@ const SettingsScreen = () => {
     [initialServerUrl],
   );
 
-  const loadSettings = async () => {
-    try {
-      const savedUrl = await serverConfigService.getServerUrl();
-      if (savedUrl) {
-        setServerUrl(savedUrl);
-        setInitialServerUrl(savedUrl);
-      }
-
-      const credentials = await Keychain.getGenericPassword();
-      if (credentials) {
-        setUsername(credentials.username);
-        setPassword(credentials.password);
-      }
-    } catch (error) {
-      console.error('Failed to load settings:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   const handleLogin = useCallback(async () => {
     const trimmedUrl = serverUrl.trim();
     const trimmedUsername = username.trim();
@@ -312,23 +325,8 @@ const SettingsScreen = () => {
   const isButtonDisabled = useMemo(() => {
     const isFieldsEmpty =
       !serverUrl.trim() || !username.trim() || !password.trim();
-    return isFieldsEmpty || isLoggingIn;
-  }, [serverUrl, username, password, isLoggingIn]);
-
-  if (isLoading) {
-    return (
-      <BlurredScreenBackground>
-        <View
-          style={[
-            styles.container,
-            styles.centered,
-            { backgroundColor: 'transparent' },
-          ]}>
-          <ActivityIndicator size="large" color={themeColors.primary} />
-        </View>
-      </BlurredScreenBackground>
-    );
-  }
+    return isHydrating || isFieldsEmpty || isLoggingIn;
+  }, [serverUrl, username, password, isHydrating, isLoggingIn]);
 
   return (
     <BlurredScreenBackground>
@@ -428,10 +426,6 @@ const SettingsScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  centered: {
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   header: {
     alignItems: 'center',

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react';
 import {
   View,
   Text,

--- a/formulus/src/services/ServerSwitchService.ts
+++ b/formulus/src/services/ServerSwitchService.ts
@@ -5,6 +5,7 @@ import { databaseService } from '../database/DatabaseService';
 import { synkronusApi } from '../api/synkronus';
 import { logout } from '../api/synkronus/Auth';
 import { serverConfigService } from './ServerConfigService';
+import { invalidateSettingsHydrationCache } from './SettingsHydrationCache';
 
 /**
  * Handles cleanup when switching Synkronus servers to avoid cross-server data.
@@ -72,6 +73,7 @@ class ServerSwitchService {
 
     // 6) Save the new server URL (recreates @settings/@server_url)
     await serverConfigService.saveServerUrl(serverUrl);
+    invalidateSettingsHydrationCache();
   }
 }
 

--- a/formulus/src/services/SettingsHydrationCache.ts
+++ b/formulus/src/services/SettingsHydrationCache.ts
@@ -1,0 +1,71 @@
+import * as Keychain from 'react-native-keychain';
+import { serverConfigService } from './ServerConfigService';
+
+export type SettingsHydrationSnapshot =
+  | { ready: false }
+  | {
+      ready: true;
+      serverUrl: string | null;
+      credentials: false | { username: string; password: string };
+    };
+
+let snapshot: SettingsHydrationSnapshot = { ready: false };
+
+let inflight: Promise<SettingsHydrationSnapshot> | null = null;
+
+function normalizeCredentials(
+  raw: Awaited<ReturnType<typeof Keychain.getGenericPassword>>,
+): false | { username: string; password: string } {
+  if (!raw || raw === false) {
+    return false;
+  }
+  return { username: raw.username, password: raw.password };
+}
+
+async function fetchSnapshot(): Promise<SettingsHydrationSnapshot> {
+  const [serverUrl, credentials] = await Promise.all([
+    serverConfigService.getServerUrl(),
+    Keychain.getGenericPassword(),
+  ]);
+  const next: SettingsHydrationSnapshot = {
+    ready: true,
+    serverUrl,
+    credentials: normalizeCredentials(credentials),
+  };
+  snapshot = next;
+  return next;
+}
+
+/**
+ * Single-flight read from AsyncStorage + Keychain. Call early (e.g. main app
+ * shell, More menu) so the first native Keychain hit happens off the Settings
+ * screen critical path.
+ */
+export function loadSettingsHydrationFromStorage(): Promise<SettingsHydrationSnapshot> {
+  if (inflight) {
+    return inflight;
+  }
+  inflight = fetchSnapshot().finally(() => {
+    inflight = null;
+  });
+  return inflight;
+}
+
+export function getSettingsHydrationSnapshot(): SettingsHydrationSnapshot {
+  return snapshot;
+}
+
+/** Typed helper for initial form state (Keychain may have no generic password). */
+export function getSettingsHydrationCredentialPair(
+  snap: SettingsHydrationSnapshot,
+): { username: string; password: string } | null {
+  if (!snap.ready || snap.credentials === false) {
+    return null;
+  }
+  return snap.credentials;
+}
+
+/** When storage may no longer match the cache (e.g. after server switch). */
+export function invalidateSettingsHydrationCache(): void {
+  snapshot = { ready: false };
+}

--- a/formulus/third_party/README.md
+++ b/formulus/third_party/README.md
@@ -1,0 +1,15 @@
+# Vendored native sources
+
+## Notifee Android core
+
+`notifee/` is a **git clone** of [invertase/notifee](https://github.com/invertase/notifee) pinned to the same commit as your installed `@notifee/react-native` (see `NOTIFEE_COMMIT` in `scripts/vendor-notifee-core.mjs`).
+
+Generate or update it before Android builds:
+
+```bash
+npm run vendor:notifee
+```
+
+The folder is gitignored. CI and F-Droid should run that command (or an equivalent `git clone` + `git checkout`) before `./gradlew assembleRelease`.
+
+When you **upgrade `@notifee/react-native`**, update the npm package, read the new `gitHead` from the [npm registry](https://www.npmjs.com/package/@notifee/react-native?activeTab=versions), paste it into `scripts/vendor-notifee-core.mjs`, then run `npm run vendor:notifee` again.


### PR DESCRIPTION
# fix(formulus): align Settings header type and speed up settings load
## Description
- **Header typography:** The Settings screen top bar uses the same title scale as Observations by driving the ODE wordmark from `odeTypography.screenTitle` and `fontWeight: 'bold'`, replacing the previous fixed `32` / `'700'` values so it matches the shared design token used for “Observations”.
- **Settings load UX:** Removed the full-screen spinner that blocked the UI until `getServerUrl()` and Keychain finished. The screen now mounts the real layout immediately. Server URL and credentials load in parallel via `Promise.all`, with `isHydrating` disabling Login until hydration completes and guarded updates so in-flight typing isn’t overwritten by late async results.
## Type of Change
- [x] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):
---
## Component(s) Affected
- [x] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:** <!-- Please specify -->
---
## Related Issue(s)
**Closes/Fixes/Resolves:** _N/A — no linked issue_
---
## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
- [x] Tested on multiple platforms (if applicable)
- [ ] Not applicable
---
## Breaking Changes
- [ ] This PR introduces breaking changes
- [x] This PR does NOT introduce breaking changes
**If breaking changes, please describe migration steps:**
_N/A_
---
## Documentation Updates
- [ ] Documentation has been updated
- [x] Documentation update is not required
---
## Checklist
- [x] Code follows project style guidelines
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [x] PR title follows Conventional Commits format
---
**Thank you for contributing to Open Data Ensemble (ODE)!**