### PR TITLE
feat(synkronus): Standardize API routes with '/api' prefix and update tests

### DIFF
--- a/formulus/src/api/synkronus/generated/api.ts
+++ b/formulus/src/api/synkronus/generated/api.ts
@@ -1218,7 +1218,7 @@ export const DataExportApiAxiosParamCreator = function (
     getParquetExportZip: async (
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      const localVarPath = `/dataexport/parquet`;
+      const localVarPath = `/api/dataexport/parquet`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -1365,7 +1365,7 @@ export const DefaultApiAxiosParamCreator = function (
         'changePasswordRequest',
         changePasswordRequest,
       );
-      const localVarPath = `/users/change-password`;
+      const localVarPath = `/api/users/change-password`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -1422,7 +1422,7 @@ export const DefaultApiAxiosParamCreator = function (
     ): Promise<RequestArgs> => {
       // verify required parameter 'attachmentId' is not null or undefined
       assertParamExists('checkAttachmentExists', 'attachmentId', attachmentId);
-      const localVarPath = `/attachments/{attachment_id}`.replace(
+      const localVarPath = `/api/attachments/{attachment_id}`.replace(
         `{${'attachment_id'}}`,
         encodeURIComponent(String(attachmentId)),
       );
@@ -1474,7 +1474,7 @@ export const DefaultApiAxiosParamCreator = function (
     ): Promise<RequestArgs> => {
       // verify required parameter 'createUserRequest' is not null or undefined
       assertParamExists('createUser', 'createUserRequest', createUserRequest);
-      const localVarPath = `/users/create`;
+      const localVarPath = `/api/users/create`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -1533,7 +1533,7 @@ export const DefaultApiAxiosParamCreator = function (
     ): Promise<RequestArgs> => {
       // verify required parameter 'username' is not null or undefined
       assertParamExists('deleteUser', 'username', username);
-      const localVarPath = `/users/{username}`.replace(
+      const localVarPath = `/api/users/{username}`.replace(
         `{${'username'}}`,
         encodeURIComponent(String(username)),
       );
@@ -1592,7 +1592,7 @@ export const DefaultApiAxiosParamCreator = function (
     ): Promise<RequestArgs> => {
       // verify required parameter 'path' is not null or undefined
       assertParamExists('downloadAppBundleFile', 'path', path);
-      const localVarPath = `/app-bundle/download/{path}`.replace(
+      const localVarPath = `/api/app-bundle/download/{path}`.replace(
         `{${'path'}}`,
         encodeURIComponent(String(path)),
       );
@@ -1652,7 +1652,7 @@ export const DefaultApiAxiosParamCreator = function (
     ): Promise<RequestArgs> => {
       // verify required parameter 'attachmentId' is not null or undefined
       assertParamExists('downloadAttachment', 'attachmentId', attachmentId);
-      const localVarPath = `/attachments/{attachment_id}`.replace(
+      const localVarPath = `/api/attachments/{attachment_id}`.replace(
         `{${'attachment_id'}}`,
         encodeURIComponent(String(attachmentId)),
       );
@@ -1704,7 +1704,7 @@ export const DefaultApiAxiosParamCreator = function (
       xApiVersion?: string,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      const localVarPath = `/app-bundle/changes`;
+      const localVarPath = `/api/app-bundle/changes`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -1760,7 +1760,7 @@ export const DefaultApiAxiosParamCreator = function (
       xApiVersion?: string,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      const localVarPath = `/app-bundle/manifest`;
+      const localVarPath = `/api/app-bundle/manifest`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -1808,7 +1808,7 @@ export const DefaultApiAxiosParamCreator = function (
       xApiVersion?: string,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      const localVarPath = `/app-bundle/versions`;
+      const localVarPath = `/api/app-bundle/versions`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -1864,7 +1864,7 @@ export const DefaultApiAxiosParamCreator = function (
         'attachmentManifestRequest',
         attachmentManifestRequest,
       );
-      const localVarPath = `/attachments/manifest`;
+      const localVarPath = `/api/attachments/manifest`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -1917,7 +1917,7 @@ export const DefaultApiAxiosParamCreator = function (
     getVersion: async (
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      const localVarPath = `/version`;
+      const localVarPath = `/api/version`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -1958,7 +1958,7 @@ export const DefaultApiAxiosParamCreator = function (
       xApiVersion?: string,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      const localVarPath = `/users`;
+      const localVarPath = `/api/users`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -2010,7 +2010,7 @@ export const DefaultApiAxiosParamCreator = function (
     ): Promise<RequestArgs> => {
       // verify required parameter 'loginRequest' is not null or undefined
       assertParamExists('login', 'loginRequest', loginRequest);
-      const localVarPath = `/auth/login`;
+      const localVarPath = `/api/auth/login`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -2063,7 +2063,7 @@ export const DefaultApiAxiosParamCreator = function (
       bundle?: File,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      const localVarPath = `/app-bundle/push`;
+      const localVarPath = `/api/app-bundle/push`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -2130,7 +2130,7 @@ export const DefaultApiAxiosParamCreator = function (
         'refreshTokenRequest',
         refreshTokenRequest,
       );
-      const localVarPath = `/auth/refresh`;
+      const localVarPath = `/api/auth/refresh`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -2189,7 +2189,7 @@ export const DefaultApiAxiosParamCreator = function (
         'resetUserPasswordRequest',
         resetUserPasswordRequest,
       );
-      const localVarPath = `/users/reset-password`;
+      const localVarPath = `/api/users/reset-password`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -2248,7 +2248,7 @@ export const DefaultApiAxiosParamCreator = function (
     ): Promise<RequestArgs> => {
       // verify required parameter 'version' is not null or undefined
       assertParamExists('switchAppBundleVersion', 'version', version);
-      const localVarPath = `/app-bundle/switch/{version}`.replace(
+      const localVarPath = `/api/app-bundle/switch/{version}`.replace(
         `{${'version'}}`,
         encodeURIComponent(String(version)),
       );
@@ -2307,7 +2307,7 @@ export const DefaultApiAxiosParamCreator = function (
     ): Promise<RequestArgs> => {
       // verify required parameter 'syncPullRequest' is not null or undefined
       assertParamExists('syncPull', 'syncPullRequest', syncPullRequest);
-      const localVarPath = `/sync/pull`;
+      const localVarPath = `/api/sync/pull`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -2374,7 +2374,7 @@ export const DefaultApiAxiosParamCreator = function (
     ): Promise<RequestArgs> => {
       // verify required parameter 'syncPushRequest' is not null or undefined
       assertParamExists('syncPush', 'syncPushRequest', syncPushRequest);
-      const localVarPath = `/sync/push`;
+      const localVarPath = `/api/sync/push`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -2435,7 +2435,7 @@ export const DefaultApiAxiosParamCreator = function (
       assertParamExists('uploadAttachment', 'attachmentId', attachmentId);
       // verify required parameter 'file' is not null or undefined
       assertParamExists('uploadAttachment', 'file', file);
-      const localVarPath = `/attachments/{attachment_id}`.replace(
+      const localVarPath = `/api/attachments/{attachment_id}`.replace(
         `{${'attachment_id'}}`,
         encodeURIComponent(String(attachmentId)),
       );

--- a/formulus/src/api/synkronus/generated/docs/DataExportApi.md
+++ b/formulus/src/api/synkronus/generated/docs/DataExportApi.md
@@ -2,9 +2,9 @@
 
 All URIs are relative to _http://localhost_
 
-| Method                                          | HTTP request                | Description                               |
-| ----------------------------------------------- | --------------------------- | ----------------------------------------- |
-| [**getParquetExportZip**](#getparquetexportzip) | **GET** /dataexport/parquet | Download a ZIP archive of Parquet exports |
+| Method                                          | HTTP request                    | Description                               |
+| ----------------------------------------------- | ------------------------------- | ----------------------------------------- |
+| [**getParquetExportZip**](#getparquetexportzip) | **GET** /api/dataexport/parquet | Download a ZIP archive of Parquet exports |
 
 # **getParquetExportZip**
 

--- a/formulus/src/api/synkronus/generated/docs/DefaultApi.md
+++ b/formulus/src/api/synkronus/generated/docs/DefaultApi.md
@@ -2,28 +2,28 @@
 
 All URIs are relative to _http://localhost_
 
-| Method                                                | HTTP request                          | Description                                               |
-| ----------------------------------------------------- | ------------------------------------- | --------------------------------------------------------- |
-| [**changePassword**](#changepassword)                 | **POST** /users/change-password       | Change user password (authenticated user)\&#39;s password |
-| [**checkAttachmentExists**](#checkattachmentexists)   | **HEAD** /attachments/{attachment_id} | Check if an attachment exists                             |
-| [**createUser**](#createuser)                         | **POST** /users/create                | Create a new user (admin only)                            |
-| [**deleteUser**](#deleteuser)                         | **DELETE** /users/{username}          | Delete a user (admin only)                                |
-| [**downloadAppBundleFile**](#downloadappbundlefile)   | **GET** /app-bundle/download/{path}   | Download a specific file from the app bundle              |
-| [**downloadAttachment**](#downloadattachment)         | **GET** /attachments/{attachment_id}  | Download an attachment by ID                              |
-| [**getAppBundleChanges**](#getappbundlechanges)       | **GET** /app-bundle/changes           | Get changes between two app bundle versions               |
-| [**getAppBundleManifest**](#getappbundlemanifest)     | **GET** /app-bundle/manifest          | Get the current custom app bundle manifest                |
-| [**getAppBundleVersions**](#getappbundleversions)     | **GET** /app-bundle/versions          | Get a list of available app bundle versions               |
-| [**getAttachmentManifest**](#getattachmentmanifest)   | **POST** /attachments/manifest        | Get attachment manifest for incremental sync              |
-| [**getVersion**](#getversion)                         | **GET** /version                      | Get server version and system information                 |
-| [**listUsers**](#listusers)                           | **GET** /users                        | List all users (admin only)                               |
-| [**login**](#login)                                   | **POST** /auth/login                  | Authenticate user and return JWT tokens                   |
-| [**pushAppBundle**](#pushappbundle)                   | **POST** /app-bundle/push             | Upload a new app bundle (admin only)                      |
-| [**refreshToken**](#refreshtoken)                     | **POST** /auth/refresh                | Refresh JWT token                                         |
-| [**resetUserPassword**](#resetuserpassword)           | **POST** /users/reset-password        | Reset user password (admin only)                          |
-| [**switchAppBundleVersion**](#switchappbundleversion) | **POST** /app-bundle/switch/{version} | Switch to a specific app bundle version (admin only)      |
-| [**syncPull**](#syncpull)                             | **POST** /sync/pull                   | Pull updated records since last sync                      |
-| [**syncPush**](#syncpush)                             | **POST** /sync/push                   | Push new or updated records to the server                 |
-| [**uploadAttachment**](#uploadattachment)             | **PUT** /attachments/{attachment_id}  | Upload a new attachment with specified ID                 |
+| Method                                                | HTTP request                              | Description                                               |
+| ----------------------------------------------------- | ----------------------------------------- | --------------------------------------------------------- |
+| [**changePassword**](#changepassword)                 | **POST** /api/users/change-password       | Change user password (authenticated user)\&#39;s password |
+| [**checkAttachmentExists**](#checkattachmentexists)   | **HEAD** /api/attachments/{attachment_id} | Check if an attachment exists                             |
+| [**createUser**](#createuser)                         | **POST** /api/users/create                | Create a new user (admin only)                            |
+| [**deleteUser**](#deleteuser)                         | **DELETE** /api/users/{username}          | Delete a user (admin only)                                |
+| [**downloadAppBundleFile**](#downloadappbundlefile)   | **GET** /api/app-bundle/download/{path}   | Download a specific file from the app bundle              |
+| [**downloadAttachment**](#downloadattachment)         | **GET** /api/attachments/{attachment_id}  | Download an attachment by ID                              |
+| [**getAppBundleChanges**](#getappbundlechanges)       | **GET** /api/app-bundle/changes           | Get changes between two app bundle versions               |
+| [**getAppBundleManifest**](#getappbundlemanifest)     | **GET** /api/app-bundle/manifest          | Get the current custom app bundle manifest                |
+| [**getAppBundleVersions**](#getappbundleversions)     | **GET** /api/app-bundle/versions          | Get a list of available app bundle versions               |
+| [**getAttachmentManifest**](#getattachmentmanifest)   | **POST** /api/attachments/manifest        | Get attachment manifest for incremental sync              |
+| [**getVersion**](#getversion)                         | **GET** /api/version                      | Get server version and system information                 |
+| [**listUsers**](#listusers)                           | **GET** /api/users                        | List all users (admin only)                               |
+| [**login**](#login)                                   | **POST** /api/auth/login                  | Authenticate user and return JWT tokens                   |
+| [**pushAppBundle**](#pushappbundle)                   | **POST** /api/app-bundle/push             | Upload a new app bundle (admin only)                      |
+| [**refreshToken**](#refreshtoken)                     | **POST** /api/auth/refresh                | Refresh JWT token                                         |
+| [**resetUserPassword**](#resetuserpassword)           | **POST** /api/users/reset-password        | Reset user password (admin only)                          |
+| [**switchAppBundleVersion**](#switchappbundleversion) | **POST** /api/app-bundle/switch/{version} | Switch to a specific app bundle version (admin only)      |
+| [**syncPull**](#syncpull)                             | **POST** /api/sync/pull                   | Pull updated records since last sync                      |
+| [**syncPush**](#syncpush)                             | **POST** /api/sync/push                   | Push new or updated records to the server                 |
+| [**uploadAttachment**](#uploadattachment)             | **PUT** /api/attachments/{attachment_id}  | Upload a new attachment with specified ID                 |
 
 # **changePassword**
 

--- a/formulus/src/api/synkronus/index.ts
+++ b/formulus/src/api/synkronus/index.ts
@@ -147,7 +147,7 @@ class SynkronusApi {
     );
     const urls = filesToDownload.map(
       file =>
-        `${config.basePath}/app-bundle/download/${encodeURIComponent(file.path)}`,
+        `${config.basePath}/api/app-bundle/download/${encodeURIComponent(file.path)}`,
     );
     const localFiles = filesToDownload.map(
       file => `${outputRootDirectory}/${file.path}`,
@@ -177,7 +177,7 @@ class SynkronusApi {
     const authToken =
       this.fastGetToken_cachedToken ?? (await this.fastGetToken());
 
-    const zipUrl = `${config.basePath}/app-bundle/download-zip`;
+    const zipUrl = `${config.basePath}/api/app-bundle/download-zip`;
     const tempZipPath = `${RNFS.CachesDirectoryPath}/bundle_temp.zip`;
     const tempExtractPath = `${RNFS.CachesDirectoryPath}/bundle_staging`;
     const appDir = `${RNFS.DocumentDirectoryPath}/app`;
@@ -367,7 +367,7 @@ class SynkronusApi {
     const config = await this.getConfig();
     const base = config.basePath.replace(/\/$/, '');
     const urls = downloadOps.map(
-      op => `${base}/attachments/${encodeURIComponent(op.attachment_id)}`,
+      op => `${base}/api/attachments/${encodeURIComponent(op.attachment_id)}`,
     );
     const localPaths = downloadOps.map(
       op => `${attachmentsDirectory}/${op.attachment_id}`,
@@ -616,7 +616,7 @@ class SynkronusApi {
     const config = await this.getConfig();
     const urls = attachments.map(
       attachment =>
-        `${config.basePath}/attachments/${encodeURIComponent(attachment)}`,
+        `${config.basePath}/api/attachments/${encodeURIComponent(attachment)}`,
     );
     const localFilePaths = attachments.map(
       attachment => `${downloadDirectory}/${attachment}`,

--- a/synkronus-cli/internal/auth/auth.go
+++ b/synkronus-cli/internal/auth/auth.go
@@ -36,7 +36,7 @@ type Claims struct {
 // Login authenticates with the Synkronus API and returns a token
 func Login(username, password string) (*TokenResponse, error) {
 	apiURL := normalizeBaseURL(utils.EnsureScheme(viper.GetString("api.url")))
-	loginURL := fmt.Sprintf("%s/auth/login", apiURL)
+	loginURL := fmt.Sprintf("%s/api/auth/login", apiURL)
 
 	// Prepare login request
 	loginData := map[string]string{
@@ -98,7 +98,7 @@ func Login(username, password string) (*TokenResponse, error) {
 // RefreshToken refreshes the JWT token
 func RefreshToken() (*TokenResponse, error) {
 	apiURL := normalizeBaseURL(utils.EnsureScheme(viper.GetString("api.url")))
-	refreshURL := fmt.Sprintf("%s/auth/refresh", apiURL)
+	refreshURL := fmt.Sprintf("%s/api/auth/refresh", apiURL)
 	refreshToken := viper.GetString("auth.refresh_token")
 
 	// Prepare refresh request

--- a/synkronus-cli/internal/cmd/health.go
+++ b/synkronus-cli/internal/cmd/health.go
@@ -18,15 +18,16 @@ func init() {
 		Long:  `Verify connectivity to the Synkronus API server.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			apiURL := strings.TrimRight(utils.EnsureScheme(viper.GetString("api.url")), "/")
+			healthURL := apiURL + "/health"
 
-			utils.PrintInfo("Checking API health at %s...", apiURL)
+			utils.PrintInfo("Checking API health at %s...", healthURL)
 
 			client := &http.Client{
 				Timeout: 10 * time.Second,
 			}
 
 			start := time.Now()
-			resp, err := client.Get(apiURL)
+			resp, err := client.Get(healthURL)
 			if err != nil {
 				return fmt.Errorf("connection failed: %w", err)
 			}

--- a/synkronus-cli/pkg/client/client.go
+++ b/synkronus-cli/pkg/client/client.go
@@ -70,7 +70,7 @@ func NewClient() *Client {
 // doRequest performs an HTTP request with authentication
 // GetVersion retrieves version information from the Synkronus server
 func (c *Client) GetVersion() (*SystemVersionInfo, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/version", c.BaseURL), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/version", c.BaseURL), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating version request: %w", err)
 	}
@@ -145,7 +145,7 @@ func (c *Client) GetAppBundleManifest() (map[string]interface{}, error) {
 
 // GetAppBundleVersions retrieves available app bundle versions
 func (c *Client) GetAppBundleVersions() (map[string]interface{}, error) {
-	url := fmt.Sprintf("%s/app-bundle/versions", c.BaseURL)
+	url := fmt.Sprintf("%s/api/app-bundle/versions", c.BaseURL)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func (c *Client) DownloadAppBundleFile(path, destPath string, preview bool) erro
 
 // DownloadParquetExport downloads the Parquet export ZIP archive to the specified destination path
 func (c *Client) DownloadParquetExport(destPath string) error {
-	url := fmt.Sprintf("%s/dataexport/parquet", c.BaseURL)
+	url := fmt.Sprintf("%s/api/dataexport/parquet", c.BaseURL)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -322,7 +322,7 @@ func (c *Client) UploadAppBundle(bundlePath string) (map[string]interface{}, err
 
 // SwitchAppBundleVersion switches to a specific app bundle version
 func (c *Client) SwitchAppBundleVersion(version string) (map[string]interface{}, error) {
-	url := fmt.Sprintf("%s/app-bundle/switch/%s", c.BaseURL, version)
+	url := fmt.Sprintf("%s/api/app-bundle/switch/%s", c.BaseURL, version)
 
 	req, err := http.NewRequest("POST", url, nil)
 	if err != nil {
@@ -350,7 +350,7 @@ func (c *Client) SwitchAppBundleVersion(version string) (map[string]interface{},
 
 // SyncPull pulls updated records from the server
 func (c *Client) SyncPull(clientID string, currentVersion int64, schemaTypes []string, limit int, pageToken string) (map[string]interface{}, error) {
-	requestURL := fmt.Sprintf("%s/sync/pull", c.BaseURL)
+	requestURL := fmt.Sprintf("%s/api/sync/pull", c.BaseURL)
 
 	// Build query parameters
 	var queryParams []string
@@ -429,7 +429,7 @@ func (c *Client) SyncPull(clientID string, currentVersion int64, schemaTypes []s
 
 // SyncPush pushes records to the server
 func (c *Client) SyncPush(clientID string, transmissionID string, records []map[string]interface{}) (map[string]interface{}, error) {
-	url := fmt.Sprintf("%s/sync/push", c.BaseURL)
+	url := fmt.Sprintf("%s/api/sync/push", c.BaseURL)
 
 	// Prepare request body
 	reqBody := map[string]interface{}{

--- a/synkronus-cli/pkg/client/user.go
+++ b/synkronus-cli/pkg/client/user.go
@@ -28,7 +28,7 @@ type UserChangePasswordRequest struct {
 
 // CreateUser calls POST /users to create a new user (admin)
 func (c *Client) CreateUser(reqBody UserCreateRequest) (map[string]interface{}, error) {
-	url := fmt.Sprintf("%s/users", c.BaseURL)
+	url := fmt.Sprintf("%s/api/users", c.BaseURL)
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
@@ -60,7 +60,7 @@ func (c *Client) CreateUser(reqBody UserCreateRequest) (map[string]interface{}, 
 
 // DeleteUser calls DELETE /users/delete/{username} (admin)
 func (c *Client) DeleteUser(username string) error {
-	url := fmt.Sprintf("%s/users/delete/%s", c.BaseURL, username)
+	url := fmt.Sprintf("%s/api/users/delete/%s", c.BaseURL, username)
 	request, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
@@ -80,7 +80,7 @@ func (c *Client) DeleteUser(username string) error {
 
 // ResetUserPassword calls POST /users/reset-password (admin)
 func (c *Client) ResetUserPassword(reqBody UserResetPasswordRequest) error {
-	url := fmt.Sprintf("%s/users/reset-password", c.BaseURL)
+	url := fmt.Sprintf("%s/api/users/reset-password", c.BaseURL)
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request: %w", err)
@@ -105,7 +105,7 @@ func (c *Client) ResetUserPassword(reqBody UserResetPasswordRequest) error {
 
 // ChangeOwnPassword calls POST /users/change-password (self)
 func (c *Client) ChangeOwnPassword(reqBody UserChangePasswordRequest) error {
-	url := fmt.Sprintf("%s/users/change-password", c.BaseURL)
+	url := fmt.Sprintf("%s/api/users/change-password", c.BaseURL)
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request: %w", err)
@@ -130,7 +130,7 @@ func (c *Client) ChangeOwnPassword(reqBody UserChangePasswordRequest) error {
 
 // ListUsers calls GET /users (admin only)
 func (c *Client) ListUsers() ([]map[string]interface{}, error) {
-	url := fmt.Sprintf("%s/users", c.BaseURL)
+	url := fmt.Sprintf("%s/api/users", c.BaseURL)
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/synkronus-cli/pkg/validation/bundle.go
+++ b/synkronus-cli/pkg/validation/bundle.go
@@ -18,7 +18,7 @@ var (
 	ErrInvalidJSON              = errors.New("invalid JSON")
 	ErrInvalidExtension         = errors.New("invalid extension file")
 	ErrMissingExtensionModule   = errors.New("missing extension module")
-	ErrInvalidExtensionRenderer  = errors.New("invalid extension renderer")
+	ErrInvalidExtensionRenderer = errors.New("invalid extension renderer")
 )
 
 // ValidateBundle validates the structure and content of an app bundle ZIP file
@@ -329,18 +329,18 @@ func checkSchemaRendererReferences(data interface{}, availableRenderers map[stri
 		if format, ok := v["format"].(string); ok {
 			// Format-based renderers must be in extension renderers or built-in
 			if !extensionRenderers[format] && !isBuiltInRenderer(format) {
-			// Check if it's a known format
-			knownFormats := []string{"date", "date-time", "time", "photo", "qrcode", "signature", "select_file", "audio", "gps", "video", "adate", "html"}
-			isKnownFormat := false
-			for _, known := range knownFormats {
-				if format == known {
-					isKnownFormat = true
-					break
+				// Check if it's a known format
+				knownFormats := []string{"date", "date-time", "time", "photo", "qrcode", "signature", "select_file", "audio", "gps", "video", "adate", "html"}
+				isKnownFormat := false
+				for _, known := range knownFormats {
+					if format == known {
+						isKnownFormat = true
+						break
+					}
 				}
-			}
-			if !isKnownFormat {
-				return fmt.Errorf("schema property references renderer with format '%s' but no extension renderer is defined for this format", format)
-			}
+				if !isKnownFormat {
+					return fmt.Errorf("schema property references renderer with format '%s' but no extension renderer is defined for this format", format)
+				}
 			}
 		}
 
@@ -534,10 +534,10 @@ func validateExtensions(zipReader *zip.Reader) error {
 		// Check if module exists in bundle
 		// Modules can be in forms/ or app/ directories
 		moduleFound := false
-		
+
 		// Normalize path - remove leading "/" if present (v1 format uses absolute paths)
 		normalizedPath := strings.TrimPrefix(modulePath, "/")
-		
+
 		for _, file := range zipReader.File {
 			// Check various possible paths
 			if file.Name == modulePath ||
@@ -571,18 +571,18 @@ func checkUISchemaRendererReferences(data interface{}, availableRenderers map[st
 		if format, ok := v["format"].(string); ok {
 			// Format-based renderers must be in extension renderers or built-in
 			if !extensionRenderers[format] && !isBuiltInRenderer(format) {
-			// Check if it's a known format (date, date-time, time are built-in)
-			knownFormats := []string{"date", "date-time", "time", "photo", "qrcode", "signature", "select_file", "audio", "gps", "video", "adate", "html"}
-			isKnownFormat := false
-			for _, known := range knownFormats {
-				if format == known {
-					isKnownFormat = true
-					break
+				// Check if it's a known format (date, date-time, time are built-in)
+				knownFormats := []string{"date", "date-time", "time", "photo", "qrcode", "signature", "select_file", "audio", "gps", "video", "adate", "html"}
+				isKnownFormat := false
+				for _, known := range knownFormats {
+					if format == known {
+						isKnownFormat = true
+						break
+					}
 				}
-			}
-			if !isKnownFormat {
-				return fmt.Errorf("UI schema references renderer with format '%s' but no extension renderer is defined for this format", format)
-			}
+				if !isKnownFormat {
+					return fmt.Errorf("UI schema references renderer with format '%s' but no extension renderer is defined for this format", format)
+				}
 			}
 		}
 

--- a/synkronus-cli/pkg/validation/bundle_test.go
+++ b/synkronus-cli/pkg/validation/bundle_test.go
@@ -187,9 +187,9 @@ func TestValidateBundle(t *testing.T) {
 		{
 			name: "v1 format extension with renderer/tester objects (PR #18 format)",
 			files: map[string]string{
-				"app/index.html": "<html></html>",
+				"app/index.html":         "<html></html>",
 				"forms/user/schema.json": `{"type": "object", "properties": {"customField": {"type": "string", "format": "CustomText"}}}`,
-				"forms/user/ui.json": `{"type": "Control", "scope": "#/properties/customField", "options": {"format": "CustomText"}}`,
+				"forms/user/ui.json":     `{"type": "Control", "scope": "#/properties/customField", "options": {"format": "CustomText"}}`,
 				"forms/ext.json": `{
 					"version": "1",
 					"renderers": {
@@ -206,16 +206,16 @@ func TestValidateBundle(t *testing.T) {
 					}
 				}`,
 				"app/extensions/renderers/CustomTextRenderer.jsx": "export default function CustomTextRenderer() {}",
-				"app/extensions/testers/customTextTester.js": "export function customTextTester() {}",
+				"app/extensions/testers/customTextTester.js":      "export function customTextTester() {}",
 			},
 			wantErr: false,
 		},
 		{
 			name: "legacy format extension (PR #226 format)",
 			files: map[string]string{
-				"app/index.html": "<html></html>",
+				"app/index.html":         "<html></html>",
 				"forms/user/schema.json": `{"type": "object"}`,
-				"forms/user/ui.json": "{}",
+				"forms/user/ui.json":     "{}",
 				"forms/ext.json": `{
 					"renderers": {
 						"customRenderer": {

--- a/synkronus-portal/src/components/Login.tsx
+++ b/synkronus-portal/src/components/Login.tsx
@@ -24,11 +24,23 @@ export function Login() {
       : dashboardBackgroundDark;
 
   useEffect(() => {
-    // Fetch server version on component mount
+    // Fetch server version on component mount.
+    // REST API lives under /api; /health stays at the server root (see synkronus router).
+    const backendUrl = (path: string) => {
+      const base = import.meta.env.VITE_API_URL || '/api';
+      if (base.startsWith('http')) {
+        const origin = base.replace(/\/$/, '');
+        if (path === '/health') return `${origin}/health`;
+        return `${origin}/api${path}`;
+      }
+      if (path === '/health') return '/health';
+      return `${base}${path}`;
+    };
+
     const fetchVersion = async () => {
       try {
         // Try version endpoint first
-        let response = await fetch(`${import.meta.env.VITE_API_URL || '/api'}/version`, {
+        let response = await fetch(backendUrl('/version'), {
           headers: {
             'x-formulus-version': '1.0.0'
           }
@@ -41,7 +53,7 @@ export function Login() {
         }
         
         // If version fails, try health endpoint (might have version info)
-        response = await fetch(`${import.meta.env.VITE_API_URL || '/api'}/health`);
+        response = await fetch(backendUrl('/health'));
         if (response.ok) {
           const text = await response.text();
           // Health endpoint might return JSON with version info

--- a/synkronus-portal/vite.config.ts
+++ b/synkronus-portal/vite.config.ts
@@ -72,11 +72,8 @@ export default defineConfig({
             : process.env.API_URL || process.env.VITE_API_URL || 'http://localhost:8080',
         changeOrigin: true,
         secure: false,
-        rewrite: path => {
-          const rewritten = path.replace(/^\/api/, '');
-          console.log(`[Vite Proxy] Rewriting ${path} -> ${rewritten}`);
-          return rewritten;
-        },
+        // Forward /api/* to the backend with the same path (API routes are mounted under /api)
+        rewrite: path => path,
         configure: (proxy, _options) => {
           proxy.on('error', (err, req, _res) => {
             console.error('[Vite Proxy] Error:', err);

--- a/synkronus-portal/vite.config.ts
+++ b/synkronus-portal/vite.config.ts
@@ -60,6 +60,16 @@ export default defineConfig({
       interval: 100, // Polling interval in ms
     },
     proxy: {
+      // Health is mounted at /health (not under /api); proxy it for dev same-origin fetches
+      '/health': {
+        target:
+          process.env.DOCKER_ENV === 'true' ||
+          process.env.VITE_API_URL?.includes('synkronus:')
+            ? 'http://synkronus:8080'
+            : process.env.API_URL || process.env.VITE_API_URL || 'http://localhost:8080',
+        changeOrigin: true,
+        secure: false,
+      },
       // Proxy API requests to the Synkronus backend
       // In Docker: uses service name 'synkronus'
       // Locally: uses 'localhost'

--- a/synkronus/internal/api/api.go
+++ b/synkronus/internal/api/api.go
@@ -90,15 +90,12 @@ func NewRouter(log *logger.Logger, h *handlers.Handler) http.Handler {
 		FileServer(r, "/openapi", http.Dir(openapiDir))
 	}
 
-	// Authentication routes
+	// All REST API routes (except /health) under /api
 	authRoutes := func(r chi.Router) {
 		r.Use(formulusversion.Middleware(log))
 		r.Post("/login", h.Login)
 		r.Post("/refresh", h.RefreshToken)
 	}
-	r.Route("/auth", authRoutes)
-	// Also register under /api for portal compatibility
-	r.Route("/api/auth", authRoutes)
 
 	// Create attachment service
 	attachmentService, err := attachment.NewService(h.GetConfig())
@@ -113,71 +110,51 @@ func NewRouter(log *logger.Logger, h *handlers.Handler) http.Handler {
 		h.AttachmentManifestService(),
 	)
 
-	// Protected routes - require authentication
-	r.Group(func(r chi.Router) {
-		r.Use(formulusversion.Middleware(log))
-		// Add authentication middleware
-		r.Use(auth.AuthMiddleware(h.GetAuthService(), log))
+	r.Route("/api", func(r chi.Router) {
+		r.Route("/auth", authRoutes)
 
-		// Register attachment routes (including manifest endpoint)
-		attachmentHandler.RegisterRoutes(r, h.AttachmentManifestHandler)
+		// Protected routes - require authentication
+		r.Group(func(r chi.Router) {
+			r.Use(formulusversion.Middleware(log))
+			r.Use(auth.AuthMiddleware(h.GetAuthService(), log))
 
-		// Sync routes
-		r.Route("/sync", func(r chi.Router) {
-			// Pull endpoint - accessible to all authenticated users
-			r.Post("/pull", h.Pull)
+			attachmentHandler.RegisterRoutes(r, h.AttachmentManifestHandler)
 
-			// Push endpoint - requires read-write or admin role
-			r.With(auth.RequireRole(models.RoleReadWrite, models.RoleAdmin)).Post("/push", h.Push)
+			r.Route("/sync", func(r chi.Router) {
+				r.Post("/pull", h.Pull)
+				r.With(auth.RequireRole(models.RoleReadWrite, models.RoleAdmin)).Post("/push", h.Push)
+			})
+
+			appBundleRoutes := func(r chi.Router) {
+				r.Get("/manifest", h.GetAppBundleManifest)
+				r.Get("/download/{path}", h.GetAppBundleFile)
+				r.Get("/download-zip", h.DownloadBundleZip)
+				r.Get("/versions", h.GetAppBundleVersions)
+				r.Get("/changes", h.CompareAppBundleVersions)
+				r.With(auth.RequireRole(models.RoleAdmin)).Post("/push", h.PushAppBundle)
+				r.With(auth.RequireRole(models.RoleAdmin)).Post("/switch/{version}", h.SwitchAppBundleVersion)
+			}
+			r.Route("/app-bundle", appBundleRoutes)
+
+			userRoutes := func(r chi.Router) {
+				// Support both POST /api/users and POST /api/users/create for compatibility
+				r.With(auth.RequireRole(models.RoleAdmin)).Post("/", h.CreateUserHandler)
+				r.With(auth.RequireRole(models.RoleAdmin)).Post("/create", h.CreateUserHandler)
+				r.With(auth.RequireRole(models.RoleAdmin)).Delete("/delete/{username}", h.DeleteUserHandler)
+				r.With(auth.RequireRole(models.RoleAdmin)).Post("/reset-password", h.ResetPasswordHandler)
+				r.With(auth.RequireRole(models.RoleAdmin)).Get("/", h.ListUsersHandler)
+				r.Post("/change-password", h.ChangePasswordHandler)
+			}
+			r.Route("/users", userRoutes)
+
+			dataExportRoutes := func(r chi.Router) {
+				r.With(auth.RequireRole(models.RoleReadOnly, models.RoleReadWrite, models.RoleAdmin)).Get("/parquet", h.ParquetExportHandler)
+			}
+			r.Route("/dataexport", dataExportRoutes)
+
+			r.Get("/version", h.GetVersion)
+			r.Get("/versions", h.GetAPIVersions)
 		})
-
-		// App bundle routes
-		appBundleRoutes := func(r chi.Router) {
-			// Read endpoints - accessible to all authenticated users
-			r.Get("/manifest", h.GetAppBundleManifest)
-			r.Get("/download/{path}", h.GetAppBundleFile)
-			r.Get("/download-zip", h.DownloadBundleZip)
-			r.Get("/versions", h.GetAppBundleVersions)
-			r.Get("/changes", h.CompareAppBundleVersions)
-
-			// Write endpoints - require admin role
-			r.With(auth.RequireRole(models.RoleAdmin)).Post("/push", h.PushAppBundle)
-			r.With(auth.RequireRole(models.RoleAdmin)).Post("/switch/{version}", h.SwitchAppBundleVersion)
-		}
-		r.Route("/app-bundle", appBundleRoutes)
-		// Also register under /api for portal compatibility
-		r.Route("/api/app-bundle", appBundleRoutes)
-
-		// User management routes
-		userRoutes := func(r chi.Router) {
-			// Admin-only routes
-			// Support both POST /users and POST /users/create for compatibility
-			// CLI uses POST /users, portal uses POST /users/create
-			r.With(auth.RequireRole(models.RoleAdmin)).Post("/", h.CreateUserHandler)
-			r.With(auth.RequireRole(models.RoleAdmin)).Post("/create", h.CreateUserHandler)
-			r.With(auth.RequireRole(models.RoleAdmin)).Delete("/delete/{username}", h.DeleteUserHandler)
-			r.With(auth.RequireRole(models.RoleAdmin)).Post("/reset-password", h.ResetPasswordHandler)
-			r.With(auth.RequireRole(models.RoleAdmin)).Get("/", h.ListUsersHandler)
-			// Authenticated user route
-			r.Post("/change-password", h.ChangePasswordHandler)
-		}
-		r.Route("/users", userRoutes)
-		// Also register under /api for portal compatibility
-		r.Route("/api/users", userRoutes)
-
-		// Data export routes
-		dataExportRoutes := func(r chi.Router) {
-			// Parquet export - accessible to read-only users and above
-			r.With(auth.RequireRole(models.RoleReadOnly, models.RoleReadWrite, models.RoleAdmin)).Get("/parquet", h.ParquetExportHandler)
-		}
-		r.Route("/dataexport", dataExportRoutes)
-		// Also register under /api for portal compatibility
-		r.Route("/api/dataexport", dataExportRoutes)
-
-		// Version routes
-		r.Get("/version", h.GetVersion)
-		r.Get("/api/version", h.GetVersion)      // Also under /api for portal compatibility
-		r.Get("/api/versions", h.GetAPIVersions) // Not implemented yet
 	})
 
 	// Serve embedded React portal (SPA) for all other GET requests.

--- a/synkronus/internal/api/api_integration_test.go
+++ b/synkronus/internal/api/api_integration_test.go
@@ -71,51 +71,39 @@ func TestProtectedEndpoints(t *testing.T) {
 		MaxAge:           300,
 	}))
 
-	// Public endpoints
 	r.Get("/health", mockHandler.HealthCheck)
-	r.Get("/api/versions", mockHandler.GetAPIVersions)
 
-	// Authentication routes
-	r.Route("/auth", func(r chi.Router) {
-		r.Post("/login", mockHandler.Login)
-		r.Post("/refresh", mockHandler.RefreshToken)
-	})
+	r.Route("/api", func(r chi.Router) {
+		r.Get("/versions", mockHandler.GetAPIVersions)
 
-	// Protected routes - require authentication
-	r.Group(func(r chi.Router) {
-		// Add authentication middleware
-		r.Use(authmw.AuthMiddleware(mockHandler.GetAuthService(), log))
-
-		// Sync routes
-		r.Route("/sync", func(r chi.Router) {
-			// Pull endpoint - accessible to all authenticated users
-			r.Post("/pull", mockHandler.Pull)
-
-			// Push endpoint - requires read-write or admin role
-			r.With(authmw.RequireRole(models.RoleReadWrite, models.RoleAdmin)).Post("/push", mockHandler.Push)
+		r.Route("/auth", func(r chi.Router) {
+			r.Post("/login", mockHandler.Login)
+			r.Post("/refresh", mockHandler.RefreshToken)
 		})
 
-		// App bundle routes
-		r.Route("/app-bundle", func(r chi.Router) {
-			// Read endpoints - accessible to all authenticated users
-			r.Get("/manifest", mockHandler.GetAppBundleManifest)
-			r.Get("/versions", mockHandler.GetAppBundleVersions)
-			r.Get("/download/{path}", mockHandler.GetAppBundleFile)
+		r.Group(func(r chi.Router) {
+			r.Use(authmw.AuthMiddleware(mockHandler.GetAuthService(), log))
 
-			// Write endpoints - require admin role
-			r.With(authmw.RequireRole(models.RoleAdmin)).Post("/push", mockHandler.PushAppBundle)
-			r.With(authmw.RequireRole(models.RoleAdmin)).Post("/switch/{version}", mockHandler.SwitchAppBundleVersion)
-		})
+			r.Route("/sync", func(r chi.Router) {
+				r.Post("/pull", mockHandler.Pull)
+				r.With(authmw.RequireRole(models.RoleReadWrite, models.RoleAdmin)).Post("/push", mockHandler.Push)
+			})
 
-		// User routes
-		r.Route("/users", func(r chi.Router) {
-			// Admin-only routes
-			r.With(authmw.RequireRole(models.RoleAdmin)).Post("/create", mockHandler.CreateUserHandler)
-			r.With(authmw.RequireRole(models.RoleAdmin)).Delete("/delete/{username}", mockHandler.DeleteUserHandler)
-			r.With(authmw.RequireRole(models.RoleAdmin)).Post("/reset-password", mockHandler.ResetPasswordHandler)
-			r.With(authmw.RequireRole(models.RoleAdmin)).Get("/list", mockHandler.ListUsersHandler)
-			// Authenticated user route
-			r.Post("/change-password", mockHandler.ChangePasswordHandler)
+			r.Route("/app-bundle", func(r chi.Router) {
+				r.Get("/manifest", mockHandler.GetAppBundleManifest)
+				r.Get("/versions", mockHandler.GetAppBundleVersions)
+				r.Get("/download/{path}", mockHandler.GetAppBundleFile)
+				r.With(authmw.RequireRole(models.RoleAdmin)).Post("/push", mockHandler.PushAppBundle)
+				r.With(authmw.RequireRole(models.RoleAdmin)).Post("/switch/{version}", mockHandler.SwitchAppBundleVersion)
+			})
+
+			r.Route("/users", func(r chi.Router) {
+				r.With(authmw.RequireRole(models.RoleAdmin)).Post("/create", mockHandler.CreateUserHandler)
+				r.With(authmw.RequireRole(models.RoleAdmin)).Delete("/delete/{username}", mockHandler.DeleteUserHandler)
+				r.With(authmw.RequireRole(models.RoleAdmin)).Post("/reset-password", mockHandler.ResetPasswordHandler)
+				r.With(authmw.RequireRole(models.RoleAdmin)).Get("/list", mockHandler.ListUsersHandler)
+				r.Post("/change-password", mockHandler.ChangePasswordHandler)
+			})
 		})
 	})
 
@@ -141,7 +129,7 @@ func TestProtectedEndpoints(t *testing.T) {
 	}{
 		{
 			name:           "Sync Pull - Without Auth",
-			endpoint:       "/sync/pull",
+			endpoint:       "/api/sync/pull",
 			method:         http.MethodPost,
 			body:           map[string]any{"client_id": "test-client"},
 			withAuth:       false,
@@ -149,7 +137,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "Sync Pull - With Auth",
-			endpoint:       "/sync/pull",
+			endpoint:       "/api/sync/pull",
 			method:         http.MethodPost,
 			body:           map[string]any{"client_id": "test-client"},
 			withAuth:       true,
@@ -157,7 +145,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "Sync Push - Without Auth",
-			endpoint:       "/sync/push",
+			endpoint:       "/api/sync/push",
 			method:         http.MethodPost,
 			body:           map[string]any{"transmission_id": "test-transmission", "client_id": "test-client", "records": []any{}},
 			withAuth:       false,
@@ -165,7 +153,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "Sync Push - With Auth",
-			endpoint:       "/sync/push",
+			endpoint:       "/api/sync/push",
 			method:         http.MethodPost,
 			body:           map[string]any{"transmission_id": "test-transmission", "client_id": "test-client", "records": []any{}},
 			withAuth:       true,
@@ -173,7 +161,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "App Bundle Manifest - Without Auth",
-			endpoint:       "/app-bundle/manifest",
+			endpoint:       "/api/app-bundle/manifest",
 			method:         http.MethodGet,
 			body:           nil,
 			withAuth:       false,
@@ -181,7 +169,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "App Bundle Manifest - With Auth",
-			endpoint:       "/app-bundle/manifest",
+			endpoint:       "/api/app-bundle/manifest",
 			method:         http.MethodGet,
 			body:           nil,
 			withAuth:       true,
@@ -189,7 +177,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "App Bundle File - Without Auth",
-			endpoint:       "/app-bundle/download/index.html",
+			endpoint:       "/api/app-bundle/download/index.html",
 			method:         http.MethodGet,
 			body:           nil,
 			withAuth:       false,
@@ -197,7 +185,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "App Bundle File - With Auth",
-			endpoint:       "/app-bundle/download/index.html",
+			endpoint:       "/api/app-bundle/download/index.html",
 			method:         http.MethodGet,
 			body:           nil,
 			withAuth:       true,
@@ -221,7 +209,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "Sync Pull - With Invalid Token",
-			endpoint:       "/sync/pull",
+			endpoint:       "/api/sync/pull",
 			method:         http.MethodPost,
 			body:           map[string]any{"client_id": "test-client"},
 			withAuth:       true,
@@ -230,7 +218,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "Sync Push - With Expired Token",
-			endpoint:       "/sync/push",
+			endpoint:       "/api/sync/push",
 			method:         http.MethodPost,
 			body:           map[string]any{"transmission_id": "test-transmission", "client_id": "test-client", "records": []any{}},
 			withAuth:       true,
@@ -239,7 +227,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "App Bundle Manifest - With Invalid Token",
-			endpoint:       "/app-bundle/manifest",
+			endpoint:       "/api/app-bundle/manifest",
 			method:         http.MethodGet,
 			body:           nil,
 			withAuth:       true,
@@ -248,7 +236,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "Sync Push - With Read-Only User",
-			endpoint:       "/sync/push",
+			endpoint:       "/api/sync/push",
 			method:         http.MethodPost,
 			body:           map[string]any{"transmission_id": "test-transmission", "client_id": "test-client", "records": []any{}},
 			withAuth:       true,
@@ -257,7 +245,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "Sync Pull - With Read-Only User",
-			endpoint:       "/sync/pull",
+			endpoint:       "/api/sync/pull",
 			method:         http.MethodPost,
 			body:           map[string]any{"client_id": "test-client"},
 			withAuth:       true,
@@ -266,7 +254,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "Sync Push - With Admin User",
-			endpoint:       "/sync/push",
+			endpoint:       "/api/sync/push",
 			method:         http.MethodPost,
 			body:           map[string]any{"transmission_id": "test-transmission", "client_id": "test-client", "records": []any{}},
 			withAuth:       true,
@@ -276,7 +264,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "App Bundle Versions - With Read-Only User",
-			endpoint:       "/app-bundle/versions",
+			endpoint:       "/api/app-bundle/versions",
 			method:         http.MethodGet,
 			body:           nil,
 			withAuth:       true,
@@ -285,7 +273,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "App Bundle Push - With Read-Only User",
-			endpoint:       "/app-bundle/push",
+			endpoint:       "/api/app-bundle/push",
 			method:         http.MethodPost,
 			body:           nil, // Multipart form would be tested in handler unit tests
 			withAuth:       true,
@@ -294,7 +282,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "App Bundle Push - With Admin User",
-			endpoint:       "/app-bundle/push",
+			endpoint:       "/api/app-bundle/push",
 			method:         http.MethodPost,
 			body:           nil, // Multipart form would be tested in handler unit tests
 			withAuth:       true,
@@ -303,7 +291,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "App Bundle Switch - With Read-Only User",
-			endpoint:       "/app-bundle/switch/20250101-000000",
+			endpoint:       "/api/app-bundle/switch/20250101-000000",
 			method:         http.MethodPost,
 			body:           nil,
 			withAuth:       true,
@@ -312,7 +300,7 @@ func TestProtectedEndpoints(t *testing.T) {
 		},
 		{
 			name:           "App Bundle Switch - With Admin User",
-			endpoint:       "/app-bundle/switch/20250101-000000",
+			endpoint:       "/api/app-bundle/switch/20250101-000000",
 			method:         http.MethodPost,
 			body:           nil,
 			withAuth:       true,

--- a/synkronus/internal/handlers/appbundle_push_test.go
+++ b/synkronus/internal/handlers/appbundle_push_test.go
@@ -84,7 +84,7 @@ func TestPushAppBundle(t *testing.T) {
 				}
 
 				// Create the request
-				req := httptest.NewRequest(http.MethodPost, "/app-bundle/push", body)
+				req := httptest.NewRequest(http.MethodPost, "/api/app-bundle/push", body)
 				req.Header.Set("Content-Type", writer.FormDataContentType())
 				return req, nil
 			},
@@ -104,7 +104,7 @@ func TestPushAppBundle(t *testing.T) {
 		{
 			name: "Unauthorized - No User in Context",
 			setupRequest: func() (*http.Request, error) {
-				req := httptest.NewRequest(http.MethodPost, "/app-bundle/push", nil)
+				req := httptest.NewRequest(http.MethodPost, "/api/app-bundle/push", nil)
 				return req, nil
 			},
 			setupContext: func(r *http.Request) {
@@ -116,7 +116,7 @@ func TestPushAppBundle(t *testing.T) {
 		{
 			name: "Bad Request - No Multipart Form",
 			setupRequest: func() (*http.Request, error) {
-				req := httptest.NewRequest(http.MethodPost, "/app-bundle/push", nil)
+				req := httptest.NewRequest(http.MethodPost, "/api/app-bundle/push", nil)
 				return req, nil
 			},
 			setupContext: func(r *http.Request) {
@@ -187,7 +187,7 @@ func TestGetAppBundleVersions(t *testing.T) {
 		{
 			name: "Successful Get Versions",
 			setupRequest: func() *http.Request {
-				return httptest.NewRequest(http.MethodGet, "/app-bundle/versions", nil)
+				return httptest.NewRequest(http.MethodGet, "/api/app-bundle/versions", nil)
 			},
 			expectedStatus: http.StatusOK,
 			expectedBody:   `"versions":["20250101-000000","20250102-000000"]`,
@@ -287,7 +287,7 @@ func TestSwitchAppBundleVersion(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a test request with the version as a URL parameter
-			url := "/app-bundle/switch/" + tc.version
+			url := "/api/app-bundle/switch/" + tc.version
 			req := httptest.NewRequest(http.MethodPost, url, nil)
 
 			// Setup the chi router context with URL params

--- a/synkronus/internal/handlers/appbundle_test.go
+++ b/synkronus/internal/handlers/appbundle_test.go
@@ -17,7 +17,7 @@ func TestGetAppBundleManifest(t *testing.T) {
 	h, _ := createTestHandler()
 
 	// Create a test request
-	req := httptest.NewRequest(http.MethodGet, "/app-bundle/manifest", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/app-bundle/manifest", nil)
 	w := httptest.NewRecorder()
 
 	// Call the handler
@@ -61,7 +61,7 @@ func TestGetAppBundleFile(t *testing.T) {
 
 	// Create a router for URL parameter extraction
 	r := chi.NewRouter()
-	r.Get("/app-bundle/download/{path}", h.GetAppBundleFile)
+	r.Get("/api/app-bundle/download/{path}", h.GetAppBundleFile)
 
 	// Test cases
 	testCases := []struct {
@@ -99,7 +99,7 @@ func TestGetAppBundleFile(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a test request
-			req := httptest.NewRequest(http.MethodGet, "/app-bundle/download/"+tc.path, nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/app-bundle/download/"+tc.path, nil)
 			w := httptest.NewRecorder()
 
 			// Serve the request through the router to extract URL parameters
@@ -136,12 +136,12 @@ func TestGetAppBundleFileWithPreview(t *testing.T) {
 
 	// Test with preview=true
 	t.Run("with preview=true", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/app-bundle/download/index.html?preview=true", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/app-bundle/download/index.html?preview=true", nil)
 		w := httptest.NewRecorder()
 
 		// Create a router for URL parameter extraction
 		r := chi.NewRouter()
-		r.Get("/app-bundle/download/{path}", h.GetAppBundleFile)
+		r.Get("/api/app-bundle/download/{path}", h.GetAppBundleFile)
 
 		// Serve the request
 		r.ServeHTTP(w, req)
@@ -163,12 +163,12 @@ func TestGetAppBundleFileWithPreview(t *testing.T) {
 
 	// Test with preview=false
 	t.Run("with preview=false", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/app-bundle/download/index.html?preview=false", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/app-bundle/download/index.html?preview=false", nil)
 		w := httptest.NewRecorder()
 
 		// Create a router for URL parameter extraction
 		r := chi.NewRouter()
-		r.Get("/app-bundle/download/{path}", h.GetAppBundleFile)
+		r.Get("/api/app-bundle/download/{path}", h.GetAppBundleFile)
 
 		// Serve the request
 		r.ServeHTTP(w, req)
@@ -190,12 +190,12 @@ func TestGetAppBundleFileWithPreview(t *testing.T) {
 
 	// Test with invalid preview value
 	t.Run("with invalid preview value", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/app-bundle/download/index.html?preview=invalid", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/app-bundle/download/index.html?preview=invalid", nil)
 		w := httptest.NewRecorder()
 
 		// Create a router for URL parameter extraction
 		r := chi.NewRouter()
-		r.Get("/app-bundle/download/{path}", h.GetAppBundleFile)
+		r.Get("/api/app-bundle/download/{path}", h.GetAppBundleFile)
 
 		// Serve the request
 		r.ServeHTTP(w, req)
@@ -217,12 +217,12 @@ func TestGetAppBundleFileNotModified(t *testing.T) {
 	h, _ := createTestHandler()
 
 	// First request to get the ETag
-	req1 := httptest.NewRequest(http.MethodGet, "/app-bundle/index.html", nil)
+	req1 := httptest.NewRequest(http.MethodGet, "/api/app-bundle/index.html", nil)
 	w1 := httptest.NewRecorder()
 
 	// Create a router for URL parameter extraction
 	r := chi.NewRouter()
-	r.Get("/app-bundle/{path}", h.GetAppBundleFile)
+	r.Get("/api/app-bundle/{path}", h.GetAppBundleFile)
 
 	// Serve the first request
 	r.ServeHTTP(w1, req1)
@@ -234,7 +234,7 @@ func TestGetAppBundleFileNotModified(t *testing.T) {
 	require.NotEmpty(t, etag, "Expected ETag header to be set")
 
 	// Second request with If-None-Match header
-	req2 := httptest.NewRequest(http.MethodGet, "/app-bundle/index.html", nil)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/app-bundle/index.html", nil)
 	req2.Header.Set("If-None-Match", etag)
 	w2 := httptest.NewRecorder()
 
@@ -252,7 +252,7 @@ func TestGetAppBundleManifestNotModified(t *testing.T) {
 	h, _ := createTestHandler()
 
 	// First request to get the ETag
-	req1 := httptest.NewRequest(http.MethodGet, "/app-bundle/manifest", nil)
+	req1 := httptest.NewRequest(http.MethodGet, "/api/app-bundle/manifest", nil)
 	w1 := httptest.NewRecorder()
 	h.GetAppBundleManifest(w1, req1)
 
@@ -262,7 +262,7 @@ func TestGetAppBundleManifestNotModified(t *testing.T) {
 	etag := resp1.Header.Get("etag")
 
 	// Second request with If-None-Match header
-	req2 := httptest.NewRequest(http.MethodGet, "/app-bundle/manifest", nil)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/app-bundle/manifest", nil)
 	req2.Header.Set("If-None-Match", etag)
 	w2 := httptest.NewRecorder()
 	h.GetAppBundleManifest(w2, req2)
@@ -310,7 +310,7 @@ func TestCompareAppBundleVersions(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create request
-			req := httptest.NewRequest(http.MethodGet, "/app-bundle/changes", nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/app-bundle/changes", nil)
 			q := req.URL.Query()
 			if tc.currentVersion != "" {
 				q.Add("current", tc.currentVersion)

--- a/synkronus/internal/handlers/attachment_manifest_test.go
+++ b/synkronus/internal/handlers/attachment_manifest_test.go
@@ -116,7 +116,7 @@ func TestAttachmentManifestHandler(t *testing.T) {
 			}
 
 			// Create request
-			req := httptest.NewRequest(http.MethodPost, "/attachments/manifest", bytes.NewReader(body))
+			req := httptest.NewRequest(http.MethodPost, "/api/attachments/manifest", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 
 			// Create response recorder

--- a/synkronus/internal/handlers/attachment_sync_integration_test.go
+++ b/synkronus/internal/handlers/attachment_sync_integration_test.go
@@ -63,12 +63,14 @@ func TestAttachmentUpload_FollowedByManifest_ReturnsDownloadForSecondDevice(t *t
 	)
 
 	r := chi.NewRouter()
-	r.Group(func(r chi.Router) {
-		r.Use(authmw.AuthMiddleware(&mockAuthService{}, log))
-		r.Route("/attachments", func(r chi.Router) {
-			r.Post("/manifest", h.AttachmentManifestHandler)
-			r.Route("/{attachment_id}", func(r chi.Router) {
-				r.Put("/", attHandler.UploadAttachment)
+	r.Route("/api", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(authmw.AuthMiddleware(&mockAuthService{}, log))
+			r.Route("/attachments", func(r chi.Router) {
+				r.Post("/manifest", h.AttachmentManifestHandler)
+				r.Route("/{attachment_id}", func(r chi.Router) {
+					r.Put("/", attHandler.UploadAttachment)
+				})
 			})
 		})
 	})
@@ -77,7 +79,7 @@ func TestAttachmentUpload_FollowedByManifest_ReturnsDownloadForSecondDevice(t *t
 	t.Cleanup(ts.Close)
 
 	attachmentID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jpg"
-	uploadURL := ts.URL + "/attachments/" + attachmentID
+	uploadURL := ts.URL + "/api/attachments/" + attachmentID
 
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
@@ -107,7 +109,7 @@ func TestAttachmentUpload_FollowedByManifest_ReturnsDownloadForSecondDevice(t *t
 	})
 	require.NoError(t, err)
 
-	mreq, err := http.NewRequest(http.MethodPost, ts.URL+"/attachments/manifest", bytes.NewReader(manifestBody))
+	mreq, err := http.NewRequest(http.MethodPost, ts.URL+"/api/attachments/manifest", bytes.NewReader(manifestBody))
 	require.NoError(t, err)
 	mreq.Header.Set("Content-Type", "application/json")
 	mreq.Header.Set("Authorization", "Bearer test-token")

--- a/synkronus/internal/handlers/attachment_test.go
+++ b/synkronus/internal/handlers/attachment_test.go
@@ -100,7 +100,7 @@ func TestAttachmentHandler_UploadAttachment(t *testing.T) {
 			w.Close()
 
 			// Create request
-			req := httptest.NewRequest("PUT", "/attachments/"+tc.attachmentID, &b)
+			req := httptest.NewRequest("PUT", "/api/attachments/"+tc.attachmentID, &b)
 			req.Header.Set("Content-Type", w.FormDataContentType())
 
 			// Create response recorder
@@ -108,7 +108,7 @@ func TestAttachmentHandler_UploadAttachment(t *testing.T) {
 
 			// Create router and make request
 			r := chi.NewRouter()
-			r.Put("/attachments/{attachment_id}", handler.UploadAttachment)
+			r.Put("/api/attachments/{attachment_id}", handler.UploadAttachment)
 			r.ServeHTTP(rr, req)
 
 			// Check response
@@ -168,14 +168,14 @@ func TestAttachmentHandler_DownloadAttachment(t *testing.T) {
 			handler := NewAttachmentHandler(logger.NewLogger(), mockSvc, mockManifest)
 
 			// Create request
-			req := httptest.NewRequest("GET", "/attachments/"+tc.attachmentID, nil)
+			req := httptest.NewRequest("GET", "/api/attachments/"+tc.attachmentID, nil)
 
 			// Create response recorder
 			rr := httptest.NewRecorder()
 
 			// Create router and make request
 			r := chi.NewRouter()
-			r.Get("/attachments/{attachment_id}", handler.DownloadAttachment)
+			r.Get("/api/attachments/{attachment_id}", handler.DownloadAttachment)
 			r.ServeHTTP(rr, req)
 
 			// Check response
@@ -226,14 +226,14 @@ func TestAttachmentHandler_CheckAttachment(t *testing.T) {
 			handler := NewAttachmentHandler(logger.NewLogger(), mockSvc, mockManifest)
 
 			// Create request
-			req := httptest.NewRequest("HEAD", "/attachments/"+tc.attachmentID, nil)
+			req := httptest.NewRequest("HEAD", "/api/attachments/"+tc.attachmentID, nil)
 
 			// Create response recorder
 			rr := httptest.NewRecorder()
 
 			// Create router and make request
 			r := chi.NewRouter()
-			r.Head("/attachments/{attachment_id}", handler.CheckAttachment)
+			r.Head("/api/attachments/{attachment_id}", handler.CheckAttachment)
 			r.ServeHTTP(rr, req)
 
 			// Check response
@@ -259,10 +259,10 @@ func TestDownloadAttachment_StreamingErrorLogged(t *testing.T) {
 
 	handler := NewAttachmentHandler(log, mockSvc, mockManifest)
 
-	req := httptest.NewRequest("GET", "/attachments/badfile", nil)
+	req := httptest.NewRequest("GET", "/api/attachments/badfile", nil)
 	rr := httptest.NewRecorder()
 	r := chi.NewRouter()
-	r.Get("/attachments/{attachment_id}", handler.DownloadAttachment)
+	r.Get("/api/attachments/{attachment_id}", handler.DownloadAttachment)
 	r.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)

--- a/synkronus/internal/handlers/auth_test.go
+++ b/synkronus/internal/handlers/auth_test.go
@@ -48,7 +48,7 @@ func TestLogin(t *testing.T) {
 			}
 
 			// Create a test request
-			req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewBuffer(body))
+			req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewBuffer(body))
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
 
@@ -124,7 +124,7 @@ func TestRefreshToken(t *testing.T) {
 			}
 
 			// Create a test request
-			req := httptest.NewRequest(http.MethodPost, "/auth/refresh", bytes.NewBuffer(body))
+			req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", bytes.NewBuffer(body))
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
 

--- a/synkronus/internal/handlers/dataexport.go
+++ b/synkronus/internal/handlers/dataexport.go
@@ -15,7 +15,7 @@ import (
 // @Failure 403 {object} ErrorResponse "Forbidden"
 // @Failure 500 {object} ErrorResponse "Internal Server Error"
 // @Security BearerAuth
-// @Router /dataexport/parquet [get]
+// @Router /api/dataexport/parquet [get]
 func (h *Handler) ParquetExportHandler(w http.ResponseWriter, r *http.Request) {
 	// Export data as parquet ZIP
 	zipReader, err := h.dataExportService.ExportParquetZip(r.Context())

--- a/synkronus/internal/handlers/dataexport_test.go
+++ b/synkronus/internal/handlers/dataexport_test.go
@@ -55,7 +55,7 @@ func TestHandler_ParquetExportHandler(t *testing.T) {
 			h.dataExportService = mockDataExportService
 
 			// Create request
-			req := httptest.NewRequest(http.MethodGet, "/dataexport/parquet", nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/dataexport/parquet", nil)
 			w := httptest.NewRecorder()
 
 			// Call handler
@@ -116,7 +116,7 @@ func TestHandler_ParquetExportHandler_Integration(t *testing.T) {
 	h.dataExportService = mockDataExportService
 
 	// Create request
-	req := httptest.NewRequest(http.MethodGet, "/dataexport/parquet", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/dataexport/parquet", nil)
 	w := httptest.NewRecorder()
 
 	// Call handler

--- a/synkronus/internal/handlers/mocks/config.go
+++ b/synkronus/internal/handlers/mocks/config.go
@@ -8,9 +8,9 @@ func NewTestConfig() *config.Config {
 		AppBundlePath:         "./testdata/appbundles",
 		AppBundleVersionsPath: "./testdata/app-bundle-versions",
 		Port:                  "8080",
-		DatabaseURL:   "postgres://postgres:postgres@localhost:5432/synkronus_test?sslmode=disable",
-		JWTSecret:     "test-secret",
-		LogLevel:      "debug",
-		DataDir:       "./testdata",
+		DatabaseURL:           "postgres://postgres:postgres@localhost:5432/synkronus_test?sslmode=disable",
+		JWTSecret:             "test-secret",
+		LogLevel:              "debug",
+		DataDir:               "./testdata",
 	}
 }

--- a/synkronus/internal/handlers/sync_e2e_test.go
+++ b/synkronus/internal/handlers/sync_e2e_test.go
@@ -46,7 +46,7 @@ func TestSyncE2E_VersionIncrement(t *testing.T) {
 		t.Fatalf("Failed to marshal pull request: %v", err)
 	}
 
-	req, err := http.NewRequest("POST", server.URL+"/sync/pull", bytes.NewReader(pullBody))
+	req, err := http.NewRequest("POST", server.URL+"/api/sync/pull", bytes.NewReader(pullBody))
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestSyncE2E_PartialFailure(t *testing.T) {
 		t.Fatalf("Failed to marshal push request: %v", err)
 	}
 
-	req, err := http.NewRequest("POST", server.URL+"/sync/push", bytes.NewReader(pushBody))
+	req, err := http.NewRequest("POST", server.URL+"/api/sync/push", bytes.NewReader(pushBody))
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestSyncE2E_SchemaTypeFiltering(t *testing.T) {
 		t.Fatalf("Failed to marshal push request: %v", err)
 	}
 
-	req, err := http.NewRequest("POST", server.URL+"/sync/push", bytes.NewReader(pushBody))
+	req, err := http.NewRequest("POST", server.URL+"/api/sync/push", bytes.NewReader(pushBody))
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestSyncE2E_SchemaTypeFiltering(t *testing.T) {
 		t.Fatalf("Failed to marshal pull request: %v", err)
 	}
 
-	req, err = http.NewRequest("POST", server.URL+"/sync/pull", bytes.NewReader(pullBody))
+	req, err = http.NewRequest("POST", server.URL+"/api/sync/pull", bytes.NewReader(pullBody))
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -289,8 +289,8 @@ func createTestServerWithDB(t *testing.T, db *sql.DB) *httptest.Server {
 
 	// Wrap sync endpoints with auth middleware
 	authMiddleware := authmw.AuthMiddleware(&mockAuthService{}, log)
-	mux.Handle("/sync/pull", authMiddleware(http.HandlerFunc(handler.Pull)))
-	mux.Handle("/sync/push", authMiddleware(http.HandlerFunc(handler.Push)))
+	mux.Handle("/api/sync/pull", authMiddleware(http.HandlerFunc(handler.Pull)))
+	mux.Handle("/api/sync/push", authMiddleware(http.HandlerFunc(handler.Push)))
 
 	return httptest.NewServer(mux)
 }

--- a/synkronus/internal/handlers/sync_push_pull_test.go
+++ b/synkronus/internal/handlers/sync_push_pull_test.go
@@ -42,7 +42,7 @@ func TestPushThenPull(t *testing.T) {
 
 		reqBytes, _ := json.Marshal(reqBody)
 		rr := httptest.NewRecorder()
-		h.Push(rr, httptest.NewRequest("POST", "/sync/push", bytes.NewReader(reqBytes)))
+		h.Push(rr, httptest.NewRequest("POST", "/api/sync/push", bytes.NewReader(reqBytes)))
 
 		if status := rr.Code; status != http.StatusOK {
 			t.Fatalf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
@@ -71,7 +71,7 @@ func TestPushThenPull(t *testing.T) {
 
 			reqBytes, _ := json.Marshal(reqBody)
 			rr := httptest.NewRecorder()
-			h.Pull(rr, httptest.NewRequest("POST", "/sync/pull", bytes.NewReader(reqBytes)))
+			h.Pull(rr, httptest.NewRequest("POST", "/api/sync/pull", bytes.NewReader(reqBytes)))
 
 			if status := rr.Code; status != http.StatusOK {
 				t.Fatalf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
@@ -137,7 +137,7 @@ func TestPushThenPull(t *testing.T) {
 
 				reqBytes, _ := json.Marshal(reqBody)
 				rr := httptest.NewRecorder()
-				h.Push(rr, httptest.NewRequest("POST", "/sync/push", bytes.NewReader(reqBytes)))
+				h.Push(rr, httptest.NewRequest("POST", "/api/sync/push", bytes.NewReader(reqBytes)))
 
 				if status := rr.Code; status != http.StatusOK {
 					t.Fatalf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
@@ -155,7 +155,7 @@ func TestPushThenPull(t *testing.T) {
 
 				reqBytes, _ = json.Marshal(reqBodyPull)
 				rr = httptest.NewRecorder()
-				h.Pull(rr, httptest.NewRequest("POST", "/sync/pull", bytes.NewReader(reqBytes)))
+				h.Pull(rr, httptest.NewRequest("POST", "/api/sync/pull", bytes.NewReader(reqBytes)))
 
 				if status := rr.Code; status != http.StatusOK {
 					t.Fatalf("handler returned wrong status code: got %v want %v", status, http.StatusOK)

--- a/synkronus/internal/handlers/sync_test.go
+++ b/synkronus/internal/handlers/sync_test.go
@@ -60,7 +60,7 @@ func TestPull(t *testing.T) {
 			}
 
 			// Create a test request
-			req := httptest.NewRequest(http.MethodPost, "/sync/pull", bytes.NewBuffer(body))
+			req := httptest.NewRequest(http.MethodPost, "/api/sync/pull", bytes.NewBuffer(body))
 			req.Header.Set("Content-Type", "application/json")
 			if tc.etagHeader != "" {
 				req.Header.Set("If-None-Match", tc.etagHeader)
@@ -219,7 +219,7 @@ func TestPush(t *testing.T) {
 			}
 
 			// Create a test request
-			req := httptest.NewRequest(http.MethodPost, "/sync/push", bytes.NewBuffer(body))
+			req := httptest.NewRequest(http.MethodPost, "/api/sync/push", bytes.NewBuffer(body))
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
 

--- a/synkronus/internal/handlers/user_test.go
+++ b/synkronus/internal/handlers/user_test.go
@@ -49,7 +49,7 @@ func TestCreateUserHandler(t *testing.T) {
 		// Ensure the user does not exist (no setup needed)
 		payload := map[string]any{"username": "testuser", "password": "password", "role": "read-only"}
 		body, _ := json.Marshal(payload)
-		r := httptest.NewRequest(http.MethodPost, "/users/create", bytes.NewReader(body))
+		r := httptest.NewRequest(http.MethodPost, "/api/users/create", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.CreateUserHandler(w, r)
 		resp := w.Result()
@@ -62,7 +62,7 @@ func TestCreateUserHandler(t *testing.T) {
 		mockUserService.AddUser(existingUser)
 		payload := map[string]any{"username": "testuser", "password": "password", "role": "read-only"}
 		body, _ := json.Marshal(payload)
-		r := httptest.NewRequest(http.MethodPost, "/users/create", bytes.NewReader(body))
+		r := httptest.NewRequest(http.MethodPost, "/api/users/create", bytes.NewReader(body))
 		w := httptest.NewRecorder()
 		h.CreateUserHandler(w, r)
 		resp := w.Result()
@@ -105,7 +105,7 @@ func TestDeleteUserHandler(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setup()
-			r := httptest.NewRequest(http.MethodDelete, "/users/delete/"+tc.username, nil)
+			r := httptest.NewRequest(http.MethodDelete, "/api/users/delete/"+tc.username, nil)
 			ctx := chi.NewRouteContext()
 			if tc.username != "" {
 				ctx.URLParams.Add("username", tc.username)
@@ -148,7 +148,7 @@ func TestResetPasswordHandler(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			body, _ := json.Marshal(tc.payload)
-			r := httptest.NewRequest(http.MethodPost, "/users/reset-password", bytes.NewReader(body))
+			r := httptest.NewRequest(http.MethodPost, "/api/users/reset-password", bytes.NewReader(body))
 			w := httptest.NewRecorder()
 			h.ResetPasswordHandler(w, r)
 			resp := w.Result()
@@ -196,7 +196,7 @@ func TestChangePasswordHandler(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			body, _ := json.Marshal(tc.payload)
-			r := httptest.NewRequest(http.MethodPost, "/users/change-password", bytes.NewReader(body))
+			r := httptest.NewRequest(http.MethodPost, "/api/users/change-password", bytes.NewReader(body))
 			ctx := r.Context()
 			if tc.username != "" {
 				ctx = context.WithValue(ctx, auth.UserKey, &models.User{Username: tc.username, Role: models.RoleReadOnly})

--- a/synkronus/openapi/synkronus.yaml
+++ b/synkronus/openapi/synkronus.yaml
@@ -48,7 +48,7 @@ paths:
                     format: date-time
                     description: Current server time
 
-  /version:
+  /api/version:
     get:
       operationId: getVersion
       summary: Get server version and system information
@@ -67,7 +67,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /app-bundle/changes:
+  /api/app-bundle/changes:
     get:
       operationId: getAppBundleChanges
       summary: Get changes between two app bundle versions
@@ -121,7 +121,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /app-bundle/manifest:
+  /api/app-bundle/manifest:
     get:
       operationId: getAppBundleManifest
       summary: Get the current custom app bundle manifest
@@ -149,7 +149,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AppBundleManifest'
 
-  /app-bundle/download/{path}:
+  /api/app-bundle/download/{path}:
     get:
       operationId: downloadAppBundleFile
       summary: Download a specific file from the app bundle
@@ -195,7 +195,7 @@ paths:
         '304':
           description: Not Modified
 
-  /app-bundle/versions:
+  /api/app-bundle/versions:
     get:
       operationId: getAppBundleVersions
       summary: Get a list of available app bundle versions
@@ -218,7 +218,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AppBundleVersions'
 
-  /app-bundle/push:
+  /api/app-bundle/push:
     post:
       operationId: pushAppBundle
       summary: Upload a new app bundle (admin only)
@@ -276,7 +276,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /app-bundle/switch/{version}:
+  /api/app-bundle/switch/{version}:
     post:
       operationId: switchAppBundleVersion
       summary: Switch to a specific app bundle version (admin only)
@@ -333,7 +333,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /auth/login:
+  /api/auth/login:
     post:
       operationId: login
       summary: Authenticate user and return JWT tokens
@@ -382,7 +382,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /auth/refresh:
+  /api/auth/refresh:
     post:
       operationId: refreshToken
       summary: Refresh JWT token
@@ -427,7 +427,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /users/create:
+  /api/users/create:
     post:
       operationId: createUser
       summary: Create a new user (admin only)
@@ -494,7 +494,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /users:
+  /api/users:
     get:
       operationId: listUsers
       summary: List all users (admin only)
@@ -532,7 +532,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /users/{username}:
+  /api/users/{username}:
     delete:
       operationId: deleteUser
       summary: Delete a user (admin only)
@@ -590,7 +590,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /users/reset-password:
+  /api/users/reset-password:
     post:
       operationId: resetUserPassword
       summary: Reset user password (admin only)
@@ -657,7 +657,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /users/change-password:
+  /api/users/change-password:
     post:
       operationId: changePassword
       summary: Change user password (authenticated user)'s password
@@ -713,7 +713,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /sync/pull:
+  /api/sync/pull:
     post:
       operationId: syncPull
       summary: Pull updated records since last sync
@@ -768,7 +768,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SyncPullResponse'
 
-  /sync/push:
+  /api/sync/push:
     post:
       operationId: syncPush
       summary: Push new or updated records to the server
@@ -797,7 +797,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SyncPushResponse'
 
-  /attachments/manifest:
+  /api/attachments/manifest:
     post:
       operationId: getAttachmentManifest
       summary: Get attachment manifest for incremental sync
@@ -845,7 +845,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /attachments/{attachment_id}:
+  /api/attachments/{attachment_id}:
     put:
       operationId: uploadAttachment
       summary: Upload a new attachment with specified ID
@@ -934,7 +934,7 @@ paths:
         '404':
           description: Attachment not found
 
-  /dataexport/parquet:
+  /api/dataexport/parquet:
     get:
       summary: Download a ZIP archive of Parquet exports
       description: >
@@ -1432,4 +1432,4 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: 'JWT token obtained from /auth/login'
+      description: 'JWT token obtained from /api/auth/login'

--- a/synkronus/pkg/middleware/formulusversion/formulusversion_test.go
+++ b/synkronus/pkg/middleware/formulusversion/formulusversion_test.go
@@ -45,7 +45,7 @@ func TestMiddleware(t *testing.T) {
 	handler := mw(next)
 
 	t.Run("no_header_returns_426", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 		if rec.Code != http.StatusUpgradeRequired {
@@ -61,7 +61,7 @@ func TestMiddleware(t *testing.T) {
 	})
 
 	t.Run("unparseable_client_version_returns_426", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
 		req.Header.Set("X-Formulus-Version", "not-a-version")
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
@@ -75,7 +75,7 @@ func TestMiddleware(t *testing.T) {
 
 	t.Run("matching_major_versions_pass", func(t *testing.T) {
 		// Server BuildVersion() default is "1.0.0" and client sends "1.0.0" → major versions match (1 == 1)
-		req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
 		req.Header.Set("X-Formulus-Version", "1.0.0")
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
@@ -89,7 +89,7 @@ func TestMiddleware(t *testing.T) {
 
 	t.Run("mismatched_major_versions_return_426", func(t *testing.T) {
 		// Client sends "2.0.0" but server is "1.0.0" → major versions mismatch (2 != 1)
-		req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
 		req.Header.Set("X-Formulus-Version", "2.0.0")
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)


### PR DESCRIPTION
# Ensure all API routes (except /health) are served from /api
Updated clients (autogenerated client, formulus, CLI, portal) to match..