### PR TITLE
feat(formulus): dark dividers 

### DIFF
--- a/formulus/src/components/MenuDrawer.tsx
+++ b/formulus/src/components/MenuDrawer.tsx
@@ -17,7 +17,6 @@ import {
   odeBorderWidth,
   odeRadius,
 } from '../theme/odeDesign';
-import tokens from '@ode/tokens/dist/react-native/tokens-resolved';
 import { useAppTheme } from '../contexts/AppThemeContext';
 import Button from './common/Button';
 import { loadSettingsHydrationFromStorage } from '../services/SettingsHydrationCache';
@@ -101,12 +100,8 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({
   const textColor = isDark
     ? (themeColors.onSurface as string)
     : (colors.neutral[900] as string);
-  const odeOpacity = (tokens as { opacity?: Record<string, string> }).opacity;
-  const dividerOpacityDark =
-    odeOpacity?.['10'] != null ? Number(odeOpacity['10']) : 0.1;
-  const sectionDividerColor = isDark
-    ? withAlpha(colors.neutral.white as string, dividerOpacityDark)
-    : (themeColors.divider as string);
+  /** darker than faint white in dark mode. */
+  const sectionDividerColor = themeColors.divider as string;
   const menuModalBorderColor = sectionDividerColor;
   const sectionBg = themeColors.surface as string;
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);

--- a/formulus/src/screens/ObservationDetailScreen.tsx
+++ b/formulus/src/screens/ObservationDetailScreen.tsx
@@ -26,6 +26,7 @@ import {
   odeSpacing,
   odeRadius,
   odeScreenHeaderHeight,
+  odeBorderWidth,
 } from '../theme/odeDesign';
 
 interface ObservationDetailScreenProps {
@@ -46,6 +47,12 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
   const [observation, setObservation] = useState<Observation | null>(null);
   const [formName, setFormName] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
+
+  /** Matches Observation Details header bottom border (hairline + theme divider). */
+  const formDataRowSeparatorStyle = {
+    borderBottomWidth: odeBorderWidth.hairline,
+    borderBottomColor: themeColors.divider as string,
+  };
 
   useEffect(() => {
     loadObservation();
@@ -149,7 +156,11 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
       return (
         <View
           key={key}
-          style={[styles.fieldContainer, { paddingLeft: level * 16 }]}>
+          style={[
+            styles.fieldContainer,
+            formDataRowSeparatorStyle,
+            { paddingLeft: level * 16 },
+          ]}>
           <Text style={fieldKeyStyle}>{key}:</Text>
           <Text style={[styles.fieldValue, { color: themeColors.onSurface }]}>
             null
@@ -162,7 +173,11 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
       return (
         <View
           key={key}
-          style={[styles.fieldContainer, { paddingLeft: level * 16 }]}>
+          style={[
+            styles.fieldContainer,
+            formDataRowSeparatorStyle,
+            { paddingLeft: level * 16 },
+          ]}>
           <Text style={fieldKeyStyle}>{key}:</Text>
           {Object.entries(value).map(([k, v]) =>
             renderDataField(k, v, level + 1),
@@ -175,7 +190,11 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
       return (
         <View
           key={key}
-          style={[styles.fieldContainer, { paddingLeft: level * 16 }]}>
+          style={[
+            styles.fieldContainer,
+            formDataRowSeparatorStyle,
+            { paddingLeft: level * 16 },
+          ]}>
           <Text style={fieldKeyStyle}>{key}:</Text>
           {value.map((item, index) => (
             <View key={index} style={styles.arrayItem}>
@@ -193,7 +212,11 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
     return (
       <View
         key={key}
-        style={[styles.fieldContainer, { paddingLeft: level * 16 }]}>
+        style={[
+          styles.fieldContainer,
+          formDataRowSeparatorStyle,
+          { paddingLeft: level * 16 },
+        ]}>
         <Text style={fieldKeyStyle}>{key}:</Text>
         <Text style={[styles.fieldValue, { color: themeColors.onSurface }]}>
           {String(value)}
@@ -472,8 +495,6 @@ const styles = StyleSheet.create({
   fieldContainer: {
     marginBottom: odeSpacing.xs,
     paddingBottom: odeSpacing.xs,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.neutral[100],
     alignSelf: 'stretch',
   },
   fieldKey: {


### PR DESCRIPTION
# Summary
In dark mode the line dividers are too light, so sections didn’t match the rest of the app. Aligning them with the same divider color and hairline as the screen header makes separation clearer and more consistent without changing layout or behavior.

## Changes:

- **Observation details**: Form Data row separators use the same hairline width and `themeColors.divider` as the screen header bottom border (replacing the old light gray / 1px lines).

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>

<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/f39a156a-ee65-4311-b932-75c76c4f8a4b" width="260"/>
</td>

<td align="center">
<img src="https://github.com/user-attachments/assets/5948416f-2a94-4c03-aa35-4ecc21283421" width="260"/>
</td>
</tr>
</table>


- **Menu drawer**: Keeps the faded-end section dividers; updates their color to `themeColors.divider` so they read clearly in dark mode and match the rest of the app.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>

<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/0c976c09-f303-4547-a77d-002f1fdbe299" width="260"/>
</td>

<td align="center">
<img src="https://github.com/user-attachments/assets/0af6ffd9-948c-4db5-a7da-ad4dfe152c3a" width="260"/>
</td>
</tr>
</table>