### PR TITLE
feat(formulus): Add export functionality

### DIFF
--- a/formulus/src/database/repositories/LocalRepoInterface.ts
+++ b/formulus/src/database/repositories/LocalRepoInterface.ts
@@ -30,6 +30,11 @@ export interface LocalRepoInterface {
   getObservationsByFormType(formType: string): Promise<Observation[]>;
 
   /**
+   * Get every observation row in local storage (including soft-deleted).
+   */
+  getAllObservations(): Promise<Observation[]>;
+
+  /**
    * Update an existing observation
    * @param input The observation ID and new data
    * @returns Promise resolving to a boolean indicating success

--- a/formulus/src/database/repositories/WatermelonDBRepo.ts
+++ b/formulus/src/database/repositories/WatermelonDBRepo.ts
@@ -238,6 +238,22 @@ export class WatermelonDBRepo implements LocalRepoInterface {
   }
 
   /**
+   * All local observation rows (including soft-deleted), for backup/export.
+   */
+  async getAllObservations(): Promise<Observation[]> {
+    try {
+      const rows = await this.observationsCollection.query().fetch();
+      return rows.map(row => this.mapObservationModelToInterface(row));
+    } catch (error) {
+      console.error(
+        'Error getting all observations:',
+        error instanceof Error ? error.message : String(error),
+      );
+      return [];
+    }
+  }
+
+  /**
    * Update an existing observation
    * @param input The observation ID and new data
    * @returns Promise resolving to a boolean indicating success

--- a/formulus/src/screens/HelpScreen.tsx
+++ b/formulus/src/screens/HelpScreen.tsx
@@ -23,6 +23,7 @@ import {
 } from '../theme/odeDesign';
 import logo from '../../assets/images/logo.png';
 import { attachmentExportService } from '../services/AttachmentExportService';
+import { observationExportService } from '../services/ObservationExportService';
 
 const FORUM_URL = 'https://forum.opendataensemble.org';
 const EMAIL_URL = 'mailto:hello@opendataensemble.org';
@@ -30,6 +31,7 @@ const GH_URL = 'https://github.com/OpenDataEnsemble';
 
 const HelpScreen: React.FC = () => {
   const [exportingAttachments, setExportingAttachments] = useState(false);
+  const [exportingObservations, setExportingObservations] = useState(false);
   const { themeColors, resolvedMode } = useAppTheme();
   const isDark = resolvedMode === 'dark';
   const sectionColor = isDark
@@ -57,6 +59,19 @@ const HelpScreen: React.FC = () => {
       Alert.alert('Export failed', message);
     } finally {
       setExportingAttachments(false);
+    }
+  };
+
+  const onExportObservations = async () => {
+    setExportingObservations(true);
+    try {
+      await observationExportService.exportAllObservationsZip();
+    } catch (e) {
+      const message =
+        e instanceof Error ? e.message : 'Could not export observations.';
+      Alert.alert('Export failed', message);
+    } finally {
+      setExportingObservations(false);
     }
   };
 
@@ -220,6 +235,42 @@ const HelpScreen: React.FC = () => {
                     { color: themeColors.primary as string },
                   ]}>
                   Download device-local attachment data
+                </Text>
+              )}
+            </Pressable>
+          </View>
+
+          <View style={[cardStyle, styles.exportSection]}>
+            <Text style={[styles.exportHint, mutedOnSurface]}>
+              Export all locally stored observations as one JSON file per row
+              (including soft-deleted), packaged in a zip. Choose where to save
+              it. Does not change any data in the app.
+            </Text>
+            <Pressable
+              onPress={onExportObservations}
+              disabled={exportingObservations}
+              accessibilityRole="button"
+              accessibilityLabel="Save all observations as zip of JSON files"
+              accessibilityState={{ disabled: exportingObservations }}
+              style={({ pressed }) => [
+                styles.exportButton,
+                {
+                  borderColor: themeColors.primary as string,
+                  opacity: exportingObservations ? 0.55 : pressed ? 0.85 : 1,
+                },
+              ]}>
+              {exportingObservations ? (
+                <ActivityIndicator
+                  size="small"
+                  color={themeColors.primary as string}
+                />
+              ) : (
+                <Text
+                  style={[
+                    styles.exportButtonText,
+                    { color: themeColors.primary as string },
+                  ]}>
+                  Download observations (JSON zip)
                 </Text>
               )}
             </Pressable>

--- a/formulus/src/screens/HelpScreen.tsx
+++ b/formulus/src/screens/HelpScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
@@ -7,6 +7,8 @@ import {
   Linking,
   Pressable,
   Image,
+  Alert,
+  ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import colors from '../theme/colors';
@@ -20,12 +22,14 @@ import {
   odeScreenHeaderHeight,
 } from '../theme/odeDesign';
 import logo from '../../assets/images/logo.png';
+import { attachmentExportService } from '../services/AttachmentExportService';
 
 const FORUM_URL = 'https://forum.opendataensemble.org';
 const EMAIL_URL = 'mailto:hello@opendataensemble.org';
 const GH_URL = 'https://github.com/OpenDataEnsemble';
 
 const HelpScreen: React.FC = () => {
+  const [exportingAttachments, setExportingAttachments] = useState(false);
   const { themeColors, resolvedMode } = useAppTheme();
   const isDark = resolvedMode === 'dark';
   const sectionColor = isDark
@@ -38,6 +42,23 @@ const HelpScreen: React.FC = () => {
     { borderColor: themeColors.divider as string, backgroundColor: cardBg },
   ];
   const onSurface = { color: themeColors.onSurface as string };
+  const mutedOnSurface = {
+    color: themeColors.onSurface as string,
+    opacity: 0.72,
+  };
+
+  const onExportAttachments = async () => {
+    setExportingAttachments(true);
+    try {
+      await attachmentExportService.exportDeviceLocalAttachmentsZip();
+    } catch (e) {
+      const message =
+        e instanceof Error ? e.message : 'Could not export attachments.';
+      Alert.alert('Export failed', message);
+    } finally {
+      setExportingAttachments(false);
+    }
+  };
 
   return (
     <BlurredScreenBackground>
@@ -167,6 +188,42 @@ const HelpScreen: React.FC = () => {
               </Text>
             </Pressable>
           </View>
+
+          <View style={[cardStyle, styles.exportSection]}>
+            <Text style={[styles.exportHint, mutedOnSurface]}>
+              Export on-device attachment files (same paths and filenames as in
+              app storage, including unique ids) into a zip you can save or
+              share. Does not change any data in the app.
+            </Text>
+            <Pressable
+              onPress={onExportAttachments}
+              disabled={exportingAttachments}
+              accessibilityRole="button"
+              accessibilityLabel="Download device-local attachment data as zip"
+              accessibilityState={{ disabled: exportingAttachments }}
+              style={({ pressed }) => [
+                styles.exportButton,
+                {
+                  borderColor: themeColors.primary as string,
+                  opacity: exportingAttachments ? 0.55 : pressed ? 0.85 : 1,
+                },
+              ]}>
+              {exportingAttachments ? (
+                <ActivityIndicator
+                  size="small"
+                  color={themeColors.primary as string}
+                />
+              ) : (
+                <Text
+                  style={[
+                    styles.exportButtonText,
+                    { color: themeColors.primary as string },
+                  ]}>
+                  Download device-local attachment data
+                </Text>
+              )}
+            </Pressable>
+          </View>
         </ScrollView>
       </SafeAreaView>
     </BlurredScreenBackground>
@@ -238,6 +295,29 @@ const styles = StyleSheet.create({
   },
   cardTextCentered: { textAlign: 'left' },
   link: { marginTop: odeSpacing.sm, fontWeight: '600' },
+  exportSection: {
+    marginTop: odeSpacing.sm,
+    paddingVertical: odeSpacing.sm,
+  },
+  exportHint: {
+    fontSize: odeTypography.caption,
+    lineHeight: 18,
+    marginBottom: odeSpacing.md,
+  },
+  exportButton: {
+    alignSelf: 'flex-start',
+    paddingVertical: odeSpacing.sm,
+    paddingHorizontal: odeSpacing.md,
+    borderRadius: odeRadius.card,
+    borderWidth: odeBorderWidth.hairline,
+    minWidth: 140,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  exportButtonText: {
+    fontSize: odeTypography.bodySm,
+    fontWeight: '600',
+  },
 });
 
 export default HelpScreen;

--- a/formulus/src/screens/HelpScreen.tsx
+++ b/formulus/src/screens/HelpScreen.tsx
@@ -192,14 +192,14 @@ const HelpScreen: React.FC = () => {
           <View style={[cardStyle, styles.exportSection]}>
             <Text style={[styles.exportHint, mutedOnSurface]}>
               Export on-device attachment files (same paths and filenames as in
-              app storage, including unique ids) into a zip you can save or
-              share. Does not change any data in the app.
+              app storage, including unique ids) into a zip, then choose where
+              to save it (e.g. Downloads). Does not change any data in the app.
             </Text>
             <Pressable
               onPress={onExportAttachments}
               disabled={exportingAttachments}
               accessibilityRole="button"
-              accessibilityLabel="Download device-local attachment data as zip"
+              accessibilityLabel="Save device-local attachment data as zip file"
               accessibilityState={{ disabled: exportingAttachments }}
               style={({ pressed }) => [
                 styles.exportButton,

--- a/formulus/src/services/AttachmentExportService.ts
+++ b/formulus/src/services/AttachmentExportService.ts
@@ -1,5 +1,10 @@
+import { Platform } from 'react-native';
 import RNFS from 'react-native-fs';
-import Share from 'react-native-share';
+import {
+  saveDocuments,
+  isErrorWithCode,
+  errorCodes,
+} from '@react-native-documents/picker';
 import { zip } from 'react-native-zip-archive';
 
 const ATTACHMENTS_DIR = `${RNFS.DocumentDirectoryPath}/attachments`;
@@ -17,14 +22,15 @@ async function directoryHasAnyFile(dirPath: string): Promise<boolean> {
   return false;
 }
 
-function fileUrlForShare(absolutePath: string): string {
-  const normalized = absolutePath.replace(/^file:\/\//, '');
-  return `file://${normalized}`;
+/** `file://` URI safe for native document save (spaces etc.). */
+function pathToFileUri(path: string): string {
+  return `file://${encodeURI(path)}`;
 }
 
 /**
  * Zips the device-local `attachments` tree (including `pending_upload` and
- * GUID-based filenames) and opens the system share sheet. Does not modify app data.
+ * GUID-based filenames) and opens the system Save-as dialog so the user can
+ * store the archive (e.g. Downloads). Does not modify app data.
  */
 export const attachmentExportService = {
   async exportDeviceLocalAttachmentsZip(): Promise<void> {
@@ -48,23 +54,28 @@ export const attachmentExportService = {
 
     await zip(ATTACHMENTS_DIR, zipPath);
 
-    const shareUrl = fileUrlForShare(zipPath);
+    const sourceUri = pathToFileUri(zipPath);
 
     try {
-      await Share.open({
-        title: 'Export attachments',
-        subject: zipName,
-        url: shareUrl,
-        type: 'application/zip',
-        filename: zipName,
-        failOnCancel: false,
+      const results = await saveDocuments({
+        sourceUris: [sourceUri],
+        mimeType: 'application/zip',
+        fileName: zipName,
+        ...(Platform.OS === 'ios' ? { copy: true as const } : {}),
       });
+      const first = results[0];
+      if (first?.error) {
+        throw new Error(first.error);
+      }
+    } catch (e) {
+      if (isErrorWithCode(e) && e.code === errorCodes.OPERATION_CANCELED) {
+        return;
+      }
+      throw e;
     } finally {
-      setTimeout(() => {
-        RNFS.unlink(zipPath).catch(() => {
-          /* best-effort cleanup of cache */
-        });
-      }, 8000);
+      await RNFS.unlink(zipPath).catch(() => {
+        /* temp zip cleanup */
+      });
     }
   },
 };

--- a/formulus/src/services/AttachmentExportService.ts
+++ b/formulus/src/services/AttachmentExportService.ts
@@ -1,11 +1,6 @@
-import { Platform } from 'react-native';
 import RNFS from 'react-native-fs';
-import {
-  saveDocuments,
-  isErrorWithCode,
-  errorCodes,
-} from '@react-native-documents/picker';
 import { zip } from 'react-native-zip-archive';
+import { saveZipToDevice } from './saveZipToDevice';
 
 const ATTACHMENTS_DIR = `${RNFS.DocumentDirectoryPath}/attachments`;
 
@@ -20,11 +15,6 @@ async function directoryHasAnyFile(dirPath: string): Promise<boolean> {
     }
   }
   return false;
-}
-
-/** `file://` URI safe for native document save (spaces etc.). */
-function pathToFileUri(path: string): string {
-  return `file://${encodeURI(path)}`;
 }
 
 /**
@@ -54,28 +44,6 @@ export const attachmentExportService = {
 
     await zip(ATTACHMENTS_DIR, zipPath);
 
-    const sourceUri = pathToFileUri(zipPath);
-
-    try {
-      const results = await saveDocuments({
-        sourceUris: [sourceUri],
-        mimeType: 'application/zip',
-        fileName: zipName,
-        ...(Platform.OS === 'ios' ? { copy: true as const } : {}),
-      });
-      const first = results[0];
-      if (first?.error) {
-        throw new Error(first.error);
-      }
-    } catch (e) {
-      if (isErrorWithCode(e) && e.code === errorCodes.OPERATION_CANCELED) {
-        return;
-      }
-      throw e;
-    } finally {
-      await RNFS.unlink(zipPath).catch(() => {
-        /* temp zip cleanup */
-      });
-    }
+    await saveZipToDevice(zipPath, zipName);
   },
 };

--- a/formulus/src/services/AttachmentExportService.ts
+++ b/formulus/src/services/AttachmentExportService.ts
@@ -1,0 +1,70 @@
+import RNFS from 'react-native-fs';
+import Share from 'react-native-share';
+import { zip } from 'react-native-zip-archive';
+
+const ATTACHMENTS_DIR = `${RNFS.DocumentDirectoryPath}/attachments`;
+
+async function directoryHasAnyFile(dirPath: string): Promise<boolean> {
+  const entries = await RNFS.readDir(dirPath);
+  for (const entry of entries) {
+    if (entry.isFile()) {
+      return true;
+    }
+    if (entry.isDirectory() && (await directoryHasAnyFile(entry.path))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function fileUrlForShare(absolutePath: string): string {
+  const normalized = absolutePath.replace(/^file:\/\//, '');
+  return `file://${normalized}`;
+}
+
+/**
+ * Zips the device-local `attachments` tree (including `pending_upload` and
+ * GUID-based filenames) and opens the system share sheet. Does not modify app data.
+ */
+export const attachmentExportService = {
+  async exportDeviceLocalAttachmentsZip(): Promise<void> {
+    const exists = await RNFS.exists(ATTACHMENTS_DIR);
+    if (!exists) {
+      throw new Error('No local attachment data found.');
+    }
+
+    const hasFiles = await directoryHasAnyFile(ATTACHMENTS_DIR);
+    if (!hasFiles) {
+      throw new Error('No local attachment data found.');
+    }
+
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    const zipName = `formulus-attachments-${stamp}.zip`;
+    const zipPath = `${RNFS.CachesDirectoryPath}/${zipName}`;
+
+    if (await RNFS.exists(zipPath)) {
+      await RNFS.unlink(zipPath);
+    }
+
+    await zip(ATTACHMENTS_DIR, zipPath);
+
+    const shareUrl = fileUrlForShare(zipPath);
+
+    try {
+      await Share.open({
+        title: 'Export attachments',
+        subject: zipName,
+        url: shareUrl,
+        type: 'application/zip',
+        filename: zipName,
+        failOnCancel: false,
+      });
+    } finally {
+      setTimeout(() => {
+        RNFS.unlink(zipPath).catch(() => {
+          /* best-effort cleanup of cache */
+        });
+      }, 8000);
+    }
+  },
+};

--- a/formulus/src/services/ObservationExportService.ts
+++ b/formulus/src/services/ObservationExportService.ts
@@ -1,0 +1,106 @@
+import RNFS from 'react-native-fs';
+import { zip } from 'react-native-zip-archive';
+import { Observation } from '../database/models/Observation';
+import { databaseService } from '../database/DatabaseService';
+import { saveZipToDevice } from './saveZipToDevice';
+
+function safeJsonFileName(observationId: string): string {
+  const base = observationId.replace(/[/\\?%*:|"<>]/g, '_');
+  const trimmed = base.length > 180 ? `${base.slice(0, 180)}_trunc` : base;
+  return `${trimmed}.json`;
+}
+
+function uniqueJsonFileName(
+  observationId: string,
+  usedNames: Set<string>,
+): string {
+  const stem = safeJsonFileName(observationId).replace(/\.json$/i, '');
+  let candidate = `${stem}.json`;
+  let suffix = 0;
+  while (usedNames.has(candidate)) {
+    suffix += 1;
+    candidate = `${stem}__${suffix}.json`;
+  }
+  usedNames.add(candidate);
+  return candidate;
+}
+
+function observationToExportJson(obs: Observation): Record<string, unknown> {
+  return {
+    observationId: obs.observationId,
+    formType: obs.formType,
+    formVersion: obs.formVersion,
+    createdAt: obs.createdAt.toISOString(),
+    updatedAt: obs.updatedAt.toISOString(),
+    syncedAt: obs.syncedAt?.toISOString() ?? null,
+    deleted: obs.deleted,
+    data: obs.data,
+    geolocation: obs.geolocation,
+    author: obs.author ?? '',
+    deviceId: obs.deviceId ?? '',
+  };
+}
+
+async function removeDirectoryRecursive(dirPath: string): Promise<void> {
+  const exists = await RNFS.exists(dirPath);
+  if (!exists) {
+    return;
+  }
+  const items = await RNFS.readDir(dirPath);
+  for (const item of items) {
+    if (item.isDirectory()) {
+      await removeDirectoryRecursive(item.path);
+    } else {
+      await RNFS.unlink(item.path);
+    }
+  }
+  await RNFS.unlink(dirPath);
+}
+
+/**
+ * Exports every local observation as one JSON file per row, zips the folder,
+ * and opens the system Save-as dialog. Does not modify app data.
+ */
+export const observationExportService = {
+  async exportAllObservationsZip(): Promise<void> {
+    const observations = await databaseService
+      .getLocalRepo()
+      .getAllObservations();
+
+    if (observations.length === 0) {
+      throw new Error('No observations to export.');
+    }
+
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    const workDir = `${RNFS.CachesDirectoryPath}/formulus-obs-export-${stamp}`;
+    const zipName = `formulus-observations-${stamp}.zip`;
+    const zipPath = `${RNFS.CachesDirectoryPath}/${zipName}`;
+
+    if (await RNFS.exists(workDir)) {
+      await removeDirectoryRecursive(workDir);
+    }
+    await RNFS.mkdir(workDir);
+
+    try {
+      const usedNames = new Set<string>();
+      for (const obs of observations) {
+        const fileName = uniqueJsonFileName(obs.observationId, usedNames);
+        const filePath = `${workDir}/${fileName}`;
+        const json = JSON.stringify(observationToExportJson(obs), null, 2);
+        await RNFS.writeFile(filePath, json, 'utf8');
+      }
+
+      if (await RNFS.exists(zipPath)) {
+        await RNFS.unlink(zipPath);
+      }
+
+      await zip(workDir, zipPath);
+    } finally {
+      await removeDirectoryRecursive(workDir).catch(() => {
+        /* best-effort cleanup */
+      });
+    }
+
+    await saveZipToDevice(zipPath, zipName);
+  },
+};

--- a/formulus/src/services/saveZipToDevice.ts
+++ b/formulus/src/services/saveZipToDevice.ts
@@ -1,0 +1,45 @@
+import { Platform } from 'react-native';
+import RNFS from 'react-native-fs';
+import {
+  saveDocuments,
+  isErrorWithCode,
+  errorCodes,
+} from '@react-native-documents/picker';
+
+/** `file://` URI safe for native document save (spaces etc.). */
+export function pathToFileUri(path: string): string {
+  return `file://${encodeURI(path)}`;
+}
+
+/**
+ * Opens the system Save-as dialog for a zip on disk, then removes the temp file.
+ * Resolves silently if the user cancels (OPERATION_CANCELED).
+ */
+export async function saveZipToDevice(
+  zipPath: string,
+  zipFileName: string,
+): Promise<void> {
+  const sourceUri = pathToFileUri(zipPath);
+
+  try {
+    const results = await saveDocuments({
+      sourceUris: [sourceUri],
+      mimeType: 'application/zip',
+      fileName: zipFileName,
+      ...(Platform.OS === 'ios' ? { copy: true as const } : {}),
+    });
+    const first = results[0];
+    if (first?.error) {
+      throw new Error(first.error);
+    }
+  } catch (e) {
+    if (isErrorWithCode(e) && e.code === errorCodes.OPERATION_CANCELED) {
+      return;
+    }
+    throw e;
+  } finally {
+    await RNFS.unlink(zipPath).catch(() => {
+      /* temp zip cleanup */
+    });
+  }
+}


### PR DESCRIPTION
# Formulus - device local export


## Description

This PR adds two functions to export attachments and observations from the device to a zip-archive that can be stored on the device. It is available from the Help & Support screen and is only intended as a last resort in various scenarios. 

## Type of Change

- [ ] Bug Fix
- [x] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [x] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:** <!-- Please specify -->

---

**Thank you for contributing to Open Data Ensemble (ODE)!**
