### PR TITLE
feat(formplayer): mobile IME navigation and progress bar controls

### DIFF
--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -70,6 +70,10 @@ import AdateQuestionRenderer, {
 import { shellMaterialRenderers } from './theme/material-wrappers';
 import { numberStepperRenderer } from './renderers/NumberStepperRenderer';
 import DynamicEnumControl, { dynamicEnumTester } from './DynamicEnumControl';
+import MaterialTextControlWithImeHint, {
+  materialTextControlWithImeHintTester,
+} from './jsonforms/MaterialTextControlWithImeHint';
+import type { KeyboardPrimaryEnterKeyHint } from './utils/keyboardEnterKeyHint';
 
 import ErrorBoundary from './components/ErrorBoundary';
 import { draftService } from './services/DraftService';
@@ -211,15 +215,25 @@ const processUISchemaWithFinalize = (
 // Create context for sharing form metadata with renderers
 interface FormContextType {
   formInitData: FormInitData | null;
+  /**
+   * Hint for mobile keyboard IME action (Go / Next / Done).
+   * Set inside swipe layout; `undefined` elsewhere.
+   */
+  keyboardEnterKeyHint?: KeyboardPrimaryEnterKeyHint;
 }
 
 export const FormContext = createContext<FormContextType>({
   formInitData: null,
+  keyboardEnterKeyHint: undefined,
 });
 
 export const useFormContext = () => useContext(FormContext);
 
 export const customRenderers = [
+  {
+    tester: materialTextControlWithImeHintTester,
+    renderer: MaterialTextControlWithImeHint,
+  },
   { tester: swipeLayoutTester, renderer: SwipeLayoutRenderer },
   { tester: groupAsSwipeLayoutTester, renderer: SwipeLayoutRenderer },
   { tester: finalizeTester, renderer: finalizeRenderer.renderer },

--- a/formulus-formplayer/src/components/FormLayout.tsx
+++ b/formulus-formplayer/src/components/FormLayout.tsx
@@ -160,9 +160,7 @@ const FormLayout: React.FC<FormLayoutProps> = ({
         overflowX: 'hidden',
         WebkitOverflowScrolling: 'touch',
         paddingBottom:
-          showNavigation &&
-          (previousButton || nextButton) &&
-          !isKeyboardVisible
+          showNavigation && (previousButton || nextButton) && !isKeyboardVisible
             ? {
                 xs: `calc(${theme.spacing(11)} + env(safe-area-inset-bottom, 0px))`,
                 sm: `calc(${theme.spacing(12)} + env(safe-area-inset-bottom, 0px))`,
@@ -177,9 +175,7 @@ const FormLayout: React.FC<FormLayoutProps> = ({
   );
 
   const navigationBar =
-    showNavigation &&
-    (previousButton || nextButton) &&
-    !isKeyboardVisible ? (
+    showNavigation && (previousButton || nextButton) && !isKeyboardVisible ? (
       <Paper
         elevation={0}
         sx={theme => ({

--- a/formulus-formplayer/src/components/FormLayout.tsx
+++ b/formulus-formplayer/src/components/FormLayout.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState, useEffect } from 'react';
+import React, { ReactNode, useState, useEffect, useCallback } from 'react';
 import { Box, Paper, Stack } from '@mui/material';
 import { Button } from '@ode/components/react-web';
 import { tokens } from '../theme/tokens-adapter';
@@ -6,6 +6,20 @@ import { tokens } from '../theme/tokens-adapter';
 const parsePx = (value: string): number =>
   parseInt(String(value).replace('px', ''), 10);
 const spacing5 = parsePx(tokens.spacing?.[5] ?? '20px');
+
+/** Keeps a submit control in the DOM for IME Go/Send when the visible bar is hidden (e.g. keyboard open). */
+const visuallyHiddenSubmitStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  clipPath: 'inset(50%)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
 
 interface FormLayoutProps {
   /**
@@ -47,6 +61,16 @@ interface FormLayoutProps {
    * Default: true
    */
   showNavigation?: boolean;
+
+  /**
+   * When set, wraps the scroll area and nav in a `<form>` so mobile keyboards
+   * (Go / Send / ->) submit this action. A visually hidden submit stays in the
+   * DOM when the bottom bar is hidden (e.g. while the keyboard is open).
+   */
+  keyboardSubmitAction?: {
+    onTrigger: () => void;
+    disabled?: boolean;
+  };
 }
 
 /**
@@ -69,6 +93,7 @@ const FormLayout: React.FC<FormLayoutProps> = ({
   nextButton,
   header,
   showNavigation = true,
+  keyboardSubmitAction,
 }) => {
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
   const [initialViewportHeight] = useState<number>(() => {
@@ -118,6 +143,137 @@ const FormLayout: React.FC<FormLayoutProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const handleFormSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!keyboardSubmitAction || keyboardSubmitAction.disabled) return;
+      keyboardSubmitAction.onTrigger();
+    },
+    [keyboardSubmitAction],
+  );
+
+  const scrollArea = (
+    <Box
+      sx={theme => ({
+        flex: 1,
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        WebkitOverflowScrolling: 'touch',
+        paddingBottom:
+          showNavigation &&
+          (previousButton || nextButton) &&
+          !isKeyboardVisible
+            ? {
+                xs: `calc(${theme.spacing(11)} + env(safe-area-inset-bottom, 0px))`,
+                sm: `calc(${theme.spacing(12)} + env(safe-area-inset-bottom, 0px))`,
+                md: `calc(${theme.spacing(13)} + env(safe-area-inset-bottom, 0px))`,
+              }
+            : theme.spacing(4),
+        overscrollBehavior: 'contain',
+        position: 'relative',
+      })}>
+      {children}
+    </Box>
+  );
+
+  const navigationBar =
+    showNavigation &&
+    (previousButton || nextButton) &&
+    !isKeyboardVisible ? (
+      <Paper
+        elevation={0}
+        sx={theme => ({
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          zIndex: theme.zIndex.appBar,
+          width: '100%',
+          padding: {
+            xs: theme.spacing(1, 1.5),
+            sm: theme.spacing(1.5, 2),
+            md: theme.spacing(1.5, 2.5),
+          },
+          paddingBottom: {
+            xs: `calc(${theme.spacing(1)} + env(safe-area-inset-bottom, 0px))`,
+            sm: `calc(${theme.spacing(1.5)} + env(safe-area-inset-bottom, 0px))`,
+            md: `calc(${theme.spacing(1.5)} + env(safe-area-inset-bottom, 0px))`,
+          },
+          backgroundColor: 'background.default',
+          borderTop: 'none',
+          borderColor: 'transparent',
+          boxShadow: 'none',
+          transition: 'opacity 0.2s ease-in-out, transform 0.2s ease-in-out',
+          boxSizing: 'border-box',
+        })}>
+        <Stack
+          direction="row"
+          spacing={2}
+          justifyContent="center"
+          sx={{
+            '& > *': {
+              flex: { xs: 1, sm: '0 1 auto' },
+              minWidth: {
+                xs: 'auto',
+                sm: `${spacing5 * 6}px`,
+                md: `${spacing5 * 7}px`,
+              },
+              maxWidth: { md: `${spacing5 * 10}px` },
+            },
+          }}>
+          {previousButton && (
+            <Button
+              variant="primary"
+              onPress={previousButton.onClick}
+              disabled={previousButton.disabled}
+              size="medium">
+              {previousButton.label || 'Previous'}
+            </Button>
+          )}
+          {nextButton && (
+            <Button
+              variant="primary"
+              nativeType={keyboardSubmitAction ? 'submit' : 'button'}
+              onPress={keyboardSubmitAction ? undefined : nextButton.onClick}
+              disabled={nextButton.disabled}
+              size="medium"
+              className="button-reverse-primary">
+              {nextButton.label || 'Next'}
+            </Button>
+          )}
+        </Stack>
+      </Paper>
+    ) : null;
+
+  const mainColumn = keyboardSubmitAction ? (
+    <form
+      onSubmit={handleFormSubmit}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: 0,
+        width: '100%',
+        margin: 0,
+        position: 'relative',
+      }}>
+      {scrollArea}
+      <button
+        type="submit"
+        aria-hidden={true}
+        tabIndex={-1}
+        disabled={Boolean(keyboardSubmitAction.disabled)}
+        style={visuallyHiddenSubmitStyle}
+      />
+      {navigationBar}
+    </form>
+  ) : (
+    <>
+      {scrollArea}
+      {navigationBar}
+    </>
+  );
+
   return (
     <Box
       sx={{
@@ -153,95 +309,7 @@ const FormLayout: React.FC<FormLayoutProps> = ({
         </Box>
       )}
 
-      <Box
-        sx={theme => ({
-          flex: 1,
-          overflowY: 'auto',
-          overflowX: 'hidden',
-          WebkitOverflowScrolling: 'touch',
-          paddingBottom:
-            showNavigation &&
-            (previousButton || nextButton) &&
-            !isKeyboardVisible
-              ? {
-                  xs: `calc(${theme.spacing(11)} + env(safe-area-inset-bottom, 0px))`,
-                  sm: `calc(${theme.spacing(12)} + env(safe-area-inset-bottom, 0px))`,
-                  md: `calc(${theme.spacing(13)} + env(safe-area-inset-bottom, 0px))`,
-                }
-              : theme.spacing(4),
-          overscrollBehavior: 'contain',
-          position: 'relative',
-        })}>
-        {children}
-      </Box>
-
-      {showNavigation &&
-        (previousButton || nextButton) &&
-        !isKeyboardVisible && (
-          <Paper
-            elevation={0}
-            sx={theme => ({
-              position: 'fixed',
-              bottom: 0,
-              left: 0,
-              right: 0,
-              zIndex: theme.zIndex.appBar,
-              width: '100%',
-              padding: {
-                xs: theme.spacing(1, 1.5),
-                sm: theme.spacing(1.5, 2),
-                md: theme.spacing(1.5, 2.5),
-              },
-              paddingBottom: {
-                xs: `calc(${theme.spacing(1)} + env(safe-area-inset-bottom, 0px))`,
-                sm: `calc(${theme.spacing(1.5)} + env(safe-area-inset-bottom, 0px))`,
-                md: `calc(${theme.spacing(1.5)} + env(safe-area-inset-bottom, 0px))`,
-              },
-              backgroundColor: 'background.default',
-              borderTop: 'none',
-              borderColor: 'transparent',
-              boxShadow: 'none',
-              transition:
-                'opacity 0.2s ease-in-out, transform 0.2s ease-in-out',
-              boxSizing: 'border-box',
-            })}>
-            <Stack
-              direction="row"
-              spacing={2}
-              justifyContent="center"
-              sx={{
-                '& > *': {
-                  flex: { xs: 1, sm: '0 1 auto' },
-                  minWidth: {
-                    xs: 'auto',
-                    sm: `${spacing5 * 6}px`,
-                    md: `${spacing5 * 7}px`,
-                  },
-                  maxWidth: { md: `${spacing5 * 10}px` },
-                },
-              }}>
-              {previousButton && (
-                <Button
-                  variant="primary"
-                  onPress={previousButton.onClick}
-                  disabled={previousButton.disabled}
-                  size="medium">
-                  {previousButton.label || 'Previous'}
-                </Button>
-              )}
-              {nextButton && (
-                <Button
-                  variant="primary"
-                  onPress={nextButton.onClick}
-                  disabled={nextButton.disabled}
-                  size="medium"
-                  className="button-reverse-primary">
-                  {nextButton.label || 'Next'}
-                </Button>
-              )}
-            </Stack>
-          </Paper>
-        )}
+      {mainColumn}
     </Box>
   );
 };

--- a/formulus-formplayer/src/components/FormProgressBar.tsx
+++ b/formulus-formplayer/src/components/FormProgressBar.tsx
@@ -1,5 +1,7 @@
-import React, { useMemo } from 'react';
-import { Box, LinearProgress, Typography } from '@mui/material';
+import React, { useMemo, useCallback } from 'react';
+import { Box, IconButton, LinearProgress, Typography } from '@mui/material';
+import ChevronLeft from '@mui/icons-material/ChevronLeft';
+import ChevronRight from '@mui/icons-material/ChevronRight';
 import { tokens } from '../theme/tokens-adapter';
 
 type JsonSchema = {
@@ -39,6 +41,14 @@ interface FormProgressBarProps {
    * Whether the user is currently on the Finalize page
    */
   isOnFinalizePage?: boolean;
+  /**
+   * Optional narrow prev/next controls flanking the bar. Use the same callbacks
+   * as primary navigation (not `.click()` on other buttons) to avoid double events.
+   */
+  onNavigatePrevious?: () => void;
+  onNavigateNext?: () => void;
+  /** When true, both header chevrons are disabled (e.g. navigation in flight). */
+  navigationDisabled?: boolean;
 }
 
 /**
@@ -117,6 +127,13 @@ const countAnsweredQuestions = (
 /**
  * FormProgressBar component that displays form completion progress
  */
+const navIconButtonSx = {
+  flexShrink: 0,
+  p: 0.25,
+  color: 'text.secondary',
+  '&.Mui-disabled': { opacity: 0.35 },
+} as const;
+
 const FormProgressBar: React.FC<FormProgressBarProps> = ({
   currentPage,
   totalScreens,
@@ -124,6 +141,9 @@ const FormProgressBar: React.FC<FormProgressBarProps> = ({
   schema,
   mode = 'screens',
   isOnFinalizePage = false,
+  onNavigatePrevious,
+  onNavigateNext,
+  navigationDisabled = false,
 }) => {
   const progress = useMemo(() => {
     if (mode === 'screens' || mode === 'both') {
@@ -163,9 +183,21 @@ const FormProgressBar: React.FC<FormProgressBarProps> = ({
     return 0;
   }, [currentPage, totalScreens, data, schema, mode, isOnFinalizePage]);
 
+  const handlePrev = useCallback(() => {
+    if (navigationDisabled || !onNavigatePrevious) return;
+    onNavigatePrevious();
+  }, [navigationDisabled, onNavigatePrevious]);
+
+  const handleNext = useCallback(() => {
+    if (navigationDisabled || !onNavigateNext) return;
+    onNavigateNext();
+  }, [navigationDisabled, onNavigateNext]);
+
   if (totalScreens === 0) {
     return null;
   }
+
+  const showHeaderNav = onNavigatePrevious != null || onNavigateNext != null;
 
   return (
     <Box
@@ -178,35 +210,68 @@ const FormProgressBar: React.FC<FormProgressBarProps> = ({
         sx={{
           display: 'flex',
           alignItems: 'center',
-          gap: 1,
+          gap: { xs: 0.25, sm: 0.5 },
           mb: 0.5,
-          px: { xs: 1, sm: 2 },
+          px: { xs: 0.5, sm: 1 },
         }}>
-        <LinearProgress
-          variant="determinate"
-          value={progress}
+        {showHeaderNav ? (
+          <IconButton
+            type="button"
+            size="small"
+            aria-label="Previous screen"
+            onClick={handlePrev}
+            disabled={navigationDisabled || !onNavigatePrevious}
+            edge="start"
+            sx={navIconButtonSx}>
+            <ChevronLeft sx={{ fontSize: 22 }} />
+          </IconButton>
+        ) : null}
+        <Box
           sx={{
-            flexGrow: 1,
-            height: 8,
-            borderRadius: 4,
-            backgroundColor: `rgba(0, 0, 0, ${(tokens as any).opacity?.['10'] ?? 0.1})`,
-            '& .MuiLinearProgress-bar': {
-              borderRadius: 4,
-              transition: 'transform 0.4s ease-in-out',
-            },
-          }}
-        />
-        <Typography
-          variant="caption"
-          sx={{
-            minWidth: `${tokens.touchTarget.comfortable}px`,
-            textAlign: 'right',
-            color: 'text.secondary',
-            fontWeight: 500,
-            pr: { xs: 1, sm: 2 },
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flex: 1,
+            minWidth: 0,
           }}>
-          {progress}%
-        </Typography>
+          <LinearProgress
+            variant="determinate"
+            value={progress}
+            sx={{
+              flexGrow: 1,
+              height: 8,
+              borderRadius: 4,
+              backgroundColor: `rgba(0, 0, 0, ${(tokens as any).opacity?.['10'] ?? 0.1})`,
+              '& .MuiLinearProgress-bar': {
+                borderRadius: 4,
+                transition: 'transform 0.4s ease-in-out',
+              },
+            }}
+          />
+          <Typography
+            variant="caption"
+            sx={{
+              flexShrink: 0,
+              minWidth: '2.25rem',
+              textAlign: 'right',
+              color: 'text.secondary',
+              fontWeight: 500,
+            }}>
+            {progress}%
+          </Typography>
+        </Box>
+        {showHeaderNav ? (
+          <IconButton
+            type="button"
+            size="small"
+            aria-label="Next screen"
+            onClick={handleNext}
+            disabled={navigationDisabled || !onNavigateNext}
+            edge="end"
+            sx={navIconButtonSx}>
+            <ChevronRight sx={{ fontSize: 22 }} />
+          </IconButton>
+        ) : null}
       </Box>
     </Box>
   );

--- a/formulus-formplayer/src/jsonforms/MaterialTextControlWithImeHint.tsx
+++ b/formulus-formplayer/src/jsonforms/MaterialTextControlWithImeHint.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {
+  ControlProps,
+  isStringControl,
+  RankedTester,
+  rankWith,
+} from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import {
+  MaterialInputControl,
+  MuiInputText,
+} from '@jsonforms/material-renderers';
+import { useFormContext } from '../App';
+
+/** Stock typings omit `muiInputProps`; MuiInputText still reads it from spread props. */
+const MaterialInputControlUntyped = MaterialInputControl as React.FC<
+  ControlProps & {
+    input: typeof MuiInputText;
+    muiInputProps?: React.ComponentProps<typeof MuiInputText>['muiInputProps'];
+  }
+>;
+
+/**
+ * Same as JSON Forms Material text control, but sets `enterKeyHint` from
+ * {@link FormContextType.keyboardEnterKeyHint} for mobile IME labels.
+ */
+const MaterialTextControlWithImeHint = (props: ControlProps) => {
+  const { keyboardEnterKeyHint } = useFormContext();
+
+  return (
+    <MaterialInputControlUntyped
+      {...props}
+      muiInputProps={
+        keyboardEnterKeyHint
+          ? { enterKeyHint: keyboardEnterKeyHint }
+          : undefined
+      }
+      input={MuiInputText}
+    />
+  );
+};
+
+/** Rank 2 beats stock `materialTextControlTester` (rank 1). */
+export const materialTextControlWithImeHintTester: RankedTester = rankWith(
+  2,
+  isStringControl,
+);
+
+export default withJsonFormsControlProps(MaterialTextControlWithImeHint);

--- a/formulus-formplayer/src/ode-components.d.ts
+++ b/formulus-formplayer/src/ode-components.d.ts
@@ -24,6 +24,8 @@ declare module '@ode/components/react-web' {
   export interface WebButtonProps extends ButtonProps {
     isPaired?: boolean;
     pairedVariant?: ButtonVariant;
+    /** Native `<button type>` for form / mobile IME (Go, Send). @default 'button' */
+    nativeType?: 'button' | 'submit' | 'reset';
   }
 
   // ButtonGroup props

--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -14,7 +14,8 @@ import {
 import { useSwipeable } from 'react-swipeable';
 import { Box, Typography, useTheme } from '@mui/material';
 import { Button } from '@ode/components/react-web';
-import { useFormContext } from '../App';
+import { FormContext, useFormContext } from '../App';
+import { primaryKeyboardEnterKeyHint } from '../utils/keyboardEnterKeyHint';
 import { draftService } from '../services/DraftService';
 import FormProgressBar from '../components/FormProgressBar';
 import FormLayout from '../components/FormLayout';
@@ -143,7 +144,8 @@ const SwipeLayoutRenderer = ({
   );
   const [snackbarMessage, setSnackbarMessage] = useState<string>('');
   const { core } = useJsonForms();
-  const { formInitData } = useFormContext();
+  const parentFormContext = useFormContext();
+  const { formInitData } = parentFormContext;
 
   const uiType = (uischema as any).type;
   const isExplicitSwipeLayout = uiType === 'SwipeLayout';
@@ -153,6 +155,24 @@ const SwipeLayoutRenderer = ({
       ? (uischema as any).elements || []
       : [uischema];
   }, [uischema, isExplicitSwipeLayout]);
+
+  const { swipeOptions, nextButtonLabelOption, finalizeButtonLabelOption } =
+    useMemo(() => {
+      const raw = (uischema as any)?.options ?? {};
+      const nextRaw = raw.nextButtonLabel;
+      const finRaw = raw.finalizeButtonLabel;
+      return {
+        swipeOptions: raw,
+        nextButtonLabelOption:
+          typeof nextRaw === 'string' && nextRaw.trim() !== ''
+            ? nextRaw
+            : undefined,
+        finalizeButtonLabelOption:
+          typeof finRaw === 'string' && finRaw.trim() !== ''
+            ? finRaw
+            : undefined,
+      };
+    }, [uischema]);
 
   if (typeof handleChange !== 'function') {
     console.warn(
@@ -421,6 +441,29 @@ const SwipeLayoutRenderer = ({
     data,
   ]);
 
+  const keyboardEnterKeyHint = useMemo(
+    () =>
+      primaryKeyboardEnterKeyHint(
+        isOnFinalizePage,
+        nextVisiblePage !== null ? nextButtonLabelOption : undefined,
+        finalizeButtonLabelOption ?? 'Finalize',
+      ),
+    [
+      isOnFinalizePage,
+      nextVisiblePage,
+      nextButtonLabelOption,
+      finalizeButtonLabelOption,
+    ],
+  );
+
+  const formContextForSwipe = useMemo(
+    () => ({
+      formInitData: parentFormContext.formInitData,
+      keyboardEnterKeyHint,
+    }),
+    [parentFormContext.formInitData, keyboardEnterKeyHint],
+  );
+
   const handleSnackbarClose = useCallback(
     (event?: React.SyntheticEvent | Event, reason?: string) => {
       if (reason === 'clickaway') {
@@ -443,182 +486,186 @@ const SwipeLayoutRenderer = ({
 
   // ----- Header options (author-configurable) -----
 
-  const uiOptions = (uischema as any)?.options || {};
   const headerTitle: string | undefined =
-    uiOptions.headerTitle || (schema as any)?.title || undefined;
-  const headerFields: string[] = (uiOptions.headerFields || []).slice(0, 2);
+    swipeOptions.headerTitle || (schema as any)?.title || undefined;
+  const headerFields: string[] = (swipeOptions.headerFields || []).slice(0, 2);
 
   // ----- Render -----
 
   return (
-    <FormLayout
-      keyboardSubmitAction={keyboardSubmitAction}
-      header={
-        <>
-          {/* Author-configured form title and sticky fields */}
-          {(headerTitle || headerFields.length > 0) && (
-            <Box sx={{ pb: headerFields.length > 0 ? 0 : 0.25 }}>
-              {headerTitle && (
-                <Typography
-                  variant="subtitle2"
-                  sx={{
-                    fontWeight: 700,
-                    fontSize: '1.125rem',
-                    lineHeight: 1.3,
-                    color: 'text.primary',
-                    mb: headerFields.length > 0 ? 0.5 : 0,
-                    textAlign: 'left',
-                  }}>
-                  {headerTitle}
-                </Typography>
-              )}
-              {headerFields.length > 0 && (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    gap: 0.5,
-                    pb: 0.5,
-                  }}>
-                  {headerFields.map((fieldKey: string) => {
-                    const fieldSchema = (schema as any)?.properties?.[fieldKey];
-                    const label = fieldSchema?.title || fieldKey;
-                    const value = data?.[fieldKey];
-                    const displayValue =
-                      value != null && value !== '' ? String(value) : '—';
-                    return (
-                      <Typography
-                        key={fieldKey}
-                        variant="caption"
-                        sx={{
-                          px: 1,
-                          py: 0.25,
-                          borderRadius: 1,
-                          backgroundColor: 'action.hover',
-                          fontSize: '0.75rem',
-                          color:
-                            displayValue === '—'
-                              ? 'text.disabled'
-                              : 'text.primary',
-                          fontWeight: displayValue === '—' ? 400 : 600,
-                          textAlign: 'left',
-                        }}>
-                        {label}: {displayValue}
-                      </Typography>
-                    );
-                  })}
-                </Box>
-              )}
-            </Box>
+    <FormContext.Provider value={formContextForSwipe}>
+      <FormLayout
+        keyboardSubmitAction={keyboardSubmitAction}
+        header={
+          <>
+            {/* Author-configured form title and sticky fields */}
+            {(headerTitle || headerFields.length > 0) && (
+              <Box sx={{ pb: headerFields.length > 0 ? 0 : 0.25 }}>
+                {headerTitle && (
+                  <Typography
+                    variant="subtitle2"
+                    sx={{
+                      fontWeight: 700,
+                      fontSize: '1.125rem',
+                      lineHeight: 1.3,
+                      color: 'text.primary',
+                      mb: headerFields.length > 0 ? 0.5 : 0,
+                      textAlign: 'left',
+                    }}>
+                    {headerTitle}
+                  </Typography>
+                )}
+                {headerFields.length > 0 && (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      gap: 0.5,
+                      pb: 0.5,
+                    }}>
+                    {headerFields.map((fieldKey: string) => {
+                      const fieldSchema = (schema as any)?.properties?.[
+                        fieldKey
+                      ];
+                      const label = fieldSchema?.title || fieldKey;
+                      const value = data?.[fieldKey];
+                      const displayValue =
+                        value != null && value !== '' ? String(value) : '—';
+                      return (
+                        <Typography
+                          key={fieldKey}
+                          variant="caption"
+                          sx={{
+                            px: 1,
+                            py: 0.25,
+                            borderRadius: 1,
+                            backgroundColor: 'action.hover',
+                            fontSize: '0.75rem',
+                            color:
+                              displayValue === '—'
+                                ? 'text.disabled'
+                                : 'text.primary',
+                            fontWeight: displayValue === '—' ? 400 : 600,
+                            textAlign: 'left',
+                          }}>
+                          {label}: {displayValue}
+                        </Typography>
+                      );
+                    })}
+                  </Box>
+                )}
+              </Box>
+            )}
+            <FormProgressBar
+              currentPage={visiblePosition}
+              totalScreens={totalVisibleScreens}
+              data={data}
+              schema={schema}
+              uischema={uischema}
+              mode="screens"
+              isOnFinalizePage={isOnFinalizePage}
+            />
+          </>
+        }
+        previousButton={
+          prevVisiblePage !== null
+            ? {
+                onClick: () => navigateToPage(prevVisiblePage),
+                disabled: isNavigating,
+              }
+            : undefined
+        }
+        nextButton={
+          nextVisiblePage !== null
+            ? {
+                onClick: () => navigateToPage(nextVisiblePage),
+                disabled: isNavigating,
+                label: nextButtonLabelOption,
+              }
+            : undefined
+        }
+        contentBottomPadding={80}
+        showNavigation={true}>
+        <div {...handlers} className="swipelayout_screen">
+          {(uischema as any)?.label && <h1>{(uischema as any).label}</h1>}
+          {layouts.length > 0 && layouts[currentPage] && (
+            <JsonFormsDispatch
+              schema={schema}
+              uischema={layouts[currentPage]}
+              path={path}
+              enabled={enabled}
+              renderers={renderers}
+              cells={cells}
+            />
           )}
-          <FormProgressBar
-            currentPage={visiblePosition}
-            totalScreens={totalVisibleScreens}
-            data={data}
-            schema={schema}
-            uischema={uischema}
-            mode="screens"
-            isOnFinalizePage={isOnFinalizePage}
-          />
-        </>
-      }
-      previousButton={
-        prevVisiblePage !== null
-          ? {
-              onClick: () => navigateToPage(prevVisiblePage),
-              disabled: isNavigating,
-            }
-          : undefined
-      }
-      nextButton={
-        nextVisiblePage !== null
-          ? {
-              onClick: () => navigateToPage(nextVisiblePage),
-              disabled: isNavigating,
-            }
-          : undefined
-      }
-      contentBottomPadding={80}
-      showNavigation={true}>
-      <div {...handlers} className="swipelayout_screen">
-        {(uischema as any)?.label && <h1>{(uischema as any).label}</h1>}
-        {layouts.length > 0 && layouts[currentPage] && (
-          <JsonFormsDispatch
-            schema={schema}
-            uischema={layouts[currentPage]}
-            path={path}
-            enabled={enabled}
-            renderers={renderers}
-            cells={cells}
-          />
-        )}
-      </div>
+        </div>
 
-      {snackbarOpen &&
-        typeof document !== 'undefined' &&
-        createPortal(
-          <Box
-            sx={{
-              position: 'fixed',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              minHeight: '100dvh',
-              height: '100%',
-              zIndex: 99,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              padding: 4,
-              backgroundColor: 'transparent',
-            }}>
+        {snackbarOpen &&
+          typeof document !== 'undefined' &&
+          createPortal(
             <Box
               sx={{
-                width: '100%',
-                maxWidth: 340,
-                borderRadius: CONFIRM_CARD_RADIUS,
-                border: `${CONFIRM_BORDER_WIDTH}px solid`,
-                borderColor: 'divider',
-                padding: `${CONFIRM_CARD_PADDING}px`,
-                backgroundColor: theme.palette.background.paper,
-                overflow: 'hidden',
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                minHeight: '100dvh',
+                height: '100%',
+                zIndex: 99,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: 4,
+                backgroundColor: 'transparent',
               }}>
-              <Typography
-                variant="h6"
-                sx={{ fontWeight: 600, textAlign: 'center', mb: 1.5 }}>
-                Missing required fields
-              </Typography>
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                sx={{ textAlign: 'center', mb: 3 }}>
-                {snackbarMessage ||
-                  'Some required fields are missing. Any unsaved changes will be available as a draft when you return.'}
-              </Typography>
               <Box
                 sx={{
-                  flexDirection: 'row',
-                  display: 'flex',
-                  justifyContent: 'center',
-                  gap: 2,
-                  flexWrap: 'wrap',
+                  width: '100%',
+                  maxWidth: 340,
+                  borderRadius: CONFIRM_CARD_RADIUS,
+                  border: `${CONFIRM_BORDER_WIDTH}px solid`,
+                  borderColor: 'divider',
+                  padding: `${CONFIRM_CARD_PADDING}px`,
+                  backgroundColor: theme.palette.background.paper,
+                  overflow: 'hidden',
                 }}>
-                <Button
-                  variant="neutral"
-                  size="medium"
-                  onPress={handleSnackbarClose}>
-                  Stay here
-                </Button>
-                <Button variant="danger" size="medium" onPress={handleGoBack}>
-                  Go back
-                </Button>
+                <Typography
+                  variant="h6"
+                  sx={{ fontWeight: 600, textAlign: 'center', mb: 1.5 }}>
+                  Missing required fields
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ textAlign: 'center', mb: 3 }}>
+                  {snackbarMessage ||
+                    'Some required fields are missing. Any unsaved changes will be available as a draft when you return.'}
+                </Typography>
+                <Box
+                  sx={{
+                    flexDirection: 'row',
+                    display: 'flex',
+                    justifyContent: 'center',
+                    gap: 2,
+                    flexWrap: 'wrap',
+                  }}>
+                  <Button
+                    variant="neutral"
+                    size="medium"
+                    onPress={handleSnackbarClose}>
+                    Stay here
+                  </Button>
+                  <Button variant="danger" size="medium" onPress={handleGoBack}>
+                    Go back
+                  </Button>
+                </Box>
               </Box>
-            </Box>
-          </Box>,
-          document.body,
-        )}
-    </FormLayout>
+            </Box>,
+            document.body,
+          )}
+      </FormLayout>
+    </FormContext.Provider>
   );
 };
 

--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -143,6 +143,7 @@ const SwipeLayoutRenderer = ({
   );
   const [snackbarMessage, setSnackbarMessage] = useState<string>('');
   const { core } = useJsonForms();
+  const { formInitData } = useFormContext();
 
   const uiType = (uischema as any).type;
   const isExplicitSwipeLayout = uiType === 'SwipeLayout';
@@ -388,6 +389,38 @@ const SwipeLayoutRenderer = ({
     return layouts[currentPage]?.type === 'Finalize';
   }, [layouts, currentPage]);
 
+  const keyboardSubmitAction = useMemo(() => {
+    const errorCount = core?.errors?.length ?? 0;
+    if (isOnFinalizePage) {
+      return {
+        onTrigger: () => {
+          if (errorCount > 0 || !formInitData) return;
+          window.dispatchEvent(
+            new CustomEvent('finalizeForm', {
+              detail: { formInitData, data },
+            }),
+          );
+        },
+        disabled: errorCount > 0 || !formInitData,
+      };
+    }
+    if (nextVisiblePage !== null) {
+      return {
+        onTrigger: () => navigateToPage(nextVisiblePage),
+        disabled: isNavigating,
+      };
+    }
+    return undefined;
+  }, [
+    isOnFinalizePage,
+    nextVisiblePage,
+    navigateToPage,
+    isNavigating,
+    core?.errors,
+    formInitData,
+    data,
+  ]);
+
   const handleSnackbarClose = useCallback(
     (event?: React.SyntheticEvent | Event, reason?: string) => {
       if (reason === 'clickaway') {
@@ -419,6 +452,7 @@ const SwipeLayoutRenderer = ({
 
   return (
     <FormLayout
+      keyboardSubmitAction={keyboardSubmitAction}
       header={
         <>
           {/* Author-configured form title and sticky fields */}

--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -564,6 +564,17 @@ const SwipeLayoutRenderer = ({
               uischema={uischema}
               mode="screens"
               isOnFinalizePage={isOnFinalizePage}
+              onNavigatePrevious={
+                prevVisiblePage !== null
+                  ? () => navigateToPage(prevVisiblePage)
+                  : undefined
+              }
+              onNavigateNext={
+                nextVisiblePage !== null
+                  ? () => navigateToPage(nextVisiblePage)
+                  : undefined
+              }
+              navigationDisabled={isNavigating}
             />
           </>
         }

--- a/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
+++ b/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
@@ -289,8 +289,8 @@ export interface FormulusInterface {
   /**
    * Get observations for a specific form
    * @param {string} formType - The identifier of the formtype
-   * @param {boolean} [isDraft=false] - Whether to include draft observations
-   * @param {boolean} [includeDeleted=false] - Whether to include deleted observations
+   * @param {boolean} [isDraft=false] - Deprecated: drafts are handled only in formplayer; ignored in Formulus
+   * @param {boolean} [includeDeleted=false] - Whether to include deleted observations (default false = exclude)
    * @returns {Promise<FormObservation[]>} Array of form observations
    */
   getObservations(
@@ -305,7 +305,7 @@ export interface FormulusInterface {
    * Age filtering via age_from_dob(data.dob) is handled client-side in formplayer.
    * @param options - Query options
    * @param options.formType - Form type to query
-   * @param options.isDraft - Include drafts (default false)
+   * @param options.isDraft - Deprecated: drafts handled in formplayer; ignored
    * @param options.includeDeleted - Include deleted (default false)
    * @param options.whereClause - SQL-like WHERE clause for filtering (e.g. "data.sex = 'male'")
    * @returns {Promise<FormObservation[]>} Array of filtered observations

--- a/formulus-formplayer/src/utils/keyboardEnterKeyHint.ts
+++ b/formulus-formplayer/src/utils/keyboardEnterKeyHint.ts
@@ -1,0 +1,55 @@
+import type { InputHTMLAttributes } from 'react';
+
+export type KeyboardPrimaryEnterKeyHint = NonNullable<
+  InputHTMLAttributes<HTMLInputElement>['enterKeyHint']
+>;
+
+const VALID_HINTS = new Set<KeyboardPrimaryEnterKeyHint>([
+  'enter',
+  'done',
+  'go',
+  'next',
+  'previous',
+  'search',
+  'send',
+]);
+
+/**
+ * Map author/localized primary action labels to a valid `enterKeyHint`.
+ * The platform keyboard only supports a fixed set (not arbitrary strings).
+ */
+export function enterKeyHintFromPrimaryButtonLabel(
+  label: string | undefined,
+): KeyboardPrimaryEnterKeyHint | undefined {
+  if (label == null || String(label).trim() === '') return undefined;
+  const t = String(label).trim().toLowerCase();
+
+  if (VALID_HINTS.has(t as KeyboardPrimaryEnterKeyHint)) {
+    return t as KeyboardPrimaryEnterKeyHint;
+  }
+
+  if (/\b(next|forward)\b/.test(t) || t === '›' || t === '→') return 'next';
+  if (
+    /\b(finalize|submit|complete|finish|save)\b/.test(t) ||
+    t.includes('finalize')
+  ) {
+    return 'done';
+  }
+  if (/\b(continu|proceed)\b/.test(t)) return 'go';
+  if (t.includes('search')) return 'search';
+  if (t.includes('send')) return 'send';
+  if (/\b(back|prev)\b/.test(t)) return 'previous';
+
+  return undefined;
+}
+
+export function primaryKeyboardEnterKeyHint(
+  isFinalizePage: boolean,
+  nextButtonLabel: string | undefined,
+  finalizeButtonLabel = 'Finalize',
+): KeyboardPrimaryEnterKeyHint {
+  if (isFinalizePage) {
+    return enterKeyHintFromPrimaryButtonLabel(finalizeButtonLabel) ?? 'done';
+  }
+  return enterKeyHintFromPrimaryButtonLabel(nextButtonLabel) ?? 'next';
+}

--- a/formulus/src/screens/SettingsScreen.tsx
+++ b/formulus/src/screens/SettingsScreen.tsx
@@ -134,15 +134,18 @@ const SettingsScreen = () => {
       const normalizedUrl = norm.href;
 
       const trimmedInitial = initialServerUrl.trim();
-      let initialComparable: string;
       if (!trimmedInitial) {
-        initialComparable = '';
-      } else {
-        const initialNorm = normalizeServerUrl(trimmedInitial);
-        initialComparable = initialNorm.ok
-          ? initialNorm.href
-          : trimmedInitial.toLowerCase();
+        // First server URL — nothing to "wipe"; avoid the switch-server dialog.
+        await serverConfigService.saveServerUrl(normalizedUrl);
+        setInitialServerUrl(normalizedUrl);
+        setServerUrl(normalizedUrl);
+        return true;
       }
+
+      const initialNorm = normalizeServerUrl(trimmedInitial);
+      const initialComparable = initialNorm.ok
+        ? initialNorm.href
+        : trimmedInitial.toLowerCase();
 
       if (normalizedUrl === initialComparable) {
         await serverConfigService.saveServerUrl(normalizedUrl);

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -433,7 +433,8 @@ export interface FormulusInterface {
   ): Promise<void>;
 
   /**
-   * Get information about the currently authenticated user
+   * Get information about the currently authenticated user.
+   * When no one is logged in, resolves with `{ username: '' }` (does not reject).
    * @returns {Promise<{username: string, displayName?: string, role?: 'read-only' | 'read-write' | 'admin'}>} User information including role
    */
   getCurrentUser(): Promise<{

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -1004,7 +1004,9 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
       try {
         const credentials = await Keychain.getGenericPassword();
         if (!credentials) {
-          throw new Error('No user credentials found');
+          // Logged out — same shape as authenticated user; empty username is
+          // the contract for callers (e.g. placeholder) and must not throw.
+          return { username: '' };
         }
 
         // Retrieve role from stored user info (set during login)

--- a/packages/components/src/react-web/Button.tsx
+++ b/packages/components/src/react-web/Button.tsx
@@ -20,6 +20,13 @@ export interface WebButtonProps extends ButtonProps {
    * The variant of the paired button (if any)
    */
   pairedVariant?: ButtonVariant;
+
+  /**
+   * Native `<button type>` — use `submit` inside a `<form>` so mobile keyboards
+   * (Go / Send) submit the form.
+   * @default 'button'
+   */
+  nativeType?: 'button' | 'submit' | 'reset';
 }
 
 // Extract token values
@@ -39,6 +46,7 @@ const Button: React.FC<WebButtonProps> = ({
   style,
   testID,
   accessibilityLabel,
+  nativeType = 'button',
 }) => {
   const [isHovered, setIsHovered] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(() => {
@@ -227,7 +235,7 @@ const Button: React.FC<WebButtonProps> = ({
 
   return (
     <button
-      type="button"
+      type={nativeType}
       onClick={handleClick}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}


### PR DESCRIPTION
## Description

Improves swipe-form navigation on mobile and in the WebView:

- **Primary keyboard action:** Wraps swipe layout content in a `<form>` with a persistent hidden `type="submit"` control so the IME **Go / Send** key triggers the same path as **Next** or **finalize** (even when the bottom nav is hidden while the keyboard is open). **Next** uses `type="submit"`; **Finalize** stays button-driven to avoid double-submit. Adds optional `nativeType` on the web `Button` in `@ode/components` and updates formplayer ambient types in `ode-components.d.ts`.
- **Enter key hint:** Introduces `keyboardEnterKeyHint` on form context (driven from swipe layout), label→hint mapping in `src/utils/keyboardEnterKeyHint.ts`, optional SwipeLayout `options.nextButtonLabel` / `finalizeButtonLabel`, and a higher-ranked JSON Forms text control that passes `enterKeyHint` into Material text inputs.
- **Header nav:** Adds compact prev/next chevrons on either side of `FormProgressBar`, calling the same `navigateToPage` handlers as the footer (no synthetic clicks).

## Type of Change

- [ ] Bug Fix
- [x] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [ ] **formulus** (React Native mobile app)
- [x] **formulus-formplayer** (React web app)
- [x] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [x] **Other:** `packages/components` (`@ode/components` web `Button` — `nativeType` for submit)

---

## Related Issue(s)

**Closes/Fixes/Resolves:** <!-- e.g., Closes #123 -->

---

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
- [x] Tested on multiple platforms (if applicable)
- [ ] Not applicable

---

## Breaking Changes

- [ ] This PR introduces breaking changes
- [x] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:**

---

## Documentation Updates

- [ ] Documentation has been updated
- [x] Documentation update is not required

---

## Checklist

- [x] Code follows project style guidelines
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**