### PR TITLE
feat(formplayer): inject Fuse into custom question type sandbox

### DIFF
--- a/docs/custom-question-types.md
+++ b/docs/custom-question-types.md
@@ -67,7 +67,7 @@ interface CustomQuestionTypeProps {
 
 ### 3. Example Implementation: `renderer.js`
 
-Because the Formplayer evaluates this at runtime within a browser without a bundler, you cannot rely on ES modules (`import/export`). Instead, use CommonJS (`module.exports`) and rely on injected globals like `React` and `MaterialUI`.
+Because the Formplayer evaluates this at runtime within a browser without a bundler, you cannot rely on ES modules (`import/export`). Instead, use CommonJS (`module.exports`) and rely on injected parameters: **`React`**, **`MaterialUI`** (MUI), and **`Fuse`** (the default export from [fuse.js](https://fusejs.io/), same as `import Fuse from 'fuse.js'`). The loader passes these as arguments to your module body; treat them like globals inside `renderer.js` (for example, `const { useState } = React; new Fuse(list, options)`).
 
 ```javascript
 const { useState, useEffect } = React;

--- a/formulus-formplayer/package-lock.json
+++ b/formulus-formplayer/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "formulus-formplayer",
       "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -29,6 +30,7 @@
         "ajv": "^8.17.1",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",
+        "fuse.js": "^7.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-swipeable": "^7.0.2",
@@ -5009,6 +5011,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/formulus-formplayer/package.json
+++ b/formulus-formplayer/package.json
@@ -27,6 +27,7 @@
     "ajv": "^8.17.1",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
+    "fuse.js": "^7.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-swipeable": "^7.0.2",

--- a/formulus-formplayer/src/services/CustomQuestionTypeLoader.ts
+++ b/formulus-formplayer/src/services/CustomQuestionTypeLoader.ts
@@ -23,6 +23,7 @@ import type {
 } from '../types/CustomQuestionTypeContract';
 import { registerCustomQuestionTypes } from './CustomQuestionTypeRegistry';
 import type React from 'react';
+import Fuse from 'fuse.js';
 
 export interface CustomQuestionTypeLoadResult {
   /** JSON Forms renderer entries ready to be merged into the renderers array */
@@ -71,7 +72,7 @@ export async function loadCustomQuestionTypes(
 
       // Create a CommonJS-compatible sandbox with module/exports shims
       // The renderers use: module.exports = { default: ComponentFunction }
-      // They also expect React and MaterialUI as globals
+      // Injected: React, MaterialUI (window), Fuse (formplayer dependency)
       const moduleShim: { exports: Record<string, unknown> } = {
         exports: {},
       };
@@ -83,6 +84,7 @@ export async function loadCustomQuestionTypes(
         'exports',
         'React',
         'MaterialUI',
+        'Fuse',
         meta.source,
       );
       factory(
@@ -90,6 +92,7 @@ export async function loadCustomQuestionTypes(
         exportsShim,
         (window as any).React,
         (window as any).MaterialUI,
+        Fuse,
       );
 
       // Extract the component: try module.exports.default, then module.exports itself


### PR DESCRIPTION
Enables fuzzy search in eval'd renderers (e.g. select-person) without vendoring fuse.js in bundle source. Document Fuse alongside React/MUI in custom-question-types.md.
