### PR TITLE
refactor: rename returnOnly to subObservationMode for clarity in form handling

### DIFF
--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -91,6 +91,12 @@ import { customValidatorRegistry } from './services/CustomValidatorRegistry';
 import { executeAllCustomValidators } from './services/CustomValidatorExecutor';
 import { newDraftSessionKey } from './utils/draftSessionKey';
 
+/** Embedded sub-observation session (also accepts legacy `returnOnly` from older hosts). */
+function isSubObservationSession(init: FormInitData): boolean {
+  const i = init as FormInitData & { returnOnly?: boolean };
+  return Boolean(i.subObservationMode || i.returnOnly);
+}
+
 // Mock and DevTestbed are loaded only in development via dynamic import (see index.tsx).
 // This keeps ~2000+ lines of mock code out of production bundles.
 function isMockActive(): boolean {
@@ -329,10 +335,11 @@ function App() {
       newObservationDraftSessionKey?: string | null,
     ) => {
       try {
-        if (initData.returnOnly) {
-          // Embedded child form: data lives only in memory until returned to parent; no local drafts.
-          setDraftSessionKey(null);
-        } else if (initData.observationId != null) {
+        if (
+          isSubObservationSession(initData) ||
+          initData.observationId != null
+        ) {
+          // Sub-observation or editing an existing observation: no new-observation draft session key.
           setDraftSessionKey(null);
         } else if (newObservationDraftSessionKey !== undefined) {
           setDraftSessionKey(newObservationDraftSessionKey);
@@ -593,7 +600,7 @@ function App() {
         // Check if this is a new form (no savedData) and if drafts exist
         const hasExistingSavedData =
           savedData && Object.keys(savedData).length > 0;
-        if (!initData.returnOnly && !hasExistingSavedData) {
+        if (!isSubObservationSession(initData) && !hasExistingSavedData) {
           const availableDrafts = draftService.getDraftsForForm(
             receivedFormType,
             (formSchema as any)?.version,
@@ -951,8 +958,8 @@ function App() {
     ({ data: newData }: { data: FormData }) => {
       setData(newData);
 
-      // Save draft data whenever form data changes (skip embedded return-only child forms)
-      if (formInitData && !formInitData.returnOnly) {
+      // Save draft data whenever form data changes (skip embedded sub-observation sessions)
+      if (formInitData && !isSubObservationSession(formInitData)) {
         draftService.saveDraft(
           formInitData.formType,
           newData,

--- a/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
+++ b/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
@@ -56,7 +56,8 @@ export interface FormInitData {
   formSchema?: unknown;
   uiSchema?: unknown;
   operationId?: string;
-  returnOnly?: boolean; // For embedded child forms: return JSON without saving to DB
+  /** Sub-observation session: embedded child form returns JSON to parent; do not persist as a top-level observation. */
+  subObservationMode?: boolean;
   extensions?: ExtensionMetadata;
   customQuestionTypes?: {
     custom_types: Record<string, { source: string }>;
@@ -285,7 +286,7 @@ export interface FormulusInterface {
     formType: string,
     params: Record<string, unknown>,
     savedData: Record<string, unknown>,
-    options?: { returnOnly?: boolean },
+    options?: { subObservationMode?: boolean },
   ): Promise<FormCompletionResult>;
 
   /**

--- a/formulus/App.tsx
+++ b/formulus/App.tsx
@@ -66,7 +66,7 @@ function AppInner(): React.JSX.Element {
     observationId: string | null;
     savedData: Record<string, unknown> | null;
     operationId: string | null;
-    returnOnly?: boolean; // For child forms opened from linkedtable
+    subObservationMode?: boolean; // Embedded sub-observation (e.g. sub-observation custom type)
   };
 
   const [formplayerStack, setFormplayerStack] = useState<
@@ -97,7 +97,7 @@ function AppInner(): React.JSX.Element {
             entry.observationId,
             entry.savedData,
             entry.operationId,
-            entry.returnOnly, // ← Pass returnOnly flag
+            entry.subObservationMode,
           );
         }, 200);
       };
@@ -146,8 +146,11 @@ function AppInner(): React.JSX.Element {
         params,
         savedData,
         operationId,
-        returnOnly,
+        subObservationMode: subObservationModeField,
       } = config;
+      const legacy = config as FormInitData & { returnOnly?: boolean };
+      const subObservationMode =
+        Boolean(subObservationModeField) || Boolean(legacy.returnOnly);
 
       try {
         const formService = await FormService.getInstance();
@@ -180,7 +183,7 @@ function AppInner(): React.JSX.Element {
           observationId: observationId || null,
           savedData: savedData || null,
           operationId: operationId || null,
-          returnOnly: returnOnly || false, // Include returnOnly flag
+          subObservationMode,
         };
 
         setFormplayerStack(current => [...current, entry]);

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -60,7 +60,7 @@ export interface FormplayerModalHandle {
     observationId: string | null,
     existingObservationData: Record<string, unknown> | null,
     operationId: string | null,
-    returnOnly?: boolean,
+    subObservationMode?: boolean,
   ) => void;
   handleSubmission: (data: {
     formType: string;
@@ -97,9 +97,9 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
     // Track if form has been successfully submitted to avoid double resolution
     const [formSubmitted, setFormSubmitted] = useState(false);
 
-    // Child / linked-table forms: return JSON only, do not persist as observations.
+    // Sub-observation (embedded child) forms: return JSON only; do not persist as top-level observations.
     // Ref updates synchronously in initializeForm so submit cannot run before flag is set.
-    const returnOnlyRef = useRef(false);
+    const subObservationModeRef = useRef(false);
 
     // Author-configurable display name shown in the native header bar
     const [currentFormDisplayName, setCurrentFormDisplayName] = useState<
@@ -214,7 +214,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       observationId: string | null,
       existingObservationData: Record<string, unknown> | null,
       operationId: string | null,
-      returnOnlyMode: boolean = false,
+      subObservationMode: boolean = false,
     ) => {
       // Check if WebView is ready, if not log a warning (retry logic will handle it)
       if (!webViewReady) {
@@ -223,7 +223,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         );
       }
 
-      returnOnlyRef.current = returnOnlyMode;
+      subObservationModeRef.current = subObservationMode;
 
       // GPS session: fresh fix + light watch while the user fills the form
       geolocationService.beginObservationSession();
@@ -457,7 +457,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         uiSchema: formType.uiSchema ?? {},
         extensions,
         customQuestionTypes,
-        returnOnly: returnOnlyMode,
+        subObservationMode,
       } as FormInitData;
 
       if (!webViewRef.current) {
@@ -499,10 +499,10 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         setIsSubmitting(true);
 
         try {
-          // Save the observation (optional - skip if returnOnly flag is set)
+          // Save the observation (optional - skip in sub-observation mode)
           let resultObservationId: string;
 
-          if (!returnOnlyRef.current) {
+          if (!subObservationModeRef.current) {
             // Normal mode: save to database
             const localRepo = databaseService.getLocalRepo();
             if (!localRepo) {
@@ -529,13 +529,8 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
               resultObservationId = newId;
             }
           } else {
-            // returnOnly mode: just generate ID, don't save to database
-            // This is used for embedded child forms in linked-table scenarios
+            // Sub-observation: return JSON to parent only; do not persist here.
             resultObservationId = '';
-            console.log(
-              '[FormplayerModal] Form returned without DB save (returnOnly mode):',
-              resultObservationId,
-            );
           }
 
           // Mark form as successfully submitted
@@ -607,7 +602,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
     );
 
     // Register/unregister modal with message handlers and reset form state.
-    // Stacked modals (e.g. linked-table child): parent stays visible but inactive — it must NOT
+    // Stacked modals (e.g. sub-observation child): parent stays visible but inactive — it must NOT
     // clear the global ref, or the child's submit would miss the active modal and fail or persist wrongly.
     useEffect(() => {
       if (visible && isActive) {
@@ -626,7 +621,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
           setIsClosing(false); // Reset closing state when modal is fully closed
           setFormSubmitted(false); // Reset submission flag
           setWebViewReady(false); // Reset WebView ready state
-          returnOnlyRef.current = false;
+          subObservationModeRef.current = false;
         }, 300); // Small delay to ensure modal is fully closed
         return () => clearTimeout(timeoutId);
       }

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -56,7 +56,8 @@ export interface FormInitData {
   formSchema?: unknown;
   uiSchema?: unknown;
   operationId?: string;
-  returnOnly?: boolean; // For embedded child forms: return JSON without saving to DB
+  /** Sub-observation session: embedded child form returns JSON to parent; do not persist as a top-level observation. */
+  subObservationMode?: boolean;
   extensions?: ExtensionMetadata;
   customQuestionTypes?: {
     custom_types: Record<string, { source: string }>;
@@ -285,7 +286,7 @@ export interface FormulusInterface {
     formType: string,
     params: Record<string, unknown>,
     savedData: Record<string, unknown>,
-    options?: { returnOnly?: boolean },
+    options?: { subObservationMode?: boolean },
   ): Promise<FormCompletionResult>;
 
   /**

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -115,7 +115,7 @@ const startFormplayerOperation = (
   params: Record<string, unknown> = {},
   savedData: Record<string, unknown> = {},
   observationId: string | null = null,
-  returnOnly: boolean = false,
+  subObservationMode: boolean = false,
 ): Promise<FormCompletionResult> => {
   const operationId = `${formType}_${Date.now()}_${Math.random()
     .toString(36)
@@ -135,7 +135,7 @@ const startFormplayerOperation = (
       savedData,
       observationId,
       operationId,
-      returnOnly,
+      subObservationMode,
     });
 
     setTimeout(
@@ -1139,14 +1139,24 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
       return await service.getObservationsByQuery(options);
     },
     onOpenFormplayer: async (
-      data: FormInitData & { options?: { returnOnly?: boolean } },
+      data: FormInitData & {
+        options?: { subObservationMode?: boolean; returnOnly?: boolean };
+        /** @deprecated Legacy key; prefer subObservationMode */
+        returnOnly?: boolean;
+      },
     ) => {
+      const subObservationMode = Boolean(
+        data.options?.subObservationMode ||
+        data.subObservationMode ||
+        data.options?.returnOnly ||
+        data.returnOnly,
+      );
       return startFormplayerOperation(
         data.formType,
         data.params,
         data.savedData,
         data.observationId ?? null,
-        data.options?.returnOnly || data.returnOnly || false,
+        subObservationMode,
       );
     },
     onFormplayerInitialized: (_data: {


### PR DESCRIPTION
## Description

Follow-up to the sub-observation / embedded child-form work: rename the init and `openFormplayer` flag from **`returnOnly`** to **`subObservationMode`**, tidy formplayer draft handling, and drop noisy logging on the no–persist path.

### What changed

| Area | Change |
|------|--------|
| **Bridge contract** | `FormInitData` and `openFormplayer` options use `subObservationMode?: boolean` (see `formulus/src/webview/FormulusInterfaceDefinition.ts`). |
| **Native (Formulus)** | `App.tsx`, `FormplayerModal.tsx`, and `FormulusMessageHandlers.ts` pass/read the new field; `formInitData` uses `subObservationMode`. |
| **Compatibility** | Older bundles that still send `returnOnly` (top-level or under `options`) are still honored for one transition period. |
| **Formplayer** | Types synced from Formulus; `App.tsx` uses `subObservationMode` and merges the draft-session reset when `subObservationMode \|\| observationId != null` (with the same legacy read where applicable). |
| **Logging** | Removed the success-path `console.log` in `FormplayerModal` for the path that does not save to the DB. |

### Files touched (high level)

| Package | Paths |
|---------|--------|
| **formulus** | `App.tsx`, `src/components/FormplayerModal.tsx`, `src/webview/FormulusInterfaceDefinition.ts`, `src/webview/FormulusMessageHandlers.ts` |
| **formulus-formplayer** | `src/App.tsx`, `src/types/FormulusInterfaceDefinition.ts` (via `npm run sync-interface`) |

### How to verify
- Open a flow that uses embedded child / sub-observation mode and confirm the child session still returns JSON to the parent and does not create a stray top-level observation.
- Smoke-test a bundle that still sends `returnOnly` (if you have one) to confirm it still works.

### Notes
- Run **`npm run sync-interface`** (and your usual **`npm run build:rn`** in `formulus-formplayer` if you ship RN-bundled assets) before merging or releasing.
- If `npm run generate` for the WebView injection script fails in your environment, it is separate from this rename; native handling of `options` is what matters for the new key.