### PR TITLE
fix: Linked table nested form lifecycle - preserve parent form state across child form sessions

### DIFF
--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -329,7 +329,10 @@ function App() {
       newObservationDraftSessionKey?: string | null,
     ) => {
       try {
-        if (initData.observationId != null) {
+        if (initData.returnOnly) {
+          // Embedded child form: data lives only in memory until returned to parent; no local drafts.
+          setDraftSessionKey(null);
+        } else if (initData.observationId != null) {
           setDraftSessionKey(null);
         } else if (newObservationDraftSessionKey !== undefined) {
           setDraftSessionKey(newObservationDraftSessionKey);
@@ -590,7 +593,7 @@ function App() {
         // Check if this is a new form (no savedData) and if drafts exist
         const hasExistingSavedData =
           savedData && Object.keys(savedData).length > 0;
-        if (!hasExistingSavedData) {
+        if (!initData.returnOnly && !hasExistingSavedData) {
           const availableDrafts = draftService.getDraftsForForm(
             receivedFormType,
             (formSchema as any)?.version,
@@ -948,8 +951,8 @@ function App() {
     ({ data: newData }: { data: FormData }) => {
       setData(newData);
 
-      // Save draft data whenever form data changes
-      if (formInitData) {
+      // Save draft data whenever form data changes (skip embedded return-only child forms)
+      if (formInitData && !formInitData.returnOnly) {
         draftService.saveDraft(
           formInitData.formType,
           newData,

--- a/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
+++ b/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
@@ -56,6 +56,7 @@ export interface FormInitData {
   formSchema?: unknown;
   uiSchema?: unknown;
   operationId?: string;
+  returnOnly?: boolean; // For embedded child forms: return JSON without saving to DB
   extensions?: ExtensionMetadata;
   customQuestionTypes?: {
     custom_types: Record<string, { source: string }>;
@@ -284,6 +285,7 @@ export interface FormulusInterface {
     formType: string,
     params: Record<string, unknown>,
     savedData: Record<string, unknown>,
+    options?: { returnOnly?: boolean },
   ): Promise<FormCompletionResult>;
 
   /**

--- a/formulus/App.tsx
+++ b/formulus/App.tsx
@@ -66,7 +66,7 @@ function AppInner(): React.JSX.Element {
     observationId: string | null;
     savedData: Record<string, unknown> | null;
     operationId: string | null;
-    returnOnly?: boolean;  // For child forms opened from linkedtable
+    returnOnly?: boolean; // For child forms opened from linkedtable
   };
 
   const [formplayerStack, setFormplayerStack] = useState<
@@ -97,7 +97,7 @@ function AppInner(): React.JSX.Element {
             entry.observationId,
             entry.savedData,
             entry.operationId,
-            entry.returnOnly,  // ← Pass returnOnly flag
+            entry.returnOnly, // ← Pass returnOnly flag
           );
         }, 200);
       };
@@ -140,8 +140,14 @@ function AppInner(): React.JSX.Element {
     );
 
     const handleOpenFormplayer = async (config: FormInitData) => {
-      const { formType, observationId, params, savedData, operationId, returnOnly } =
-        config;
+      const {
+        formType,
+        observationId,
+        params,
+        savedData,
+        operationId,
+        returnOnly,
+      } = config;
 
       try {
         const formService = await FormService.getInstance();
@@ -174,7 +180,7 @@ function AppInner(): React.JSX.Element {
           observationId: observationId || null,
           savedData: savedData || null,
           operationId: operationId || null,
-          returnOnly: returnOnly || false,  // Include returnOnly flag
+          returnOnly: returnOnly || false, // Include returnOnly flag
         };
 
         setFormplayerStack(current => [...current, entry]);

--- a/formulus/App.tsx
+++ b/formulus/App.tsx
@@ -19,6 +19,7 @@ import QRScannerModal from './src/components/QRScannerModal';
 import SignatureCaptureModal from './src/components/SignatureCaptureModal';
 import MainAppNavigator from './src/navigation/MainAppNavigator';
 import { FormInitData } from './src/webview/FormulusInterfaceDefinition.ts';
+import { FormSpec } from './src/services';
 
 /**
  * Inner component that consumes the AppTheme context to build a dynamic
@@ -58,13 +59,58 @@ function AppInner(): React.JSX.Element {
     onResult: (result: unknown) => void;
   } | null>(null);
 
-  const [formplayerVisible, setFormplayerVisible] = useState(false);
-  const formplayerModalRef = React.useRef<FormplayerModalHandle>(null);
-  const formplayerVisibleRef = React.useRef(false);
+  type FormplayerStackEntry = {
+    id: string;
+    formSpec: FormSpec;
+    params: Record<string, unknown> | null;
+    observationId: string | null;
+    savedData: Record<string, unknown> | null;
+    operationId: string | null;
+  };
 
-  useEffect(() => {
-    formplayerVisibleRef.current = formplayerVisible;
-  }, [formplayerVisible]);
+  const [formplayerStack, setFormplayerStack] = useState<
+    FormplayerStackEntry[]
+  >([]);
+  const formplayerModalRefs = React.useRef(
+    new Map<string, FormplayerModalHandle | null>(),
+  );
+
+  const initializeStackEntry = React.useCallback(
+    (entry: FormplayerStackEntry) => {
+      let attempt = 0;
+
+      const tryInitialize = () => {
+        const modalHandle = formplayerModalRefs.current.get(entry.id);
+        if (!modalHandle) {
+          if (attempt < 20) {
+            attempt += 1;
+            setTimeout(tryInitialize, 100);
+          }
+          return;
+        }
+
+        setTimeout(() => {
+          modalHandle.initializeForm(
+            entry.formSpec,
+            entry.params,
+            entry.observationId,
+            entry.savedData,
+            entry.operationId,
+          );
+        }, 200);
+      };
+
+      tryInitialize();
+    },
+    [],
+  );
+
+  const closeFormplayerEntry = React.useCallback((entryId: string) => {
+    formplayerModalRefs.current.delete(entryId);
+    setFormplayerStack(current =>
+      current.filter(entry => entry.id !== entryId),
+    );
+  }, []);
 
   useEffect(() => {
     FormService.getInstance();
@@ -92,17 +138,6 @@ function AppInner(): React.JSX.Element {
     );
 
     const handleOpenFormplayer = async (config: FormInitData) => {
-      // If formplayer is already visible, close it first to allow opening a new form
-      if (formplayerVisibleRef.current) {
-        console.log(
-          '[App] Formplayer already visible, closing first before opening new form',
-        );
-        formplayerVisibleRef.current = false;
-        setFormplayerVisible(false);
-        // Wait for modal to close before proceeding
-        await new Promise<void>(resolve => setTimeout(() => resolve(), 300));
-      }
-
       const { formType, observationId, params, savedData, operationId } =
         config;
 
@@ -127,21 +162,20 @@ function AppInner(): React.JSX.Element {
           return;
         }
 
-        // Set visible state first to mount the modal
-        formplayerVisibleRef.current = true;
-        setFormplayerVisible(true);
+        const entryId =
+          operationId ||
+          `${formType}_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+        const entry: FormplayerStackEntry = {
+          id: entryId,
+          formSpec,
+          params: params || null,
+          observationId: observationId || null,
+          savedData: savedData || null,
+          operationId: operationId || null,
+        };
 
-        // Wait for modal to mount and WebView to start loading before initializing form
-        // This ensures the WebView ref is available and the modal is visible
-        setTimeout(() => {
-          formplayerModalRef.current?.initializeForm(
-            formSpec,
-            params || null,
-            observationId || null,
-            savedData || null,
-            operationId || null,
-          );
-        }, 200);
+        setFormplayerStack(current => [...current, entry]);
+        initializeStackEntry(entry);
       } catch (error) {
         console.error('[App] Error opening formplayer:', error);
         Alert.alert(
@@ -150,15 +184,19 @@ function AppInner(): React.JSX.Element {
             error instanceof Error ? error.message : 'Unknown error'
           }`,
         );
-        // Reset state on error
-        formplayerVisibleRef.current = false;
-        setFormplayerVisible(false);
       }
     };
 
     const handleCloseFormplayer = () => {
-      formplayerVisibleRef.current = false;
-      setFormplayerVisible(false);
+      setFormplayerStack(current => {
+        if (current.length === 0) {
+          return current;
+        }
+        const next = current.slice(0, -1);
+        const removed = current[current.length - 1];
+        formplayerModalRefs.current.delete(removed.id);
+        return next;
+      });
     };
 
     appEvents.addListener(
@@ -182,7 +220,7 @@ function AppInner(): React.JSX.Element {
       );
       appEvents.removeListener('closeFormplayer', handleCloseFormplayer);
     };
-  }, []);
+  }, [closeFormplayerEntry, initializeStackEntry]);
 
   return (
     <>
@@ -192,14 +230,23 @@ function AppInner(): React.JSX.Element {
       />
       <NavigationContainer theme={navigationTheme}>
         <MainAppNavigator />
-        <FormplayerModal
-          ref={formplayerModalRef}
-          visible={formplayerVisible}
-          onClose={() => {
-            formplayerVisibleRef.current = false;
-            setFormplayerVisible(false);
-          }}
-        />
+        {formplayerStack.map((entry, index) => (
+          <FormplayerModal
+            key={entry.id}
+            ref={instance => {
+              if (instance) {
+                formplayerModalRefs.current.set(entry.id, instance);
+              } else {
+                formplayerModalRefs.current.delete(entry.id);
+              }
+            }}
+            visible={true}
+            isActive={index === formplayerStack.length - 1}
+            onClose={() => {
+              closeFormplayerEntry(entry.id);
+            }}
+          />
+        ))}
       </NavigationContainer>
 
       <QRScannerModal

--- a/formulus/App.tsx
+++ b/formulus/App.tsx
@@ -66,6 +66,7 @@ function AppInner(): React.JSX.Element {
     observationId: string | null;
     savedData: Record<string, unknown> | null;
     operationId: string | null;
+    returnOnly?: boolean;  // For child forms opened from linkedtable
   };
 
   const [formplayerStack, setFormplayerStack] = useState<
@@ -96,6 +97,7 @@ function AppInner(): React.JSX.Element {
             entry.observationId,
             entry.savedData,
             entry.operationId,
+            entry.returnOnly,  // ← Pass returnOnly flag
           );
         }, 200);
       };
@@ -138,7 +140,7 @@ function AppInner(): React.JSX.Element {
     );
 
     const handleOpenFormplayer = async (config: FormInitData) => {
-      const { formType, observationId, params, savedData, operationId } =
+      const { formType, observationId, params, savedData, operationId, returnOnly } =
         config;
 
       try {
@@ -172,6 +174,7 @@ function AppInner(): React.JSX.Element {
           observationId: observationId || null,
           savedData: savedData || null,
           operationId: operationId || null,
+          returnOnly: returnOnly || false,  // Include returnOnly flag
         };
 
         setFormplayerStack(current => [...current, entry]);

--- a/formulus/android/app/src/main/assets/webview/FormulusInjectionScript.js
+++ b/formulus/android/app/src/main/assets/webview/FormulusInjectionScript.js
@@ -285,7 +285,7 @@
     },
 
     // openFormplayer: formType: string, params: Record<string, any>, savedData: Record<string, any> => Promise<FormCompletionResult>
-    openFormplayer: function (formType, params, savedData) {
+    openFormplayer: function (formType, params, savedData, options) {
       return new Promise((resolve, reject) => {
         const messageId =
           'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
@@ -342,6 +342,7 @@
             formType: formType,
             params: params,
             savedData: savedData,
+            options: options,
           }),
         );
       });

--- a/formulus/android/app/src/main/assets/webview/formulus-api.js
+++ b/formulus/android/app/src/main/assets/webview/formulus-api.js
@@ -50,7 +50,7 @@ const FormulusAPI = {
    * @param {Object} savedData - Previously saved form data (for editing)
    * @returns {Promise<FormCompletionResult>} Promise that resolves when the form is completed/closed with result details
    */
-  openFormplayer: function (formType, params, savedData) {},
+  openFormplayer: function (formType, params, savedData, options) {},
 
   /**
    * Get observations for a specific form

--- a/formulus/assets/webview/FormulusInjectionScript.js
+++ b/formulus/assets/webview/FormulusInjectionScript.js
@@ -230,8 +230,8 @@
       });
     },
 
-    // openFormplayer: formType: string, params: Record<string, unknown>, savedData: Record<string, unknown> => Promise<FormCompletionResult>
-    openFormplayer: function (formType, params, savedData) {
+    // openFormplayer: formType, params, savedData, options? => Promise<FormCompletionResult>
+    openFormplayer: function (formType, params, savedData, options) {
       return new Promise((resolve, reject) => {
         const messageId =
           'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
@@ -288,6 +288,7 @@
             formType: formType,
             params: params,
             savedData: savedData,
+            options: options,
           }),
         );
       });

--- a/formulus/assets/webview/formulus-api.js
+++ b/formulus/assets/webview/formulus-api.js
@@ -50,7 +50,7 @@ const FormulusAPI = {
    * @param {Object} savedData - Previously saved form data (for editing)
    * @returns {Promise<FormCompletionResult>} Promise that resolves when the form is completed/closed with result details
    */
-  openFormplayer: function (formType, params, savedData) {},
+  openFormplayer: function (formType, params, savedData, options) {},
 
   /**
    * Get observations for a specific form

--- a/formulus/assets/webview/placeholder_app.html
+++ b/formulus/assets/webview/placeholder_app.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>Custom App Placeholder</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <style>
       /* ODE_TOKENS_START */
-/*
+      /*
        * ODE design tokens — generated from packages/tokens. Do not edit; run npm run generate:placeholder-tokens to update.
        */
       :root {
@@ -39,7 +39,8 @@
         --font-weight-regular: 400;
         --font-weight-bold: 700;
         /* font.family.sans */
-        --font-family-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+        --font-family-sans:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
         /* font.lineHeight */
         --line-height-tight: 1.25;
         --line-height-normal: 1.5;
@@ -54,8 +55,11 @@
       }
       /* ODE_TOKENS_END */
 
-      * { box-sizing: border-box; }
-      html, body {
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
         margin: 0;
         padding: 0;
         min-height: 100%;
@@ -70,12 +74,14 @@
         justify-content: center;
         padding: var(--spacing-8);
         background: transparent;
-        transition: color 0.2s ease, background-color 0.2s ease;
+        transition:
+          color 0.2s ease,
+          background-color 0.2s ease;
       }
-      [data-theme="light"] body {
+      [data-theme='light'] body {
         color: var(--color-neutral-600);
       }
-      [data-theme="dark"] body {
+      [data-theme='dark'] body {
         color: var(--color-neutral-white);
       }
       html:not([data-theme]) body {
@@ -105,10 +111,10 @@
         line-height: var(--line-height-normal);
         margin: 0 0 var(--spacing-8);
       }
-      [data-theme="dark"] .placeholder-subtitle {
+      [data-theme='dark'] .placeholder-subtitle {
         color: var(--color-neutral-400);
       }
-      [data-theme="light"] .placeholder-subtitle {
+      [data-theme='light'] .placeholder-subtitle {
         color: var(--color-neutral-600);
       }
 
@@ -127,7 +133,9 @@
         border: var(--border-width-thin) solid var(--color-brand-primary-500);
         border-radius: var(--border-radius-md);
         cursor: pointer;
-        transition: background-color 0.15s ease, color 0.15s ease;
+        transition:
+          background-color 0.15s ease,
+          color 0.15s ease;
         margin-bottom: var(--spacing-8);
       }
       .placeholder-btn:hover,
@@ -140,29 +148,30 @@
         font-size: var(--font-size-sm);
         margin: 0 0 var(--spacing-2);
       }
-      [data-theme="dark"] .placeholder-tagline {
+      [data-theme='dark'] .placeholder-tagline {
         color: var(--color-neutral-white);
       }
-      [data-theme="light"] .placeholder-tagline {
+      [data-theme='light'] .placeholder-tagline {
         color: var(--color-neutral-600);
       }
       .placeholder-version {
         font-size: var(--font-size-xs);
         margin: 0;
       }
-      [data-theme="dark"] .placeholder-version {
+      [data-theme='dark'] .placeholder-version {
         color: var(--color-neutral-400);
       }
-      [data-theme="light"] .placeholder-version {
+      [data-theme='light'] .placeholder-version {
         color: var(--color-neutral-600);
       }
     </style>
   </head>
   <body>
     <div class="placeholder-card">
-      <h1 class="placeholder-title">Your Custom<br>App</h1>
+      <h1 class="placeholder-title">Your Custom<br />App</h1>
       <p class="placeholder-subtitle" id="subtitle-text">
-        <strong>Login</strong> and <strong>Update App Bundle</strong> to load your forms
+        <strong>Login</strong> and <strong>Update App Bundle</strong> to load
+        your forms
       </p>
       <button
         type="button"
@@ -175,129 +184,156 @@
       <p class="placeholder-version" id="version-el">v0.1.0-native</p>
     </div>
     <script>
-    (function() {
-      function setTheme(mode) {
-        document.documentElement.setAttribute('data-theme', mode === 'dark' ? 'dark' : 'light');
-      }
-      window.__formulusSetTheme = setTheme;
-
-      function navigateToLogin() {
-        try {
-          if (window.ReactNativeWebView && typeof window.ReactNativeWebView.postMessage === 'function') {
-            window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'formulusNavigateToSettings' }));
-          }
-        } catch (e) {
-          console.error('Placeholder: failed to post formulusNavigateToSettings', e);
+      (function () {
+        function setTheme(mode) {
+          document.documentElement.setAttribute(
+            'data-theme',
+            mode === 'dark' ? 'dark' : 'light',
+          );
         }
-      }
+        window.__formulusSetTheme = setTheme;
 
-      function navigateToSync() {
-        try {
-          if (window.ReactNativeWebView && typeof window.ReactNativeWebView.postMessage === 'function') {
-            window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'formulusNavigateToSync' }));
-          }
-        } catch (e) {
-          console.error('Placeholder: failed to post formulusNavigateToSync', e);
-        }
-      }
-
-      var loginBtn = document.getElementById('login-btn');
-      var subtitleEl = document.getElementById('subtitle-text');
-
-      /** Logged-out copy: bold Login + Update App Bundle. Logged-in copy: bold Update App Bundle only. */
-      var SUBTITLE_LOGIN =
-        '<strong>Login</strong> and <strong>Update App Bundle</strong> to load your forms';
-      var SUBTITLE_UPDATE =
-        '<strong>Update App Bundle</strong> to load your forms';
-
-      function setButtonMode(mode) {
-        if (!loginBtn) return;
-        if (mode === 'sync') {
-          // Logged in: button goes to Sync screen to update app bundle
-          loginBtn.textContent = 'Update Now';
-          loginBtn.setAttribute('aria-label', 'Update App Bundle to load forms');
-          loginBtn.onclick = navigateToSync;
-          if (subtitleEl) subtitleEl.innerHTML = SUBTITLE_UPDATE;
-        } else {
-          loginBtn.textContent = 'Login Now';
-          loginBtn.setAttribute('aria-label', 'Login to load forms');
-          loginBtn.onclick = navigateToLogin;
-          if (subtitleEl) subtitleEl.innerHTML = SUBTITLE_LOGIN;
-        }
-      }
-
-      function refreshLoginState() {
-        try {
-          var api = window.formulus || globalThis.formulus;
-          if (!api || typeof api.getCurrentUser !== 'function') {
-            setButtonMode('login');
-            return;
-          }
-          api
-            .getCurrentUser()
-            .then(function(user) {
-              if (user && user.username) {
-                setButtonMode('sync');
-              } else {
-                setButtonMode('login');
-              }
-            })
-            .catch(function() {
-              setButtonMode('login');
-            });
-        } catch (e) {
-          console.error('Placeholder: failed to refresh login state', e);
-          setButtonMode('login');
-        }
-      }
-
-      // Expose a hook so the native app can force-refresh the button state
-      window.__formulusPlaceholderRefreshLoginState = refreshLoginState;
-
-      // Default state before we know anything about login
-      setButtonMode('login');
-
-      function waitForFormulus(cb, tries) {
-        tries = tries !== undefined ? tries : 50;
-        var api = window.formulus || globalThis.formulus;
-        if (api && typeof api.getVersion === 'function') {
+        function navigateToLogin() {
           try {
-            var versionPromise = api.getVersion();
-            if (versionPromise && typeof versionPromise.then === 'function') {
-              versionPromise.then(function(v) {
-                var el = document.getElementById('version-el');
-                if (el && typeof v === 'string') el.textContent = 'v' + v;
-                if (typeof cb === 'function') cb();
-              }).catch(function() {
-                if (typeof cb === 'function') cb();
+            if (
+              window.ReactNativeWebView &&
+              typeof window.ReactNativeWebView.postMessage === 'function'
+            ) {
+              window.ReactNativeWebView.postMessage(
+                JSON.stringify({ type: 'formulusNavigateToSettings' }),
+              );
+            }
+          } catch (e) {
+            console.error(
+              'Placeholder: failed to post formulusNavigateToSettings',
+              e,
+            );
+          }
+        }
+
+        function navigateToSync() {
+          try {
+            if (
+              window.ReactNativeWebView &&
+              typeof window.ReactNativeWebView.postMessage === 'function'
+            ) {
+              window.ReactNativeWebView.postMessage(
+                JSON.stringify({ type: 'formulusNavigateToSync' }),
+              );
+            }
+          } catch (e) {
+            console.error(
+              'Placeholder: failed to post formulusNavigateToSync',
+              e,
+            );
+          }
+        }
+
+        var loginBtn = document.getElementById('login-btn');
+        var subtitleEl = document.getElementById('subtitle-text');
+
+        /** Logged-out copy: bold Login + Update App Bundle. Logged-in copy: bold Update App Bundle only. */
+        var SUBTITLE_LOGIN =
+          '<strong>Login</strong> and <strong>Update App Bundle</strong> to load your forms';
+        var SUBTITLE_UPDATE =
+          '<strong>Update App Bundle</strong> to load your forms';
+
+        function setButtonMode(mode) {
+          if (!loginBtn) return;
+          if (mode === 'sync') {
+            // Logged in: button goes to Sync screen to update app bundle
+            loginBtn.textContent = 'Update Now';
+            loginBtn.setAttribute(
+              'aria-label',
+              'Update App Bundle to load forms',
+            );
+            loginBtn.onclick = navigateToSync;
+            if (subtitleEl) subtitleEl.innerHTML = SUBTITLE_UPDATE;
+          } else {
+            loginBtn.textContent = 'Login Now';
+            loginBtn.setAttribute('aria-label', 'Login to load forms');
+            loginBtn.onclick = navigateToLogin;
+            if (subtitleEl) subtitleEl.innerHTML = SUBTITLE_LOGIN;
+          }
+        }
+
+        function refreshLoginState() {
+          try {
+            var api = window.formulus || globalThis.formulus;
+            if (!api || typeof api.getCurrentUser !== 'function') {
+              setButtonMode('login');
+              return;
+            }
+            api
+              .getCurrentUser()
+              .then(function (user) {
+                if (user && user.username) {
+                  setButtonMode('sync');
+                } else {
+                  setButtonMode('login');
+                }
+              })
+              .catch(function () {
+                setButtonMode('login');
               });
-            } else {
-              var el = document.getElementById('version-el');
-              if (el && typeof versionPromise === 'string') el.textContent = 'v' + versionPromise;
+          } catch (e) {
+            console.error('Placeholder: failed to refresh login state', e);
+            setButtonMode('login');
+          }
+        }
+
+        // Expose a hook so the native app can force-refresh the button state
+        window.__formulusPlaceholderRefreshLoginState = refreshLoginState;
+
+        // Default state before we know anything about login
+        setButtonMode('login');
+
+        function waitForFormulus(cb, tries) {
+          tries = tries !== undefined ? tries : 50;
+          var api = window.formulus || globalThis.formulus;
+          if (api && typeof api.getVersion === 'function') {
+            try {
+              var versionPromise = api.getVersion();
+              if (versionPromise && typeof versionPromise.then === 'function') {
+                versionPromise
+                  .then(function (v) {
+                    var el = document.getElementById('version-el');
+                    if (el && typeof v === 'string') el.textContent = 'v' + v;
+                    if (typeof cb === 'function') cb();
+                  })
+                  .catch(function () {
+                    if (typeof cb === 'function') cb();
+                  });
+              } else {
+                var el = document.getElementById('version-el');
+                if (el && typeof versionPromise === 'string')
+                  el.textContent = 'v' + versionPromise;
+                if (typeof cb === 'function') cb();
+              }
+            } catch (err) {
               if (typeof cb === 'function') cb();
             }
-          } catch (err) {
+          } else if (tries > 0) {
+            setTimeout(function () {
+              waitForFormulus(cb, tries - 1);
+            }, 100);
+          } else {
             if (typeof cb === 'function') cb();
           }
-        } else if (tries > 0) {
-          setTimeout(function() { waitForFormulus(cb, tries - 1); }, 100);
-        } else {
-          if (typeof cb === 'function') cb();
         }
-      }
 
-      if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', function() {
-          waitForFormulus(function() {
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', function () {
+            waitForFormulus(function () {
+              refreshLoginState();
+            });
+          });
+        } else {
+          waitForFormulus(function () {
             refreshLoginState();
           });
-        });
-      } else {
-        waitForFormulus(function() {
-          refreshLoginState();
-        });
-      }
-    })();
+        }
+      })();
     </script>
   </body>
 </html>

--- a/formulus/formplayer_question_types.md
+++ b/formulus/formplayer_question_types.md
@@ -104,7 +104,6 @@ Allows users to scan QR codes or enter QR code data manually.
 
 - **QR Code** - Quick Response codes
 
-
 **Data Structure:**
 The QR code field stores a simple string value:
 

--- a/formulus/scripts/vendor-notifee-core.mjs
+++ b/formulus/scripts/vendor-notifee-core.mjs
@@ -52,7 +52,9 @@ function patchNotifeeAndroidReleaseMinify() {
     `$1// [formulus] notifee_core release: keep minify off (R8 made InitProvider.onCreate final → LinkageError in NotifeeInitProvider)\n      minifyEnabled false`,
   );
   fs.writeFileSync(gradle, s);
-  console.log('Patched notifee android/build.gradle (release minifyEnabled false).');
+  console.log(
+    'Patched notifee android/build.gradle (release minifyEnabled false).',
+  );
 }
 
 if (!fs.existsSync(path.join(dest, 'android', 'build.gradle'))) {

--- a/formulus/src/components/CustomAppWebView.tsx
+++ b/formulus/src/components/CustomAppWebView.tsx
@@ -26,6 +26,7 @@ export interface CustomAppWebViewHandle {
   injectJavaScript: (script: string) => void;
   sendFormInit: (formData: FormInitData) => Promise<void>;
   sendAttachmentData: (attachmentData: File) => Promise<void>;
+  notifyReceiveFocus: () => void;
 }
 
 interface CustomAppWebViewProps {
@@ -340,6 +341,7 @@ const CustomAppWebView = forwardRef<
           messageManager.sendFormInit(formData),
         sendAttachmentData: (attachmentData: File) =>
           messageManager.sendAttachmentData(attachmentData),
+        notifyReceiveFocus: () => messageManager.notifyReceiveFocus(),
       }),
       [messageManager],
     );

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -59,6 +59,7 @@ export interface FormplayerModalHandle {
     observationId: string | null,
     existingObservationData: Record<string, unknown> | null,
     operationId: string | null,
+    returnOnly?: boolean,
   ) => void;
   handleSubmission: (data: {
     formType: string;
@@ -94,6 +95,10 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
 
     // Track if form has been successfully submitted to avoid double resolution
     const [formSubmitted, setFormSubmitted] = useState(false);
+
+    // Track if this form should return JSON only without saving to database
+    // Used for child forms embedded in linked-table scenarios
+    const [returnOnly, setReturnOnly] = useState(false);
 
     // Author-configurable display name shown in the native header bar
     const [currentFormDisplayName, setCurrentFormDisplayName] = useState<
@@ -208,6 +213,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       observationId: string | null,
       existingObservationData: Record<string, unknown> | null,
       operationId: string | null,
+      returnOnlyMode: boolean = false,
     ) => {
       // Check if WebView is ready, if not log a warning (retry logic will handle it)
       if (!webViewReady) {
@@ -215,6 +221,9 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           '[FormplayerModal] WebView not ready yet, form init will be queued by message handler',
         );
       }
+
+      // Set returnOnly flag for this form session
+      setReturnOnly(returnOnlyMode);
 
       // GPS session: fresh fix + light watch while the user fills the form
       geolocationService.beginObservationSession();
@@ -489,32 +498,44 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         setIsSubmitting(true);
 
         try {
-          // Get the local repository from the database service
-          const localRepo = databaseService.getLocalRepo();
-          if (!localRepo) {
-            throw new Error('Database repository not available');
-          }
-
-          // Save the observation
+          // Save the observation (optional - skip if returnOnly flag is set)
           let resultObservationId: string;
-          if (effectiveObservationId) {
-            const updateSuccess = await localRepo.updateObservation({
-              observationId: effectiveObservationId,
-              data: finalData,
-            });
-            if (!updateSuccess) {
-              throw new Error('Failed to update observation');
+          
+          if (!returnOnly) {
+            // Normal mode: save to database
+            const localRepo = databaseService.getLocalRepo();
+            if (!localRepo) {
+              throw new Error('Database repository not available');
             }
-            resultObservationId = effectiveObservationId;
+
+            if (effectiveObservationId) {
+              const updateSuccess = await localRepo.updateObservation({
+                observationId: effectiveObservationId,
+                data: finalData,
+              });
+              if (!updateSuccess) {
+                throw new Error('Failed to update observation');
+              }
+              resultObservationId = effectiveObservationId;
+            } else {
+              const newId = await localRepo.saveObservation({
+                formType,
+                data: finalData,
+              });
+              if (!newId) {
+                throw new Error('Failed to save new observation');
+              }
+              resultObservationId = newId;
+            }
           } else {
-            const newId = await localRepo.saveObservation({
-              formType,
-              data: finalData,
-            });
-            if (!newId) {
-              throw new Error('Failed to save new observation');
-            }
-            resultObservationId = newId;
+            // returnOnly mode: just generate ID, don't save to database
+            // This is used for embedded child forms in linked-table scenarios
+            resultObservationId =
+              effectiveObservationId || crypto.randomUUID();
+            console.log(
+              '[FormplayerModal] Form returned without DB save (returnOnly mode):',
+              resultObservationId,
+            );
           }
 
           // Mark form as successfully submitted
@@ -582,7 +603,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           throw error;
         }
       },
-      [currentObservationId, currentOperationId, onClose, showConfirm],
+      [currentObservationId, currentOperationId, onClose, showConfirm, returnOnly],
     );
 
     // Register/unregister modal with message handlers and reset form state

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -500,7 +500,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         try {
           // Save the observation (optional - skip if returnOnly flag is set)
           let resultObservationId: string;
-          
+
           if (!returnOnly) {
             // Normal mode: save to database
             const localRepo = databaseService.getLocalRepo();
@@ -602,7 +602,13 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           throw error;
         }
       },
-      [currentObservationId, currentOperationId, onClose, showConfirm, returnOnly],
+      [
+        currentObservationId,
+        currentOperationId,
+        onClose,
+        showConfirm,
+        returnOnly,
+      ],
     );
 
     // Register/unregister modal with message handlers and reset form state

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -25,6 +25,7 @@ import {
   resolveFormOperation,
   resolveFormOperationByType,
   setActiveFormplayerModal,
+  clearActiveFormplayerModalIfMatches,
 } from '../webview/FormulusMessageHandlers';
 import {
   FormCompletionResult,
@@ -605,19 +606,19 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       [currentObservationId, currentOperationId, onClose, showConfirm],
     );
 
-    // Register/unregister modal with message handlers and reset form state
+    // Register/unregister modal with message handlers and reset form state.
+    // Stacked modals (e.g. linked-table child): parent stays visible but inactive — it must NOT
+    // clear the global ref, or the child's submit would miss the active modal and fail or persist wrongly.
     useEffect(() => {
       if (visible && isActive) {
-        // Register this modal as the active one for handling submissions
         setActiveFormplayerModal({ handleSubmission });
-      } else {
-        // Inactive/hidden modals must not handle submissions.
-        setActiveFormplayerModal(null);
+        return () => {
+          clearActiveFormplayerModalIfMatches(handleSubmission);
+        };
       }
 
       if (!visible) {
-        // Reset form state only when the modal actually closes.
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           setCurrentFormType(null);
           setCurrentFormDisplayName(null);
           setCurrentObservationId(null);
@@ -627,7 +628,10 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           setWebViewReady(false); // Reset WebView ready state
           returnOnlyRef.current = false;
         }, 300); // Small delay to ensure modal is fully closed
+        return () => clearTimeout(timeoutId);
       }
+
+      return undefined;
     }, [visible, isActive, handleSubmission]);
 
     useEffect(() => {

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -48,6 +48,7 @@ import { geolocationService } from '../services/GeolocationService';
 
 interface FormplayerModalProps {
   visible: boolean;
+  isActive?: boolean;
   onClose: () => void;
 }
 
@@ -67,7 +68,7 @@ export interface FormplayerModalHandle {
 }
 
 const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
-  ({ visible, onClose }, ref) => {
+  ({ visible, isActive = true, onClose }, ref) => {
     const webViewRef = useRef<CustomAppWebViewHandle>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const { showConfirm } = useConfirmModal();
@@ -191,6 +192,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
 
     // Track WebView ready state
     const [webViewReady, setWebViewReady] = useState(false);
+    const previousIsActiveRef = useRef(isActive);
 
     // Handle WebView load complete
     const handleWebViewLoad = () => {
@@ -585,14 +587,16 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
 
     // Register/unregister modal with message handlers and reset form state
     useEffect(() => {
-      if (visible) {
+      if (visible && isActive) {
         // Register this modal as the active one for handling submissions
         setActiveFormplayerModal({ handleSubmission });
       } else {
-        // Unregister when modal is closed
+        // Inactive/hidden modals must not handle submissions.
         setActiveFormplayerModal(null);
+      }
 
-        // Reset form state when modal is closed
+      if (!visible) {
+        // Reset form state only when the modal actually closes.
         setTimeout(() => {
           setCurrentFormType(null);
           setCurrentFormDisplayName(null);
@@ -603,7 +607,20 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           setWebViewReady(false); // Reset WebView ready state
         }, 300); // Small delay to ensure modal is fully closed
       }
-    }, [visible, handleSubmission]);
+    }, [visible, isActive, handleSubmission]);
+
+    useEffect(() => {
+      if (
+        visible &&
+        isActive &&
+        webViewReady &&
+        currentFormType &&
+        previousIsActiveRef.current === false
+      ) {
+        webViewRef.current?.notifyReceiveFocus();
+      }
+      previousIsActiveRef.current = isActive;
+    }, [visible, isActive, webViewReady, currentFormType]);
 
     useImperativeHandle(ref, () => ({ initializeForm, handleSubmission }));
 

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -530,8 +530,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           } else {
             // returnOnly mode: just generate ID, don't save to database
             // This is used for embedded child forms in linked-table scenarios
-            resultObservationId =
-              effectiveObservationId || crypto.randomUUID();
+            resultObservationId = '';
             console.log(
               '[FormplayerModal] Form returned without DB save (returnOnly mode):',
               resultObservationId,

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -96,9 +96,9 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
     // Track if form has been successfully submitted to avoid double resolution
     const [formSubmitted, setFormSubmitted] = useState(false);
 
-    // Track if this form should return JSON only without saving to database
-    // Used for child forms embedded in linked-table scenarios
-    const [returnOnly, setReturnOnly] = useState(false);
+    // Child / linked-table forms: return JSON only, do not persist as observations.
+    // Ref updates synchronously in initializeForm so submit cannot run before flag is set.
+    const returnOnlyRef = useRef(false);
 
     // Author-configurable display name shown in the native header bar
     const [currentFormDisplayName, setCurrentFormDisplayName] = useState<
@@ -222,8 +222,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         );
       }
 
-      // Set returnOnly flag for this form session
-      setReturnOnly(returnOnlyMode);
+      returnOnlyRef.current = returnOnlyMode;
 
       // GPS session: fresh fix + light watch while the user fills the form
       geolocationService.beginObservationSession();
@@ -457,6 +456,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         uiSchema: formType.uiSchema ?? {},
         extensions,
         customQuestionTypes,
+        returnOnly: returnOnlyMode,
       } as FormInitData;
 
       if (!webViewRef.current) {
@@ -501,7 +501,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           // Save the observation (optional - skip if returnOnly flag is set)
           let resultObservationId: string;
 
-          if (!returnOnly) {
+          if (!returnOnlyRef.current) {
             // Normal mode: save to database
             const localRepo = databaseService.getLocalRepo();
             if (!localRepo) {
@@ -607,7 +607,6 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         currentOperationId,
         onClose,
         showConfirm,
-        returnOnly,
       ],
     );
 
@@ -631,6 +630,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           setIsClosing(false); // Reset closing state when modal is fully closed
           setFormSubmitted(false); // Reset submission flag
           setWebViewReady(false); // Reset WebView ready state
+          returnOnlyRef.current = false;
         }, 300); // Small delay to ensure modal is fully closed
       }
     }, [visible, isActive, handleSubmission]);

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -602,12 +602,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           throw error;
         }
       },
-      [
-        currentObservationId,
-        currentOperationId,
-        onClose,
-        showConfirm,
-      ],
+      [currentObservationId, currentOperationId, onClose, showConfirm],
     );
 
     // Register/unregister modal with message handlers and reset form state

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -56,6 +56,7 @@ export interface FormInitData {
   formSchema?: unknown;
   uiSchema?: unknown;
   operationId?: string;
+  returnOnly?: boolean;  // For embedded child forms: return JSON without saving to DB
   extensions?: ExtensionMetadata;
   customQuestionTypes?: {
     custom_types: Record<string, { source: string }>;

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -285,6 +285,7 @@ export interface FormulusInterface {
     formType: string,
     params: Record<string, unknown>,
     savedData: Record<string, unknown>,
+    options?: { returnOnly?: boolean },
   ): Promise<FormCompletionResult>;
 
   /**

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -56,7 +56,7 @@ export interface FormInitData {
   formSchema?: unknown;
   uiSchema?: unknown;
   operationId?: string;
-  returnOnly?: boolean;  // For embedded child forms: return JSON without saving to DB
+  returnOnly?: boolean; // For embedded child forms: return JSON without saving to DB
   extensions?: ExtensionMetadata;
   customQuestionTypes?: {
     custom_types: Record<string, { source: string }>;

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -116,6 +116,7 @@ const startFormplayerOperation = (
   params: Record<string, unknown> = {},
   savedData: Record<string, unknown> = {},
   observationId: string | null = null,
+  returnOnly: boolean = false,
 ): Promise<FormCompletionResult> => {
   const operationId = `${formType}_${Date.now()}_${Math.random()
     .toString(36)
@@ -135,6 +136,7 @@ const startFormplayerOperation = (
       savedData,
       observationId,
       operationId,
+      returnOnly,
     });
 
     setTimeout(
@@ -1168,12 +1170,13 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
       const service = await FormService.getInstance();
       return await service.getObservationsByQuery(options);
     },
-    onOpenFormplayer: async (data: FormInitData) => {
+    onOpenFormplayer: async (data: FormInitData & { options?: { returnOnly?: boolean } }) => {
       return startFormplayerOperation(
         data.formType,
         data.params,
         data.savedData,
         data.observationId ?? null,
+        data.options?.returnOnly || data.returnOnly || false,
       );
     },
     onFormplayerInitialized: (_data: {

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -1170,7 +1170,9 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
       const service = await FormService.getInstance();
       return await service.getObservationsByQuery(options);
     },
-    onOpenFormplayer: async (data: FormInitData & { options?: { returnOnly?: boolean } }) => {
+    onOpenFormplayer: async (
+      data: FormInitData & { options?: { returnOnly?: boolean } },
+    ) => {
       return startFormplayerOperation(
         data.formType,
         data.params,

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -42,14 +42,12 @@ type AudioSet = {
   AudioChannels: number;
 };
 import { FormService } from '../services/FormService';
-import { Observation, ObservationData } from '../database/models/Observation';
 import {
   getAttachmentsDirectoryFileUrl,
   getCustomAppDirectoryFileUrl,
   getFormSpecsDirectoryFileUrl,
   resolveAttachmentFileUrl,
 } from '../services/WebViewFileUrlResolver';
-import { commitDraftAttachmentsAfterSave } from '../services/attachmentStorage';
 
 export type HandlerArgs = {
   data: unknown;
@@ -161,24 +159,32 @@ export const openFormplayerFromNative = (
   return startFormplayerOperation(formType, params, savedData, observationId);
 };
 
-let activeFormplayerModalRef: {
+export type ActiveFormplayerModalHandle = {
   handleSubmission: (data: {
     formType: string;
     finalData: Record<string, unknown>;
     observationId?: string | null;
   }) => Promise<string>;
-} | null = null;
+};
+
+let activeFormplayerModalRef: ActiveFormplayerModalHandle | null = null;
 
 export const setActiveFormplayerModal = (
-  modalRef: {
-    handleSubmission: (data: {
-      formType: string;
-      finalData: Record<string, unknown>;
-      observationId?: string | null;
-    }) => Promise<string>;
-  } | null,
+  modalRef: ActiveFormplayerModalHandle | null,
 ) => {
   activeFormplayerModalRef = modalRef;
+};
+
+/** Clears the global active modal only if it still points to this submission handler (stacked modals). */
+export const clearActiveFormplayerModalIfMatches = (
+  handleSubmission: ActiveFormplayerModalHandle['handleSubmission'],
+) => {
+  if (
+    activeFormplayerModalRef &&
+    activeFormplayerModalRef.handleSubmission === handleSubmission
+  ) {
+    activeFormplayerModalRef = null;
+  }
 };
 
 export const resolveFormOperation = (
@@ -226,46 +232,6 @@ export const rejectFormOperation = (operationId: string, error: Error) => {
   }
 };
 
-const saveFormData = async (
-  formType: string,
-  data: ObservationData,
-  observationId: string | null,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  isPartial = true,
-) => {
-  try {
-    const observation: Partial<Observation> = {
-      formType,
-      data,
-    };
-
-    if (observationId !== null) {
-      observation.observationId = observationId;
-      observation.updatedAt = new Date();
-    } else {
-      observation.createdAt = new Date();
-    }
-
-    const formService = await FormService.getInstance();
-    const id =
-      observationId !== null
-        ? await formService.updateObservation(observationId, data)
-        : await formService.addNewObservation(formType, data);
-
-    if (id != null) {
-      const fixedData = await commitDraftAttachmentsAfterSave(
-        data as Record<string, unknown>,
-      );
-      await formService.updateObservation(id, fixedData);
-    }
-
-    return id;
-  } catch (error) {
-    console.error('Error saving form data:', error);
-    return null;
-  }
-};
-
 export function createFormulusMessageHandlers(): FormulusMessageHandlers {
   return {
     onInitForm: (payload: unknown) => {
@@ -297,13 +263,15 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
           formType,
           finalData,
         });
-      } else {
-        // Fallback to the old method if no modal is active
-        console.warn(
-          'FormulusMessageHandlers: No active FormplayerModal, using fallback saveFormData',
-        );
-        return await saveFormData(formType, finalData, null, false);
       }
+
+      console.error(
+        'FormulusMessageHandlers: No active FormplayerModal for submitObservation; refusing to persist.',
+        { formType },
+      );
+      throw new Error(
+        'Form submission failed: no active form session. Close and reopen the form.',
+      );
     },
     onUpdateObservation: async (data: {
       observationId: string;
@@ -322,11 +290,13 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
           observationId: data.observationId,
         });
       }
-      return await saveFormData(
-        data.formType,
-        data.finalData,
-        data.observationId,
-        false,
+
+      console.error(
+        'FormulusMessageHandlers: No active FormplayerModal for updateObservation; refusing to persist.',
+        { observationId: data.observationId, formType: data.formType },
+      );
+      throw new Error(
+        'Form update failed: no active form session. Close and reopen the form.',
       );
     },
     onRequestCamera: async (fieldId: string): Promise<unknown> => {

--- a/formulus/src/webview/FormulusWebViewHandler.ts
+++ b/formulus/src/webview/FormulusWebViewHandler.ts
@@ -264,7 +264,30 @@ export class FormulusWebViewMessageManager {
     }
   }
 
+  public notifyReceiveFocus(): void {
+    if (!this.webViewRef.current || !this.isWebViewReady) {
+      return;
+    }
+
+    this.webViewRef.current.injectJavaScript(`
+      (function() {
+        try {
+          if (typeof window.onReceiveFocus === 'function') {
+            Promise.resolve(window.onReceiveFocus()).catch(function(error) {
+              console.error('Error in window.onReceiveFocus:', error);
+            });
+          }
+        } catch (error) {
+          console.error('Error invoking window.onReceiveFocus:', error);
+        }
+      })();
+      true;
+    `);
+  }
+
   public handleReceiveFocus(): void {
+    this.notifyReceiveFocus();
+
     // Optionally call native-side handler if it exists for onReceiveFocus
     if (this.nativeSideHandlers.onReceiveFocus) {
       try {


### PR DESCRIPTION
## Description

<h3>Summary</h3>
<p>Linked-table question types in AnthroCollect need to open a child form on top of a parent form, wait for the child to be completed or dismissed, and then return to the parent form <strong>exactly where it was</strong> — same page, same field state, same scroll position. This matches the behavior that existed in the original OMO repo running on top of ODK-X.</p>
<p>This PR fixes the root cause: the native Formulus app was destroying the parent form modal before opening the child form, making state restoration impossible.</p>

<img width="1456" height="778" alt="image" src="https://github.com/user-attachments/assets/4e0a83b3-6aca-4911-a7e1-fda12c80ca7c" />

<hr>
<h3>Problem</h3>
<p>The original <code>App.tsx</code> maintained a <strong>single formplayer modal instance</strong>. When <code>openFormplayer</code> was called while a modal was already visible, it explicitly closed the existing modal first:</p>
<pre><code class="language-ts">// Old code — parent is torn down before child opens
if (formplayerVisibleRef.current) {
  setFormplayerVisible(false);
  await new Promise&lt;void&gt;(resolve =&gt; setTimeout(() =&gt; resolve(), 300));
}
</code></pre>
<p>This meant:</p>
<ul>
<li>The parent form's React state was unmounted and lost</li>
<li>The parent's current page position was lost</li>
<li>The parent's WebView was destroyed and would have to reinitialise from scratch</li>
<li>Returning to the parent after the child completed required the parent to reload entirely</li>
</ul>
<hr>
<h3>Solution</h3>
<p>Replace the single-modal design with a <strong>modal stack</strong>. Each <code>openFormplayer</code> call pushes a new entry onto the stack. The parent modal stays mounted underneath the child modal. When the child closes, the parent becomes the top of the stack again and receives a focus notification so the form JS layer can react.</p>
<h4>Key concepts</h4>

Concept | Detail
-- | --
formplayerStack | Array of FormplayerStackEntry objects, one per open form level
isActive prop | Only the top-of-stack modal is isActive=true; all others are false
Submission guard | Submission handler only registers when visible && isActive - inactive parent modals don't compete
State preservation | Form state reset only fires when visible goes false, not when isActive changes
Focus handoff | When isActive transitions false → true on a ready WebView, onReceiveFocus() is injected into the WebView JS context
Retry initialiser | initializeStackEntry polls for the modal ref up to 20 times × 100ms to handle slow mounts before calling initializeForm