### PR TITLE
fix(portal): avoid double v in server version on login

### DIFF
--- a/synkronus-portal/src/components/Login.tsx
+++ b/synkronus-portal/src/components/Login.tsx
@@ -121,7 +121,9 @@ export function Login() {
 
         {serverVersion && (
           <div className="server-version">
-            <span className="version-text">Server v{serverVersion}</span>
+            <span className="version-text">
+              Server v{serverVersion.replace(/^v+/i, '')}
+            </span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Fixes the login page server version label so it shows **`Server v…`** instead of **`Server vv…`** when the API already returns a leading `v`.

## Screenshots

**Before**

![Before](https://github.com/user-attachments/assets/fc2b628b-3f12-4200-aa93-62c77bf7376c)

**After**

![After](https://github.com/user-attachments/assets/c123a0ee-ed50-4f21-a393-9e82c4c625be)