### PR TITLE
fix(sync): record attachment ops, stabilize observation ids, and harden tests

### DIFF
--- a/formulus/src/api/synkronus/index.ts
+++ b/formulus/src/api/synkronus/index.ts
@@ -362,8 +362,12 @@ class SynkronusApi {
     const attachmentsDirectory = `${RNFS.DocumentDirectoryPath}/attachments`;
     await RNFS.mkdir(attachmentsDirectory);
 
-    const urls = downloadOps.map(op =>
-      op.download_url ? op.download_url : '',
+    // Build URLs from the app's configured server base path. The manifest's download_url is
+    // generated server-side and may point at localhost, which fails on real devices.
+    const config = await this.getConfig();
+    const base = config.basePath.replace(/\/$/, '');
+    const urls = downloadOps.map(
+      op => `${base}/attachments/${encodeURIComponent(op.attachment_id)}`,
     );
     const localPaths = downloadOps.map(
       op => `${attachmentsDirectory}/${op.attachment_id}`,

--- a/formulus/src/database/repositories/WatermelonDBRepo.ts
+++ b/formulus/src/database/repositories/WatermelonDBRepo.ts
@@ -119,6 +119,20 @@ export class WatermelonDBRepo implements LocalRepoInterface {
     }
   }
 
+  /** Resolve a row by Watermelon id or by observation_id column (legacy ingested rows - TODO: Legacy support to be removed in vNextMinor). */
+  private async findObservationRecord(
+    stableId: string,
+  ): Promise<ObservationModel | null> {
+    try {
+      return await this.observationsCollection.find(stableId);
+    } catch {
+      const rows = await this.observationsCollection
+        .query(Q.where('observation_id', stableId))
+        .fetch();
+      return rows[0] ?? null;
+    }
+  }
+
   /**
    * Get an observation by its ID
    * @param id The unique identifier for the observation
@@ -235,10 +249,7 @@ export class WatermelonDBRepo implements LocalRepoInterface {
         input.observationId,
       );
 
-      // Find the observation by ID (which is now the observationId)
-      const record = await this.observationsCollection.find(
-        input.observationId,
-      );
+      const record = await this.findObservationRecord(input.observationId);
 
       if (!record) {
         console.error('Observation not found with ID:', input.observationId);
@@ -292,8 +303,7 @@ export class WatermelonDBRepo implements LocalRepoInterface {
     try {
       console.log('Deleting observation with ObservationId:', id);
 
-      // Find the observation by ID (which is now the observationId)
-      const record = await this.observationsCollection.find(id);
+      const record = await this.findObservationRecord(id);
 
       if (!record) {
         console.error('Observation not found with ID:', id);
@@ -424,38 +434,40 @@ export class WatermelonDBRepo implements LocalRepoInterface {
       const existingMap = new Map(
         existingRecords.map(record => [record.observationId, record]),
       );
-      const batchOps = changes.map(change => {
-        const existing = existingMap.get(change.observationId);
-        if (existing) {
-          console.debug(`Preparing update for observation: ${existing.id}`);
-          if (existing.updatedAt > existing.syncedAt) {
-            console.debug(
-              `Skipping server change for ${existing.id} because it's locally dirty`,
-            );
-            return null; // skip applying server version (TODO: maybe include this information in the return value to be able to report it to the user)
+      const batchOps = changes
+        .map(change => {
+          const existing = existingMap.get(change.observationId);
+          if (existing) {
+            console.debug(`Preparing update for observation: ${existing.id}`);
+            if (existing.updatedAt > existing.syncedAt) {
+              console.debug(
+                `Skipping server change for ${existing.id} because it's locally dirty`,
+              );
+              return null; // skip applying server version (TODO: maybe include this information in the return value to be able to report it to the user)
+            }
+            return existing.prepareUpdate(record => {
+              record.formType = change.formType || record.formType;
+              record.formVersion = change.formVersion || record.formVersion;
+              record.data =
+                typeof change.data === 'string'
+                  ? change.data
+                  : JSON.stringify(change.data);
+              record.deleted = change.deleted ?? record.deleted;
+              // Set optional metadata if provided
+              if (change.author !== undefined) {
+                record.author = change.author ?? '';
+              }
+              if (change.deviceId !== undefined) {
+                record.deviceId = change.deviceId ?? '';
+              }
+              record.syncedAt = new Date();
+            });
           }
-          return existing.prepareUpdate(record => {
-            record.formType = change.formType || record.formType;
-            record.formVersion = change.formVersion || record.formVersion;
-            record.data =
-              typeof change.data === 'string'
-                ? change.data
-                : JSON.stringify(change.data);
-            record.deleted = change.deleted ?? record.deleted;
-            // Set optional metadata if provided
-            if (change.author !== undefined) {
-              record.author = change.author ?? '';
-            }
-            if (change.deviceId !== undefined) {
-              record.deviceId = change.deviceId ?? '';
-            }
-            record.syncedAt = new Date();
-          });
-        } else {
           console.debug(
             `Preparing create for new observation: ${change.observationId}`,
           );
           return this.observationsCollection.prepareCreate(record => {
+            record._raw.id = change.observationId;
             record.observationId = change.observationId;
             record.formType = change.formType || '';
             record.formVersion = change.formVersion || '1.0';
@@ -468,9 +480,11 @@ export class WatermelonDBRepo implements LocalRepoInterface {
             record.deleted = change.deleted ?? false;
             record.syncedAt = new Date();
           });
-        }
-      });
-      await this.database.batch(...batchOps);
+        })
+        .filter((op): op is NonNullable<typeof op> => op != null);
+      if (batchOps.length > 0) {
+        await this.database.batch(...batchOps);
+      }
       return batchOps.length;
     });
     return count;
@@ -501,11 +515,22 @@ export class WatermelonDBRepo implements LocalRepoInterface {
    * @param ids The unique identifiers for the observations
    */
   async markObservationsAsSynced(ids: string[]): Promise<void> {
+    if (ids.length === 0) {
+      return;
+    }
     const now = new Date();
     await this.database.write(async () => {
-      const records = await this.observationsCollection
+      const byPk = await this.observationsCollection
         .query(Q.where('id', Q.oneOf(ids)))
         .fetch();
+      const byObservationColumn = await this.observationsCollection
+        .query(Q.where('observation_id', Q.oneOf(ids)))
+        .fetch();
+      const merged = new Map<string, ObservationModel>();
+      for (const r of [...byPk, ...byObservationColumn]) {
+        merged.set(r.id, r);
+      }
+      const records = [...merged.values()];
 
       const batchOps = records.map(record =>
         record.prepareUpdate(rec => {
@@ -513,7 +538,9 @@ export class WatermelonDBRepo implements LocalRepoInterface {
         }),
       );
 
-      await this.database.batch(...batchOps);
+      if (batchOps.length > 0) {
+        await this.database.batch(...batchOps);
+      }
     });
   }
 
@@ -599,7 +626,7 @@ export class WatermelonDBRepo implements LocalRepoInterface {
     }
 
     return {
-      observationId: model.id, // Now model.id is the same as observationId
+      observationId: ObservationMapper.observationIdFromDBModel(model),
       formType: model.formType,
       formVersion: model.formVersion,
       data: parsedData,

--- a/formulus/src/database/repositories/__tests__/WatermelonDBRepo.test.ts
+++ b/formulus/src/database/repositories/__tests__/WatermelonDBRepo.test.ts
@@ -564,8 +564,7 @@ describe('WatermelonDBRepo', () => {
     expect(record).toBeDefined();
     const model = record as ObservationModel;
     expect(model.observationId).toBe(serverObservationId);
-    // Watermelon may assign its own primary key when _raw.id is not set on create.
-    expect(model.id).not.toBe(serverObservationId);
+    expect(model.id).toBe(serverObservationId);
 
     const domain = ObservationMapper.fromDBModel(model);
     expect(domain.observationId).toBe(serverObservationId);

--- a/formulus/src/database/repositories/__tests__/WatermelonDBRepo.test.ts
+++ b/formulus/src/database/repositories/__tests__/WatermelonDBRepo.test.ts
@@ -1,9 +1,27 @@
+jest.mock('../../../services/GeolocationService', () => ({
+  geolocationService: {
+    getCachedLocation: jest.fn(() => null),
+    getCurrentLocationForObservation: jest.fn(async () => null),
+  },
+}));
+
+jest.mock('../../../services/ClientIdService', () => ({
+  clientIdService: {
+    getClientId: jest.fn(async () => 'jest-test-client'),
+  },
+}));
+
+jest.mock('../../../api/synkronus/Auth', () => ({
+  getUserInfo: jest.fn(async () => ({ username: 'jest-user' })),
+}));
+
 import { Database } from '@nozbe/watermelondb';
 import LokiJSAdapter from '@nozbe/watermelondb/adapters/lokijs';
 import { schemas } from '../../schema';
 import { ObservationModel } from '../../models/ObservationModel';
 import { WatermelonDBRepo } from '../WatermelonDBRepo';
 import { Observation } from '../LocalRepoInterface';
+import { ObservationMapper } from '../../../mappers/ObservationMapper';
 import { Q } from '@nozbe/watermelondb';
 
 // Create a test database with in-memory LokiJS adapter
@@ -180,7 +198,7 @@ describe('WatermelonDBRepo', () => {
     expect(count).toBe(0);
   });
 
-  test('getObservationsByFormId should return observations for a specific form type', async () => {
+  test('getObservationsByFormType should return observations for a specific form type', async () => {
     // Arrange
     const formType1 = 'form-type-1';
     const formType2 = 'form-type-2';
@@ -235,7 +253,7 @@ describe('WatermelonDBRepo', () => {
     expect(records3.length).toBe(1);
 
     // Act
-    const observations = await repo.getObservationsByFormId(formType1);
+    const observations = await repo.getObservationsByFormType(formType1);
     console.log(
       `Found ${observations.length} observations for form type ${formType1}`,
     );
@@ -271,7 +289,8 @@ describe('WatermelonDBRepo', () => {
     console.log('Original observation:', originalObservation);
 
     // Act
-    const updateSuccess = await repo.updateObservation(id, {
+    const updateSuccess = await repo.updateObservation({
+      observationId: id,
       data: { field1: 'updated' },
     });
 
@@ -507,5 +526,55 @@ describe('WatermelonDBRepo', () => {
     }
   });
 
-  test.todo('synchronize should pull and push observations correctly');
+  /**
+   * Regression: observations ingested via applyServerChanges must keep the server's
+   * observation_id as the canonical id exposed to the app and to Synkronus push payloads.
+   *
+   * Why earlier tests missed it:
+   * - All existing WatermelonDBRepo tests only used saveObservation(), which sets both
+   *   Watermelon record id and observation_id to the same obs_${timestamp}_ value.
+   * - applyServerChanges was never covered (only a synchronize() todo).
+   * - prepareCreate for pull sets observation_id but leaves Watermelon to assign a
+   *   different internal id; mappers incorrectly used model.id as domain observationId,
+   *   so pushes could use a random uuid as observation_id and duplicate server rows.
+   */
+  test('applyServerChanges (new row): domain observationId matches server observation_id', async () => {
+    const serverObservationId = 'obs_pulled_from_sync_1001';
+    const serverObservation: Observation = {
+      observationId: serverObservationId,
+      formType: 'register_coffee',
+      formVersion: '1.0',
+      createdAt: new Date('2025-01-02T10:00:00.000Z'),
+      updatedAt: new Date('2025-01-02T11:00:00.000Z'),
+      syncedAt: null,
+      deleted: false,
+      data: { name: 'From server' },
+      geolocation: null,
+      author: 'alice',
+      deviceId: 'device-a',
+    };
+
+    const applied = await repo.applyServerChanges([serverObservation]);
+    expect(applied).toBe(1);
+
+    const collection = database.get('observations');
+    const [record] = await collection
+      .query(Q.where('observation_id', serverObservationId))
+      .fetch();
+    expect(record).toBeDefined();
+    const model = record as ObservationModel;
+    expect(model.observationId).toBe(serverObservationId);
+    // Watermelon may assign its own primary key when _raw.id is not set on create.
+    expect(model.id).not.toBe(serverObservationId);
+
+    const domain = ObservationMapper.fromDBModel(model);
+    expect(domain.observationId).toBe(serverObservationId);
+
+    const viaLookup = await repo.getObservation(serverObservationId);
+    expect(viaLookup).not.toBeNull();
+    expect(viaLookup!.observationId).toBe(serverObservationId);
+
+    const apiPayload = ObservationMapper.toApi(domain);
+    expect(apiPayload.observation_id).toBe(serverObservationId);
+  });
 });

--- a/formulus/src/mappers/ObservationMapper.ts
+++ b/formulus/src/mappers/ObservationMapper.ts
@@ -75,6 +75,15 @@ export class ObservationMapper {
     };
   }
 
+  /**
+   * Canonical observation id for API/sync: the `observation_id` column (server id).
+   * Falls back to Watermelon row id for empty legacy rows.
+   */
+  static observationIdFromDBModel(model: ObservationModel): string {
+    const col = model.observationId?.trim();
+    return col || model.id;
+  }
+
   // DB Model -> Domain
   static fromDBModel(model: ObservationModel): DomainObservation {
     let geolocation: ObservationGeolocation | null = null;
@@ -87,7 +96,7 @@ export class ObservationMapper {
     }
 
     return {
-      observationId: model.id,
+      observationId: ObservationMapper.observationIdFromDBModel(model),
       formType: model.formType,
       formVersion: model.formVersion,
       data:

--- a/formulus/src/mappers/__tests__/ObservationMapper.syncIdentity.test.ts
+++ b/formulus/src/mappers/__tests__/ObservationMapper.syncIdentity.test.ts
@@ -1,0 +1,37 @@
+import { ObservationMapper } from '../ObservationMapper';
+import type { ObservationModel } from '../../database/models/ObservationModel';
+
+/**
+ * Documents the contract broken when domain observationId is taken from WatermelonDB's
+ * internal row id instead of the observation_id column (see WatermelonDBRepo.applyServerChanges prepareCreate).
+ *
+ * Why this was not caught earlier: WatermelonDBRepo tests only exercised saveObservation(),
+ * which sets _raw.id === observation_id, so model.id and model.observationId were always equal.
+ */
+describe('ObservationMapper sync identity (regression)', () => {
+  test('fromDBModel must use observation_id column when it differs from Watermelon row id', () => {
+    const serverId = 'obs_pulled_from_sync_1001';
+    const rowAsModel = {
+      id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      observationId: serverId,
+      formType: 'register_coffee',
+      formVersion: '1.0',
+      data: JSON.stringify({ k: 'v' }),
+      geolocation: '',
+      deleted: false,
+      author: 'a',
+      deviceId: 'd1',
+      createdAt: new Date('2025-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2025-01-02T00:00:00.000Z'),
+      syncedAt: new Date('2025-01-03T00:00:00.000Z'),
+    } as ObservationModel;
+
+    const domain = ObservationMapper.fromDBModel(rowAsModel);
+
+    expect(domain.observationId).toBe(serverId);
+    expect(domain.observationId).not.toBe(rowAsModel.id);
+
+    const api = ObservationMapper.toApi(domain);
+    expect(api.observation_id).toBe(serverId);
+  });
+});

--- a/synkronus/internal/api/api.go
+++ b/synkronus/internal/api/api.go
@@ -107,7 +107,11 @@ func NewRouter(log *logger.Logger, h *handlers.Handler) http.Handler {
 	}
 
 	// Create attachment handler
-	attachmentHandler := handlers.NewAttachmentHandler(log, attachmentService)
+	attachmentHandler := handlers.NewAttachmentHandler(
+		log,
+		attachmentService,
+		h.AttachmentManifestService(),
+	)
 
 	// Protected routes - require authentication
 	r.Group(func(r chi.Router) {

--- a/synkronus/internal/handlers/attachment.go
+++ b/synkronus/internal/handlers/attachment.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
 
@@ -12,14 +14,20 @@ import (
 )
 
 type AttachmentHandler struct {
-	service attachment.Service
-	log     *logger.Logger
+	service  attachment.Service
+	manifest attachment.ManifestService
+	log      *logger.Logger
 }
 
-func NewAttachmentHandler(log *logger.Logger, service attachment.Service) *AttachmentHandler {
+func NewAttachmentHandler(
+	log *logger.Logger,
+	service attachment.Service,
+	manifest attachment.ManifestService,
+) *AttachmentHandler {
 	return &AttachmentHandler{
-		service: service,
-		log:     log,
+		service:  service,
+		manifest: manifest,
+		log:      log,
 	}
 }
 
@@ -55,7 +63,7 @@ func (h *AttachmentHandler) UploadAttachment(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Get the file from the form data
-	file, _, err := r.FormFile("file")
+	file, header, err := r.FormFile("file")
 	if err != nil {
 		if errors.Is(err, http.ErrMissingFile) {
 			SendErrorResponse(w, http.StatusBadRequest, nil, "file is required")
@@ -77,10 +85,33 @@ func (h *AttachmentHandler) UploadAttachment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// Record manifest operation so other clients receive a download op in /attachments/manifest.
+	// client_id empty => NULL, meaning all clients (see migration comment on attachment_operations).
+	if err := h.recordAttachmentCreate(r.Context(), attachmentID, header); err != nil {
+		h.log.Error("Failed to record attachment manifest operation", "attachmentId", attachmentID, "error", err)
+		SendErrorResponse(w, http.StatusInternalServerError, err, "Failed to register attachment for sync")
+		return
+	}
+
 	// Return success response
 	SendJSONResponse(w, http.StatusOK, map[string]string{
 		"status": "success",
 	})
+}
+
+func (h *AttachmentHandler) recordAttachmentCreate(ctx context.Context, attachmentID string, header *multipart.FileHeader) error {
+	var sizePtr *int
+	if header != nil && header.Size > 0 {
+		s := int(header.Size)
+		sizePtr = &s
+	}
+	var contentType *string
+	if header != nil {
+		if ct := header.Header.Get("Content-Type"); ct != "" {
+			contentType = &ct
+		}
+	}
+	return h.manifest.RecordOperation(ctx, attachmentID, "create", "", sizePtr, contentType)
 }
 
 // DownloadAttachment handles GET /attachments/{attachment_id}

--- a/synkronus/internal/handlers/attachment_sync_integration_test.go
+++ b/synkronus/internal/handlers/attachment_sync_integration_test.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendataensemble/synkronus/internal/handlers/mocks"
+	"github.com/opendataensemble/synkronus/pkg/attachment"
+	"github.com/opendataensemble/synkronus/pkg/config"
+	"github.com/opendataensemble/synkronus/pkg/logger"
+	authmw "github.com/opendataensemble/synkronus/pkg/middleware/auth"
+	"github.com/opendataensemble/synkronus/pkg/sync"
+)
+
+// TestAttachmentUpload_FollowedByManifest_ReturnsDownloadForSecondDevice exercises the
+// contract the mobile app relies on: PUT /attachments/{id} must register a manifest row
+// so POST /attachments/manifest returns a download for other clients.
+func TestAttachmentUpload_FollowedByManifest_ReturnsDownloadForSecondDevice(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires PostgreSQL")
+	}
+
+	db, cleanup := sync.SetupTestDatabase(t)
+	defer cleanup()
+
+	dataDir := t.TempDir()
+	cfg := &config.Config{
+		Port:    "8098",
+		DataDir: dataDir,
+	}
+	log := logger.NewLogger()
+
+	attSvc, err := attachment.NewService(cfg)
+	require.NoError(t, err)
+	manifestSvc := attachment.NewManifestService(db, cfg, log)
+	require.NoError(t, manifestSvc.Initialize(context.Background()))
+
+	attHandler := NewAttachmentHandler(log, attSvc, manifestSvc)
+
+	mockSync := mocks.NewMockSyncService()
+	require.NoError(t, mockSync.Initialize(context.Background()))
+
+	h := NewHandler(
+		log,
+		cfg,
+		&mockAuthService{},
+		&mockAppBundleService{},
+		mockSync,
+		&mockUserService{},
+		&mockVersionService{},
+		manifestSvc,
+		mocks.NewMockDataExportService(),
+	)
+
+	r := chi.NewRouter()
+	r.Group(func(r chi.Router) {
+		r.Use(authmw.AuthMiddleware(&mockAuthService{}, log))
+		r.Route("/attachments", func(r chi.Router) {
+			r.Post("/manifest", h.AttachmentManifestHandler)
+			r.Route("/{attachment_id}", func(r chi.Router) {
+				r.Put("/", attHandler.UploadAttachment)
+			})
+		})
+	})
+
+	ts := httptest.NewServer(r)
+	t.Cleanup(ts.Close)
+
+	attachmentID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jpg"
+	uploadURL := ts.URL + "/attachments/" + attachmentID
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile("file", "photo.jpg")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("fake jpeg bytes"))
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+
+	req, err := http.NewRequest(http.MethodPut, uploadURL, &buf)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer test-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	ubody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("upload status %d: %s", resp.StatusCode, string(ubody))
+	}
+
+	manifestBody, err := json.Marshal(attachment.AttachmentManifestRequest{
+		ClientID:     "second-device",
+		SinceVersion: 0,
+	})
+	require.NoError(t, err)
+
+	mreq, err := http.NewRequest(http.MethodPost, ts.URL+"/attachments/manifest", bytes.NewReader(manifestBody))
+	require.NoError(t, err)
+	mreq.Header.Set("Content-Type", "application/json")
+	mreq.Header.Set("Authorization", "Bearer test-token")
+
+	mresp, err := http.DefaultClient.Do(mreq)
+	require.NoError(t, err)
+	defer mresp.Body.Close()
+	mbody, err := io.ReadAll(mresp.Body)
+	require.NoError(t, err)
+	if mresp.StatusCode != http.StatusOK {
+		t.Fatalf("manifest status %d: %s", mresp.StatusCode, string(mbody))
+	}
+
+	var m attachment.AttachmentManifestResponse
+	require.NoError(t, json.Unmarshal(mbody, &m))
+	require.Len(t, m.Operations, 1)
+	op := m.Operations[0]
+	assert.Equal(t, "download", op.Operation)
+	assert.Equal(t, attachmentID, op.AttachmentID)
+	require.NotNil(t, op.DownloadURL)
+}

--- a/synkronus/internal/handlers/attachment_test.go
+++ b/synkronus/internal/handlers/attachment_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/opendataensemble/synkronus/internal/handlers/mocks"
 	"github.com/opendataensemble/synkronus/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -75,8 +76,21 @@ func TestAttachmentHandler_UploadAttachment(t *testing.T) {
 			mockSvc := &mockAttachmentService{}
 			tc.setupMocks(mockSvc)
 
+			var manifestRecords int
+			mockManifest := &mocks.MockAttachmentManifestService{
+				RecordOperationFunc: func(ctx context.Context, attachmentID, operation, clientID string, size *int, contentType *string) error {
+					manifestRecords++
+					if tc.expectedStatus == http.StatusOK {
+						assert.Equal(t, tc.attachmentID, attachmentID)
+						assert.Equal(t, "create", operation)
+						assert.Equal(t, "", clientID)
+					}
+					return nil
+				},
+			}
+
 			// Create handler with mock service
-			handler := NewAttachmentHandler(logger.NewLogger(), mockSvc)
+			handler := NewAttachmentHandler(logger.NewLogger(), mockSvc, mockManifest)
 
 			// Create a test file
 			var b bytes.Buffer
@@ -101,6 +115,11 @@ func TestAttachmentHandler_UploadAttachment(t *testing.T) {
 			assert.Equal(t, tc.expectedStatus, rr.Code)
 			if tc.expectedBody != "" {
 				assert.JSONEq(t, tc.expectedBody, rr.Body.String())
+			}
+			if tc.expectedStatus == http.StatusOK {
+				assert.Equal(t, 1, manifestRecords, "manifest RecordOperation should run after successful save")
+			} else {
+				assert.Equal(t, 0, manifestRecords, "manifest should not be updated when upload fails")
 			}
 		})
 	}
@@ -143,8 +162,10 @@ func TestAttachmentHandler_DownloadAttachment(t *testing.T) {
 			mockSvc := &mockAttachmentService{}
 			tc.setupMocks(mockSvc)
 
+			mockManifest := &mocks.MockAttachmentManifestService{}
+
 			// Create handler with mock service
-			handler := NewAttachmentHandler(logger.NewLogger(), mockSvc)
+			handler := NewAttachmentHandler(logger.NewLogger(), mockSvc, mockManifest)
 
 			// Create request
 			req := httptest.NewRequest("GET", "/attachments/"+tc.attachmentID, nil)
@@ -199,8 +220,10 @@ func TestAttachmentHandler_CheckAttachment(t *testing.T) {
 			mockSvc := &mockAttachmentService{}
 			tc.setupMocks(mockSvc)
 
+			mockManifest := &mocks.MockAttachmentManifestService{}
+
 			// Create handler with mock service
-			handler := NewAttachmentHandler(logger.NewLogger(), mockSvc)
+			handler := NewAttachmentHandler(logger.NewLogger(), mockSvc, mockManifest)
 
 			// Create request
 			req := httptest.NewRequest("HEAD", "/attachments/"+tc.attachmentID, nil)
@@ -232,7 +255,9 @@ func TestDownloadAttachment_StreamingErrorLogged(t *testing.T) {
 	mockSvc.On("Exists", mock.Anything, "badfile").Return(true, nil)
 	mockSvc.On("Get", mock.Anything, "badfile").Return(io.NopCloser(errReader{}), nil)
 
-	handler := NewAttachmentHandler(log, mockSvc)
+	mockManifest := &mocks.MockAttachmentManifestService{}
+
+	handler := NewAttachmentHandler(log, mockSvc, mockManifest)
 
 	req := httptest.NewRequest("GET", "/attachments/badfile", nil)
 	rr := httptest.NewRecorder()

--- a/synkronus/internal/handlers/handlers.go
+++ b/synkronus/internal/handlers/handlers.go
@@ -59,3 +59,8 @@ func (h *Handler) GetAuthService() auth.AuthServiceInterface {
 func (h *Handler) GetConfig() *config.Config {
 	return h.config
 }
+
+// AttachmentManifestService returns the attachment manifest service (sync operations).
+func (h *Handler) AttachmentManifestService() attachment.ManifestService {
+	return h.attachmentManifestService
+}

--- a/synkronus/pkg/attachment/manifest_integration_test.go
+++ b/synkronus/pkg/attachment/manifest_integration_test.go
@@ -1,0 +1,54 @@
+package attachment_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendataensemble/synkronus/pkg/attachment"
+	"github.com/opendataensemble/synkronus/pkg/config"
+	"github.com/opendataensemble/synkronus/pkg/logger"
+	synctest "github.com/opendataensemble/synkronus/pkg/sync"
+)
+
+// TestManifest_RecordOperation_ReachesOtherClients verifies that attachment manifest
+// rows with NULL client_id are returned to any client. A missing RecordOperation on
+// upload used to mean other devices never saw download ops — this test guards the DB contract.
+func TestManifest_RecordOperation_ReachesOtherClients(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires PostgreSQL")
+	}
+
+	db, cleanup := synctest.SetupTestDatabase(t)
+	defer cleanup()
+
+	log := logger.NewLogger()
+	cfg := &config.Config{Port: "8099"}
+	svc := attachment.NewManifestService(db, cfg, log)
+	require.NoError(t, svc.Initialize(context.Background()))
+
+	ctx := context.Background()
+	attachmentID := "00000000-1111-2222-3333-444444444444.jpg"
+	size := 2048
+	ct := "image/jpeg"
+
+	require.NoError(t, svc.RecordOperation(ctx, attachmentID, "create", "", &size, &ct))
+
+	for _, clientID := range []string{"device-a", "device-b"} {
+		manifest, err := svc.GetManifest(ctx, attachment.AttachmentManifestRequest{
+			ClientID:     clientID,
+			SinceVersion: 0,
+		})
+		require.NoError(t, err, "client_id=%q", clientID)
+		require.Len(t, manifest.Operations, 1, "client_id=%q", clientID)
+		op := manifest.Operations[0]
+		assert.Equal(t, "download", op.Operation)
+		assert.Equal(t, attachmentID, op.AttachmentID)
+		assert.NotNil(t, op.DownloadURL)
+		assert.Equal(t, size, *op.Size)
+		require.NotNil(t, op.ContentType)
+		assert.Equal(t, ct, *op.ContentType)
+	}
+}

--- a/synkronus/pkg/sync/testdb_helper.go
+++ b/synkronus/pkg/sync/testdb_helper.go
@@ -105,9 +105,12 @@ func pingWithTimeout(db *sql.DB, timeout time.Duration) error {
 
 // ensureTestSchema creates or updates test database schema
 func ensureTestSchema(db *sql.DB) error {
-	// Drop existing tables to ensure clean state
+	// Drop existing tables to ensure clean state (order: triggers → tables → functions)
 	dropQueries := []string{
+		"DROP TRIGGER IF EXISTS attachment_operations_version_trigger ON attachment_operations",
 		"DROP TRIGGER IF EXISTS observations_version_trigger ON observations",
+		"DROP TABLE IF EXISTS attachment_operations",
+		"DROP FUNCTION IF EXISTS increment_attachment_sync_version()",
 		"DROP FUNCTION IF EXISTS update_sync_version()",
 		"DROP TABLE IF EXISTS observations",
 		"DROP TABLE IF EXISTS sync_version",
@@ -186,11 +189,68 @@ func ensureTestSchema(db *sql.DB) error {
 		return fmt.Errorf("failed to create trigger: %w", err)
 	}
 
+	// Attachment manifest (matches production migration; required for attachment sync integration tests)
+	attachmentTableSQL := `
+		CREATE TABLE IF NOT EXISTS attachment_operations (
+			id SERIAL PRIMARY KEY,
+			attachment_id VARCHAR(255) NOT NULL,
+			operation VARCHAR(10) NOT NULL CHECK (operation IN ('create', 'update', 'delete')),
+			client_id VARCHAR(255),
+			version BIGINT NOT NULL,
+			size INTEGER,
+			content_type VARCHAR(255),
+			created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+		)
+	`
+	if _, err := db.Exec(attachmentTableSQL); err != nil {
+		return fmt.Errorf("failed to create attachment_operations table: %w", err)
+	}
+
+	attachmentIndexes := []string{
+		`CREATE INDEX IF NOT EXISTS idx_attachment_operations_version ON attachment_operations(version)`,
+		`CREATE INDEX IF NOT EXISTS idx_attachment_operations_client ON attachment_operations(client_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_attachment_operations_attachment_id ON attachment_operations(attachment_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_attachment_operations_version_client ON attachment_operations(version, client_id)`,
+	}
+	for _, q := range attachmentIndexes {
+		if _, err := db.Exec(q); err != nil {
+			return fmt.Errorf("failed to create attachment_operations index: %w", err)
+		}
+	}
+
+	incrementAttachmentVersionSQL := `
+		CREATE OR REPLACE FUNCTION increment_attachment_sync_version() RETURNS TRIGGER AS $$
+		BEGIN
+			UPDATE sync_version SET current_version = current_version + 1, updated_at = NOW() WHERE id = 1;
+			NEW.version = (SELECT current_version FROM sync_version WHERE id = 1);
+			NEW.created_at = NOW();
+			RETURN NEW;
+		END;
+		$$ LANGUAGE plpgsql;
+	`
+	if _, err := db.Exec(incrementAttachmentVersionSQL); err != nil {
+		return fmt.Errorf("failed to create increment_attachment_sync_version: %w", err)
+	}
+
+	attachmentTriggerSQL := `
+		CREATE TRIGGER attachment_operations_version_trigger
+			BEFORE INSERT ON attachment_operations
+			FOR EACH ROW
+			EXECUTE FUNCTION increment_attachment_sync_version();
+	`
+	if _, err := db.Exec(attachmentTriggerSQL); err != nil {
+		return fmt.Errorf("failed to create attachment_operations trigger: %w", err)
+	}
+
 	return nil
 }
 
 // ResetTestData cleans all test data and resets version to 1
 func ResetTestData(db *sql.DB) error {
+	if _, err := db.Exec("DELETE FROM attachment_operations"); err != nil {
+		return fmt.Errorf("failed to clean attachment_operations: %w", err)
+	}
+
 	// Clean observations
 	if _, err := db.Exec("DELETE FROM observations"); err != nil {
 		return fmt.Errorf("failed to clean observations: %w", err)


### PR DESCRIPTION
## Description
**Synkronus (Go)**
- After a successful `PUT /attachments/{id}`, the server now calls **`RecordOperation(..., "create", "")`** so `attachment_operations` gets a row with **`client_id` NULL**, and other devices receive **`download`** entries from `POST /attachments/manifest`. Fixes missing photo files on non-uploader devices.
- **`NewAttachmentHandler`** accepts **`ManifestService`**; handler tests updated.
- **Integration tests:** attachment manifest schema in `SetupTestDatabase`, `TestManifest_RecordOperation_ReachesOtherClients`, and HTTP **`TestAttachmentUpload_FollowedByManifest_ReturnsDownloadForSecondDevice`**.
- **`pkg/sync` test DB** extended with `attachment_operations` + trigger; **`ResetTestData`** clears it.
**Formulus (React Native)**
- **`processAttachmentDownloads`** builds URLs from **`getConfig().basePath`** + `/attachments/{id}` so downloads work on real devices (avoids manifest URLs pointing at `localhost`).
- **Observation sync identity:** `applyServerChanges` sets **`record._raw.id`** on ingest; **`ObservationMapper.observationIdFromDBModel`**; **`markObservationsAsSynced`** matches by `id` or `observation_id`; **`updateObservation` / `deleteObservation`** use shared lookup for legacy rows; **`applyServerChanges`** filters **`null`** batch ops before `batch()`.
- **Tests:** Jest mocks for repo tests; **`ObservationMapper.syncIdentity`** + **`applyServerChanges` regression**; fixes for `getObservationsByFormType` and **`updateObservation`** call shape.
- **Docs:** **`docs/remove-legacy-observation-row-ids.md`** — checklist to drop legacy dual-lookup before go-live.
## Type of Change
- [x] Bug Fix
- [ ] New Feature / Enhancement
- [x] Refactor / Code Cleanup
- [x] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):
---
## Component(s) Affected
- [x] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [x] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [x] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:**
---
## Related Issue(s)
**Closes/Fixes/Resolves:** *(add issue numbers if applicable)*
---
## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manually tested *(recommended: two devices, photo sync + observation edit)*
- [ ] Tested on multiple platforms (if applicable)
- [ ] Not applicable
---
## Breaking Changes
- [ ] This PR introduces breaking changes
- [x] This PR does NOT introduce breaking changes
**If breaking changes, please describe migration steps:**
- N/A. Server change is backward compatible; clients build attachment download URLs from configured base path. Existing DBs may still need manifest backfill or re-upload for attachments uploaded before `RecordOperation` existed.
---
## Documentation Updates
- [x] Documentation has been updated
- [ ] Documentation update is not required
---
## Checklist
- [x] Code follows project style guidelines
- [ ] All existing tests pass *(run `go test ./...` in synkronus and `npm test` in formulus)*
- [x] New tests added for new functionality
- [x] PR title follows Conventional Commits format
---
**Thank you for contributing to Open Data Ensemble (ODE)!**