### PR TITLE
feat(formplayer): add observationId support in handleSubmission

### DIFF
--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -61,6 +61,7 @@ export interface FormplayerModalHandle {
   handleSubmission: (data: {
     formType: string;
     finalData: Record<string, unknown>;
+    observationId?: string | null;
   }) => Promise<string>;
 }
 
@@ -469,8 +470,12 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       async (data: {
         formType: string;
         finalData: Record<string, unknown>;
+        observationId?: string | null;
       }): Promise<string> => {
-        const { formType, finalData } = data;
+        const { formType, finalData, observationId: observationIdFromBridge } =
+          data;
+        const effectiveObservationId =
+          observationIdFromBridge ?? currentObservationId;
 
         // Set submitting state
         setIsSubmitting(true);
@@ -484,15 +489,15 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
 
           // Save the observation
           let resultObservationId: string;
-          if (currentObservationId) {
+          if (effectiveObservationId) {
             const updateSuccess = await localRepo.updateObservation({
-              observationId: currentObservationId,
+              observationId: effectiveObservationId,
               data: finalData,
             });
             if (!updateSuccess) {
               throw new Error('Failed to update observation');
             }
-            resultObservationId = currentObservationId;
+            resultObservationId = effectiveObservationId;
           } else {
             const newId = await localRepo.saveObservation({
               formType,
@@ -509,7 +514,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
 
           // Resolve the form operation with success result
           const completionResult: FormCompletionResult = {
-            status: currentObservationId ? 'form_updated' : 'form_submitted',
+            status: effectiveObservationId ? 'form_updated' : 'form_submitted',
             observationId: resultObservationId,
             formData: finalData,
             formType: formType,
@@ -524,7 +529,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           }
 
           // Show success message and close modal
-          const successMessage = currentObservationId
+          const successMessage = effectiveObservationId
             ? 'Observation updated successfully!'
             : 'Form submitted successfully!';
           showConfirm({

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -472,8 +472,11 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         finalData: Record<string, unknown>;
         observationId?: string | null;
       }): Promise<string> => {
-        const { formType, finalData, observationId: observationIdFromBridge } =
-          data;
+        const {
+          formType,
+          finalData,
+          observationId: observationIdFromBridge,
+        } = data;
         const effectiveObservationId =
           observationIdFromBridge ?? currentObservationId;
 

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -156,6 +156,7 @@ let activeFormplayerModalRef: {
   handleSubmission: (data: {
     formType: string;
     finalData: Record<string, unknown>;
+    observationId?: string | null;
   }) => Promise<string>;
 } | null = null;
 
@@ -164,6 +165,7 @@ export const setActiveFormplayerModal = (
     handleSubmission: (data: {
       formType: string;
       finalData: Record<string, unknown>;
+      observationId?: string | null;
     }) => Promise<string>;
   } | null,
 ) => {
@@ -292,6 +294,18 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
       formType: string;
       finalData: Record<string, unknown>;
     }) => {
+      // Formplayer uses updateObservation for existing rows; submitObservation for new.
+      // Route updates through the modal too so the operation promise resolves and the UI closes.
+      if (activeFormplayerModalRef) {
+        console.log(
+          'FormulusMessageHandlers: Delegating to FormplayerModal.handleSubmission (update)',
+        );
+        return await activeFormplayerModalRef.handleSubmission({
+          formType: data.formType,
+          finalData: data.finalData,
+          observationId: data.observationId,
+        });
+      }
       return await saveFormData(
         data.formType,
         data.finalData,


### PR DESCRIPTION
## Description

Formplayer finalization for **existing** observations uses the WebView bridge message `updateObservation`, which was handled only by `onUpdateObservation` → `saveFormData`. That path never ran `FormplayerModal.handleSubmission`, so the pending `openFormplayerFromNative` flow did not align with the new-observation path (`onSubmitObservation` → modal), and the modal did not complete/close consistently after save.

**Change:** When the Formplayer modal is active, `onUpdateObservation` now delegates to the same `handleSubmission` as `onSubmitObservation`, passing the bridge `observationId`. `handleSubmission` accepts optional `observationId` and uses `observationIdFromBridge ?? currentObservationId` for update vs create, completion status, and success messaging. Non-modal callers still use `saveFormData` as before.

## Type of Change

- [x] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [x] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:** <!-- Please specify -->

---

## Related Issue(s)

<!-- Use keywords: Closes #123, Fixes #456, Resolves #789 -->

**Closes/Fixes/Resolves:** <!-- e.g., Closes #123 — add if applicable -->

---

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
- [ ] Tested on multiple platforms (if applicable)
- [ ] Not applicable

**Suggested checks:** Edit an existing observation in Formplayer and finalize → same success + dismiss flow as a new observation; `openFormplayerFromNative` resolves with `form_updated`. New observation flow unchanged. Optional: confirm no duplicate success UI is undesirable on screens that also alert after the promise resolves.

---

## Breaking Changes

- [ ] This PR introduces breaking changes
- [x] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:**

---

## Documentation Updates

- [ ] Documentation has been updated
- [x] Documentation update is not required

---

## Checklist

- [x] Code follows project style guidelines
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [x] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**