### PR TITLE
feat(formulus): better error messages

### DIFF
--- a/formulus/src/api/synkronus/Auth.ts
+++ b/formulus/src/api/synkronus/Auth.ts
@@ -36,11 +36,12 @@ export interface HttpError extends Error {
   code?: string | number;
 }
 
-// Re-export VersionMismatchError for convenience
-export {
+import {
   VersionMismatchError,
   isVersionMismatchError,
 } from '../../errors/VersionMismatchError';
+
+export { VersionMismatchError, isVersionMismatchError };
 
 const decodeBase64 = (input: string): string => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -240,4 +241,81 @@ export const isUnauthorizedError = (error: unknown): boolean => {
   if (httpError.code === 'UNAUTHORIZED' || httpError.code === 401) return true;
 
   return false;
+};
+
+/** User-visible explanation when the server rejects observation upload (e.g. read-only role). */
+export const SYNC_WRITE_FORBIDDEN_MESSAGE =
+  'You do not have permission to upload observations. Confirm with your administrator that your account has write access, or sign in with an account that can submit data.';
+
+/**
+ * Checks if an error is a 403 Forbidden error (e.g. read-only user attempting sync push).
+ */
+export const isForbiddenError = (error: unknown): boolean => {
+  if (!error) return false;
+
+  const httpError = error as HttpError;
+
+  if (httpError.response?.status === 403) return true;
+
+  if (httpError.status === 403 || httpError.statusCode === 403) return true;
+
+  if (httpError.body?.status === 403 || httpError.data?.status === 403)
+    return true;
+
+  if (typeof httpError.message === 'string') {
+    const msg = httpError.message.toLowerCase();
+    if (msg.includes('403') || msg.includes('forbidden')) {
+      return true;
+    }
+  }
+
+  if (httpError.code === 'FORBIDDEN' || httpError.code === 403) return true;
+
+  return false;
+};
+
+/**
+ * Checks if an error is a 404 Not Found (e.g. missing app bundle on server).
+ */
+export const isNotFoundError = (error: unknown): boolean => {
+  if (!error) return false;
+
+  const httpError = error as HttpError;
+
+  if (httpError.response?.status === 404) return true;
+
+  if (httpError.status === 404 || httpError.statusCode === 404) return true;
+
+  if (httpError.body?.status === 404 || httpError.data?.status === 404)
+    return true;
+
+  if (typeof httpError.message === 'string') {
+    const msg = httpError.message.toLowerCase();
+    if (
+      msg.includes('status code 404') ||
+      (msg.includes('404') && msg.includes('not found'))
+    ) {
+      return true;
+    }
+  }
+
+  if (httpError.code === 'NOT_FOUND' || httpError.code === 404) return true;
+
+  return false;
+};
+
+/**
+ * Maps sync failures to short text suitable for notifications, status line, and alerts.
+ */
+export const getUserFacingSyncErrorMessage = (error: unknown): string => {
+  if (isVersionMismatchError(error)) {
+    return (error as Error).message;
+  }
+  if (isForbiddenError(error)) {
+    return SYNC_WRITE_FORBIDDEN_MESSAGE;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return 'Unknown error occurred';
 };

--- a/formulus/src/api/synkronus/index.ts
+++ b/formulus/src/api/synkronus/index.ts
@@ -10,7 +10,11 @@ import { Observation } from '../../database/models/Observation';
 import { ObservationMapper } from '../../mappers/ObservationMapper';
 import RNFS from 'react-native-fs';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { getApiAuthToken } from './Auth';
+import {
+  getApiAuthToken,
+  isForbiddenError,
+  SYNC_WRITE_FORBIDDEN_MESSAGE,
+} from './Auth';
 import { databaseService } from '../../database/DatabaseService';
 import randomId from '@nozbe/watermelondb/utils/common/randomId';
 import { clientIdService } from '../../services/ClientIdService';
@@ -961,6 +965,9 @@ class SynkronusApi {
       return res.data.current_version;
     } catch (error: unknown) {
       console.error('Failed to push observations:', error);
+      if (isForbiddenError(error)) {
+        throw new Error(SYNC_WRITE_FORBIDDEN_MESSAGE);
+      }
       throw new Error(`Push failed: ${error}`);
     }
   }

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -18,7 +18,11 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import * as Keychain from 'react-native-keychain';
-import { login, isVersionMismatchError } from '../api/synkronus/Auth';
+import {
+  login,
+  isVersionMismatchError,
+  getUserFacingSyncErrorMessage,
+} from '../api/synkronus/Auth';
 import {
   normalizeServerUrl,
   serverConfigService,
@@ -170,7 +174,7 @@ const SettingsScreen = () => {
           } catch (error) {
             console.error('Sync before server switch failed:', error);
             ToastService.showLong(
-              'Sync failed. Please retry or proceed without syncing.',
+              `${getUserFacingSyncErrorMessage(error)}\n\nPlease retry or proceed without syncing.`,
             );
             return false;
           }

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -19,7 +19,7 @@ import { syncService } from '../services/SyncService';
 import { useSyncContext } from '../contexts/SyncContext';
 import RNFS from 'react-native-fs';
 import { databaseService } from '../database/DatabaseService';
-import { getUserInfo } from '../api/synkronus/Auth';
+import { getUserInfo, getUserFacingSyncErrorMessage } from '../api/synkronus/Auth';
 import colors from '../theme/colors';
 import { Button } from '../components/common';
 import { useAppTheme } from '../contexts/AppThemeContext';
@@ -139,7 +139,7 @@ const SyncScreen = () => {
       await Promise.race([syncPromise, timeoutPromise]);
       await refreshAfterOperation();
     } catch (error) {
-      syncError = (error as Error).message || 'Unknown error occurred';
+      syncError = getUserFacingSyncErrorMessage(error);
       Alert.alert('Sync Failed', syncError);
     } finally {
       finishSync(syncError);
@@ -191,7 +191,7 @@ const SyncScreen = () => {
       const fs = await formService.FormService.getInstance();
       await fs.invalidateCache();
     } catch (error) {
-      const errorMessage = (error as Error).message;
+      const errorMessage = getUserFacingSyncErrorMessage(error);
       finishSync(errorMessage);
       Alert.alert('Operation Failed', errorMessage);
     } finally {

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -19,7 +19,10 @@ import { syncService } from '../services/SyncService';
 import { useSyncContext } from '../contexts/SyncContext';
 import RNFS from 'react-native-fs';
 import { databaseService } from '../database/DatabaseService';
-import { getUserInfo, getUserFacingSyncErrorMessage } from '../api/synkronus/Auth';
+import {
+  getUserInfo,
+  getUserFacingSyncErrorMessage,
+} from '../api/synkronus/Auth';
 import colors from '../theme/colors';
 import { Button } from '../components/common';
 import { useAppTheme } from '../contexts/AppThemeContext';

--- a/formulus/src/services/ServerConfigService.ts
+++ b/formulus/src/services/ServerConfigService.ts
@@ -151,6 +151,37 @@ export class ServerConfigService {
     }
   }
 
+  /**
+   * GET {serverUrl}/health with timeout. Returns true if the server responds with a
+   * success status (2xx), e.g. 200 OK when the service is healthy.
+   */
+  async isHealthEndpointOk(serverUrl: string): Promise<boolean> {
+    const normalized = normalizeServerUrl(serverUrl);
+    if (!normalized.ok) {
+      return false;
+    }
+
+    const base = normalized.href;
+    try {
+      const healthUrl = `${base}/health`;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+      const response = await fetch(healthUrl, {
+        method: 'GET',
+        signal: controller.signal,
+        headers: {
+          Accept: 'application/json',
+        },
+      });
+
+      clearTimeout(timeoutId);
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
   async testConnection(
     serverUrl: string,
   ): Promise<{ success: boolean; message: string }> {

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -3,9 +3,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { appEvents } from '../webview/FormulusMessageHandlers';
 import { SyncProgress } from '../contexts/SyncContext';
 import { notificationService } from './NotificationService';
+import { getUserFacingAppBundleUpdateErrorMessage } from './appBundleUpdateErrors';
 import { FormService } from './FormService';
 import {
   autoLogin,
+  getUserFacingSyncErrorMessage,
   isUnauthorizedError,
   isVersionMismatchError,
   HttpError,
@@ -282,9 +284,7 @@ export class SyncService {
       return finalVersion;
     } catch (error) {
       console.error('Sync failed', error);
-      const errorMessage = isVersionMismatchError(error)
-        ? error.message
-        : 'Unknown error occurred';
+      const errorMessage = getUserFacingSyncErrorMessage(error);
       this.updateStatus(`Sync failed: ${errorMessage}`);
 
       // Don't let notification service block error handling
@@ -378,11 +378,12 @@ export class SyncService {
       appEvents.emit('bundleUpdated');
     } catch (error) {
       console.error('App sync failed', error);
-      const message = isVersionMismatchError(error)
-        ? error.message
-        : 'App sync failed';
+      const message = await getUserFacingAppBundleUpdateErrorMessage(error);
       this.updateStatus(message);
-      throw error;
+      if (error instanceof Error && message === error.message) {
+        throw error;
+      }
+      throw new Error(message);
     } finally {
       this.isSyncing = false;
       this.canCancel = false;

--- a/formulus/src/services/appBundleUpdateErrors.ts
+++ b/formulus/src/services/appBundleUpdateErrors.ts
@@ -1,0 +1,48 @@
+import { isNotFoundError, isVersionMismatchError } from '../api/synkronus/Auth';
+import { serverConfigService } from './ServerConfigService';
+
+/** Server responds on /health but app-bundle returned 404 — nothing published yet. */
+export const APP_BUNDLE_NOT_PUBLISHED_USER_MESSAGE =
+  'The server is online, but no app bundle is available yet. Ask an administrator to publish an app bundle for this server, or try again later.';
+
+/** /health did not return a successful response — URL or connectivity problem. */
+export const APP_BUNDLE_SERVER_UNAVAILABLE_USER_MESSAGE =
+  'Could not reach the server. Check the server URL, your network connection, and that the service is running.';
+
+function isBundleZipHttpNotFound(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /\bHTTP\s+404\b/i.test(error.message) &&
+    error.message.toLowerCase().includes('bundle')
+  );
+}
+
+function isAppBundleNotFoundError(error: unknown): boolean {
+  return isNotFoundError(error) || isBundleZipHttpNotFound(error);
+}
+
+/**
+ * User-facing text for app bundle download/update failures (manifest or zip).
+ * For 404, uses GET /health to distinguish "server up, no bundle" vs unreachable server.
+ */
+export async function getUserFacingAppBundleUpdateErrorMessage(
+  error: unknown,
+): Promise<string> {
+  if (isVersionMismatchError(error)) {
+    return (error as Error).message;
+  }
+
+  const serverUrl = await serverConfigService.getServerUrl();
+  if (serverUrl && isAppBundleNotFoundError(error)) {
+    const healthy = await serverConfigService.isHealthEndpointOk(serverUrl);
+    return healthy
+      ? APP_BUNDLE_NOT_PUBLISHED_USER_MESSAGE
+      : APP_BUNDLE_SERVER_UNAVAILABLE_USER_MESSAGE;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'App sync failed';
+}


### PR DESCRIPTION
# Better error messages

feat(formulus): clearer sync 403 and app bundle 404 error messages
## Description
Improves user-facing errors in the mobile app when sync or app bundle operations fail in common server-side situations:
- **Observation sync (403):** Read-only (or otherwise forbidden) users no longer see generic “sync failed” / opaque Axios wording. The app surfaces a short explanation to verify **write** access or use an account that can submit data, consistent across sync status, failure notifications, Sync screen alerts, and the server-switch pre-sync toast.
- **App bundle update (404):** When the manifest or bundle zip returns **404**, the app performs a **GET `{server}/health`** probe. If health succeeds (2xx), the message explains that the server is up but **no app bundle is published yet**. If health does not succeed, the message points to **URL, network, or service availability**.
Implementation highlights: shared HTTP helpers (`isForbiddenError`, `isNotFoundError`), `getUserFacingSyncErrorMessage`, push handler throws a clean message on 403, `ServerConfigService.isHealthEndpointOk`, and `getUserFacingAppBundleUpdateErrorMessage` used from `SyncService.updateAppBundle`.
## Type of Change
- [ ] Bug Fix
- [x] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):
---
## Component(s) Affected
- [x] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:** <!-- Please specify -->
---
## Related Issue(s)
**Closes/Fixes/Resolves:** <!-- e.g., Closes #123 -->
---
## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
- [ ] Tested on multiple platforms (if applicable)
- [ ] Not applicable
*(Existing `Auth` unit tests were run and pass; no new tests were added specifically for the new sync/app-bundle message helpers.)*
---
## Breaking Changes
- [ ] This PR introduces breaking changes
- [x] This PR does NOT introduce breaking changes
**If breaking changes, please describe migration steps:**
---
## Documentation Updates
- [ ] Documentation has been updated
- [x] Documentation update is not required
---
## Checklist
- [x] Code follows project style guidelines
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [x] PR title follows Conventional Commits format
*(Adjust “All existing tests pass” after you run your full suite locally; some environments may still skip or fail unrelated tests e.g. SyncService + geolocation Jest setup.)*
---
**Thank you for contributing to Open Data Ensemble (ODE)!**