### PR TITLE
feat(formulus): Making Formulus UI a Banger

### DIFF
--- a/formulus/src/components/common/ObservationCard.tsx
+++ b/formulus/src/components/common/ObservationCard.tsx
@@ -66,7 +66,7 @@ const ObservationCard: React.FC<ObservationCardProps> = ({
             size={24}
             color={
               isSynced
-                ? (themeColors.primary as string)
+                ? (colors.brand.primary['500'] as string)
                 : colors.semantic.warning[500]
             }
           />

--- a/formulus/src/screens/ObservationDetailScreen.tsx
+++ b/formulus/src/screens/ObservationDetailScreen.tsx
@@ -340,7 +340,7 @@ const ObservationDetailScreen: React.FC<ObservationDetailScreenProps> = ({
                   size={16}
                   color={
                     isSynced
-                      ? (themeColors.primary as string)
+                      ? (colors.brand.primary['500'] as string)
                       : (colors.semantic.warning[500] as unknown as string)
                   }
                 />

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -292,6 +292,8 @@ const SyncScreen = () => {
   };
 
   const observationStatus = getObservationStatusText();
+  /** Check icon on idle success uses ODE brand green; status text still follows app theme primary. */
+  const odeStatusIconGreen = colors.brand.primary['500'] as string;
   const observationStatusColor = isObservationSyncActive
     ? themeColors.primary
     : syncState.error
@@ -299,6 +301,13 @@ const SyncScreen = () => {
       : pendingObservations > 0 || pendingUploads.count > 0
         ? colors.semantic.warning[500]
         : (themeColors.primary as string);
+  const observationStatusIconColor = isObservationSyncActive
+    ? themeColors.primary
+    : syncState.error
+      ? colors.semantic.error[500]
+      : pendingObservations > 0 || pendingUploads.count > 0
+        ? colors.semantic.warning[500]
+        : odeStatusIconGreen;
 
   useEffect(() => {
     const unsubscribeStatus = syncService.subscribeToStatusUpdates(() => {});
@@ -555,7 +564,7 @@ const SyncScreen = () => {
                           : 'check-circle'
                   }
                   size={20}
-                  color={observationStatusColor as string}
+                  color={observationStatusIconColor as string}
                 />
                 <Text
                   style={[

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -562,7 +562,7 @@ const SyncScreen = () => {
                     styles.statusCardTitle,
                     { color: themeColors.onSurface as string },
                   ]}>
-                  Observation status
+                  Status
                 </Text>
               </View>
               <Text
@@ -605,7 +605,7 @@ const SyncScreen = () => {
                     styles.statusCardTitle,
                     { color: themeColors.onSurface as string },
                   ]}>
-                  Last observation sync
+                  Last Sync
                 </Text>
               </View>
               <Text


### PR DESCRIPTION
## Summary

### Sync Status card: 
- Changed Observation card titles "**OBSERVATION STATUS**" to simply "**STATUS**" and "**LAST OBSERVATION SYNC**" to simply "**LAST SYNC**" .
- Used fixed ODE brand green (`colors.brand.primary['500']`) for the success check icon.

<img width="484" height="1080" alt="image" src="https://github.com/user-attachments/assets/f0dfb66f-c584-4ab2-9683-38505b0f7bd2" />

### Observations list and observation detail status: 
- Same fixed green for synced check icons.
<img width="484" height="1080" alt="image" src="https://github.com/user-attachments/assets/0672a437-a4df-4a88-b96f-ad4fdce5366e" />
