### PR TITLE
feat(formulus): patch Android build.gradle to disable minification fo…

### DIFF
--- a/formulus/scripts/vendor-notifee-core.mjs
+++ b/formulus/scripts/vendor-notifee-core.mjs
@@ -32,6 +32,29 @@ function headAt(destDir) {
   }
 }
 
+/** Upstream enables minify on :notifee_core release; R8 then marks InitProvider.onCreate() final. NotifeeInitProvider subclasses it from another module → LinkageError on release APK only. */
+function patchNotifeeAndroidReleaseMinify() {
+  const gradle = path.join(dest, 'android', 'build.gradle');
+  if (!fs.existsSync(gradle)) return;
+  let s = fs.readFileSync(gradle, 'utf8');
+  if (s.includes('[formulus] notifee_core release: keep minify off')) return;
+  const re = /(\s+release\s*\{\s*\n\s*)minifyEnabled\s+true/;
+  if (!re.test(s)) {
+    if (!s.includes('minifyEnabled false')) {
+      console.warn(
+        'vendor-notifee-core: expected `release { minifyEnabled true }` in android/build.gradle — not patching',
+      );
+    }
+    return;
+  }
+  s = s.replace(
+    re,
+    `$1// [formulus] notifee_core release: keep minify off (R8 made InitProvider.onCreate final → LinkageError in NotifeeInitProvider)\n      minifyEnabled false`,
+  );
+  fs.writeFileSync(gradle, s);
+  console.log('Patched notifee android/build.gradle (release minifyEnabled false).');
+}
+
 if (!fs.existsSync(path.join(dest, 'android', 'build.gradle'))) {
   fs.mkdirSync(dest, { recursive: true });
   if (!fs.existsSync(path.join(dest, '.git'))) {
@@ -41,12 +64,14 @@ if (!fs.existsSync(path.join(dest, 'android', 'build.gradle'))) {
   console.log(`Fetching notifee@${NOTIFEE_COMMIT} ...`);
   sh(`git fetch --depth 1 origin ${NOTIFEE_COMMIT}`, { cwd: dest });
   sh('git checkout FETCH_HEAD', { cwd: dest });
+  patchNotifeeAndroidReleaseMinify();
   console.log('notifee core ready.');
   process.exit(0);
 }
 
 const head = headAt(dest);
 if (head === NOTIFEE_COMMIT) {
+  patchNotifeeAndroidReleaseMinify();
   console.log(`notifee core already at ${NOTIFEE_COMMIT}`);
   process.exit(0);
 }
@@ -54,4 +79,5 @@ if (head === NOTIFEE_COMMIT) {
 console.log(`Updating notifee ${head || '(unknown)'} → ${NOTIFEE_COMMIT} ...`);
 sh(`git fetch --depth 1 origin ${NOTIFEE_COMMIT}`, { cwd: dest });
 sh('git checkout FETCH_HEAD', { cwd: dest });
+patchNotifeeAndroidReleaseMinify();
 console.log('notifee core ready.');


### PR DESCRIPTION
App crashes on start due to Notifee minifying causing a linkage error

- Added a function to modify the Android build.gradle file to set minifyEnabled to false for the notifee_core release configuration, preventing LinkageError issues during APK builds.
- The patch is applied when fetching or updating the notifee core.
