### PR TITLE
feat(formplayer): capture GPS in-form via requestLocation bridge

### DIFF
--- a/desktop/.prettierignore
+++ b/desktop/.prettierignore
@@ -1,6 +1,8 @@
 node_modules
 dist
 .vscode
+# Copied from formulus/assets/webview/FormulusInjectionScript.js (npm run generate); not Prettier-stable.
+public/formulus-injection.js
 package-lock.json
 src/generated
 src-tauri/target

--- a/desktop/public/formulus-injection.js
+++ b/desktop/public/formulus-injection.js
@@ -1,51 +1,38 @@
 // Auto-generated from FormulusInterfaceDefinition.ts
 // Do not edit directly - this file will be overwritten
-// Last generated: 2026-04-17T14:59:47.429Z
+// Last generated: 2026-05-02T14:24:11.519Z
 
-(function () {
+(function() {
   // Enhanced API availability detection and recovery
   function getFormulus() {
     // Check multiple locations where the API might exist
-    return (
-      globalThis.formulus ||
-      (typeof window !== 'undefined' ? window.formulus : undefined)
-    );
+    return globalThis.formulus || (typeof window !== 'undefined' ? window.formulus : undefined);
   }
 
   function isFormulusAvailable() {
     const api = getFormulus();
-    return (
-      api && typeof api === 'object' && typeof api.getVersion === 'function'
-    );
+    return api && typeof api === 'object' && typeof api.getVersion === 'function';
   }
 
   // Idempotent guard to avoid double-initialization when scripts are reinjected
-  if (globalThis.__formulusBridgeInitialized) {
+  if ((globalThis).__formulusBridgeInitialized) {
     if (isFormulusAvailable()) {
-      console.debug(
-        'Formulus bridge already initialized and functional. Skipping duplicate injection.',
-      );
+      console.debug('Formulus bridge already initialized and functional. Skipping duplicate injection.');
       return;
     } else {
-      console.warn(
-        'Formulus bridge flag is set but API is not functional. Proceeding with re-injection...',
-      );
+      console.warn('Formulus bridge flag is set but API is not functional. Proceeding with re-injection...');
     }
   }
 
   // If API already exists and is functional, skip injection
   if (isFormulusAvailable()) {
-    console.debug(
-      'Formulus interface already exists and is functional. Skipping injection.',
-    );
+    console.debug('Formulus interface already exists and is functional. Skipping injection.');
     return;
   }
 
   // If API exists but is not functional, log warning and proceed with re-injection
   if (getFormulus()) {
-    console.warn(
-      'Formulus interface exists but appears non-functional. Re-injecting...',
-    );
+    console.warn('Formulus interface exists but appears non-functional. Re-injecting...');
   }
 
   // Helper function to handle callbacks
@@ -61,7 +48,7 @@
 
   // Initialize callbacks
   const callbacks = {};
-
+  
   // Global function to handle responses from React Native
   function handleMessage(event) {
     try {
@@ -74,1542 +61,1201 @@
         // console.warn('Global handleMessage: Received message with unexpected data type:', typeof event.data, event.data);
         return; // Or handle error, but for now, just return to avoid breaking others.
       }
-
+      
       // Handle callbacks
-      if (
-        data.type === 'callback' &&
-        data.callbackId &&
-        callbacks[data.callbackId]
-      ) {
+      if (data.type === 'callback' && data.callbackId && callbacks[data.callbackId]) {
         handleCallback(callbacks[data.callbackId], data.data);
         delete callbacks[data.callbackId];
       }
-
+      
       // Handle specific callbacks
-
-      if (
-        data.type === 'onFormulusReady' &&
-        globalThis.formulusCallbacks?.onFormulusReady
-      ) {
+      
+      
+      if (data.type === 'onFormulusReady' && globalThis.formulusCallbacks?.onFormulusReady) {
         handleCallback(globalThis.formulusCallbacks.onFormulusReady);
       }
     } catch (e) {
-      console.error(
-        'Global handleMessage: Error processing message:',
-        e,
-        'Raw event.data:',
-        event.data,
-      );
+      console.error('Global handleMessage: Error processing message:', e, 'Raw event.data:', event.data);
     }
   }
-
+  
   // Set up message listener
   document.addEventListener('message', handleMessage);
   window.addEventListener('message', handleMessage);
 
   // Initialize the formulus interface
   globalThis.formulus = {
-    // getVersion:  => Promise<string>
-    getVersion: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getVersion callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getVersion callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getVersion_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getVersion:  => Promise<string>
+        getVersion: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getVersion callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getVersion callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getVersion_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getVersion' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getVersion' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getVersion',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // getAvailableForms:  => Promise<FormInfo[]>
-    getAvailableForms: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getAvailableForms callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getAvailableForms callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getAvailableForms_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getAvailableForms:  => Promise<FormInfo[]>
+        getAvailableForms: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getAvailableForms callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getAvailableForms callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getAvailableForms_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getAvailableForms' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getAvailableForms' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getAvailableForms',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // openFormplayer: formType: string, params: Record<string, unknown>, savedData: Record<string, unknown>, options: { subObservationMode?: boolean; } => Promise<FormCompletionResult>
-    openFormplayer: function (formType, params, savedData, options) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('openFormplayer callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'openFormplayer callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'openFormplayer_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // openFormplayer: formType: string, params: Record<string, unknown>, savedData: Record<string, unknown>, options: { subObservationMode?: boolean; } => Promise<FormCompletionResult>
+        openFormplayer: function(formType, params, savedData, options) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('openFormplayer callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('openFormplayer callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'openFormplayer_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'openFormplayer' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'openFormplayer' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'openFormplayer',
             messageId,
-            formType: formType,
+                        formType: formType,
             params: params,
             savedData: savedData,
-            options: options,
-          }),
-        );
-      });
-    },
+            options: options
+          }));
+          
+          });
+        },
 
-    // getObservations: formType: string, isDraft: boolean, includeDeleted: boolean => Promise<FormObservation[]>
-    getObservations: function (formType, isDraft, includeDeleted) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getObservations callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getObservations callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getObservations_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getObservations: formType: string, isDraft: boolean, includeDeleted: boolean => Promise<FormObservation[]>
+        getObservations: function(formType, isDraft, includeDeleted) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getObservations callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getObservations callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getObservations_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getObservations' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getObservations' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getObservations',
             messageId,
-            formType: formType,
+                        formType: formType,
             isDraft: isDraft,
-            includeDeleted: includeDeleted,
-          }),
-        );
-      });
-    },
+            includeDeleted: includeDeleted
+          }));
+          
+          });
+        },
 
-    // getObservationsByQuery: options: { formType: string; isDraft?: boolean; includeDeleted?: boolean; whereClause?: string; } => Promise<FormObservation[]>
-    getObservationsByQuery: function (options) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getObservationsByQuery callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getObservationsByQuery callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getObservationsByQuery_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getObservationsByQuery: options: { formType: string; isDraft?: boolean; includeDeleted?: boolean; whereClause?: string; } => Promise<FormObservation[]>
+        getObservationsByQuery: function(options) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getObservationsByQuery callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getObservationsByQuery callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getObservationsByQuery_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getObservationsByQuery' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getObservationsByQuery' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getObservationsByQuery',
             messageId,
-            options: options,
-          }),
-        );
-      });
-    },
+                        options: options
+          }));
+          
+          });
+        },
 
-    // submitObservation: formType: string, finalData: Record<string, unknown> => Promise<string>
-    submitObservation: function (formType, finalData) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('submitObservation callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'submitObservation callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'submitObservation_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // submitObservation: formType: string, finalData: Record<string, unknown> => Promise<string>
+        submitObservation: function(formType, finalData) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('submitObservation callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('submitObservation callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'submitObservation_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'submitObservation' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'submitObservation' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'submitObservation',
             messageId,
-            formType: formType,
-            finalData: finalData,
-          }),
-        );
-      });
-    },
+                        formType: formType,
+            finalData: finalData
+          }));
+          
+          });
+        },
 
-    // updateObservation: observationId: string, formType: string, finalData: Record<string, unknown> => Promise<string>
-    updateObservation: function (observationId, formType, finalData) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('updateObservation callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'updateObservation callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'updateObservation_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // updateObservation: observationId: string, formType: string, finalData: Record<string, unknown> => Promise<string>
+        updateObservation: function(observationId, formType, finalData) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('updateObservation callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('updateObservation callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'updateObservation_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'updateObservation' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'updateObservation' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'updateObservation',
             messageId,
-            observationId: observationId,
+                        observationId: observationId,
             formType: formType,
-            finalData: finalData,
-          }),
-        );
-      });
-    },
+            finalData: finalData
+          }));
+          
+          });
+        },
 
-    // requestCamera: fieldId: string => Promise<CameraResult>
-    requestCamera: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestCamera callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestCamera callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestCamera_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestCamera: fieldId: string => Promise<CameraResult>
+        requestCamera: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestCamera callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestCamera callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestCamera_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestCamera' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestCamera' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestCamera',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // requestLocation: fieldId: string => Promise<void>
-    requestLocation: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestLocation callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestLocation callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestLocation_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestLocation: fieldId: string => Promise<LocationResult>
+        requestLocation: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestLocation callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestLocation callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestLocation_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestLocation' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestLocation' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestLocation',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // requestFile: fieldId: string => Promise<FileResult>
-    requestFile: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestFile callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestFile callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestFile_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestFile: fieldId: string => Promise<FileResult>
+        requestFile: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestFile callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestFile callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestFile_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestFile' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestFile' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestFile',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // launchIntent: fieldId: string, intentSpec: Record<string, unknown> => Promise<void>
-    launchIntent: function (fieldId, intentSpec) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('launchIntent callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'launchIntent callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'launchIntent_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // launchIntent: fieldId: string, intentSpec: Record<string, unknown> => Promise<void>
+        launchIntent: function(fieldId, intentSpec) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('launchIntent callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('launchIntent callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'launchIntent_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'launchIntent' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'launchIntent' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'launchIntent',
             messageId,
-            fieldId: fieldId,
-            intentSpec: intentSpec,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId,
+            intentSpec: intentSpec
+          }));
+          
+          });
+        },
 
-    // callSubform: fieldId: string, formType: string, options: Record<string, unknown> => Promise<void>
-    callSubform: function (fieldId, formType, options) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('callSubform callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'callSubform callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'callSubform_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // callSubform: fieldId: string, formType: string, options: Record<string, unknown> => Promise<void>
+        callSubform: function(fieldId, formType, options) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('callSubform callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('callSubform callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'callSubform_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'callSubform' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'callSubform' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'callSubform',
             messageId,
-            fieldId: fieldId,
+                        fieldId: fieldId,
             formType: formType,
-            options: options,
-          }),
-        );
-      });
-    },
+            options: options
+          }));
+          
+          });
+        },
 
-    // requestAudio: fieldId: string => Promise<AudioResult>
-    requestAudio: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestAudio callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestAudio callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestAudio_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestAudio: fieldId: string => Promise<AudioResult>
+        requestAudio: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestAudio callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestAudio callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestAudio_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestAudio' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestAudio' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestAudio',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // requestQrcode: fieldId: string => Promise<QrcodeResult>
-    requestQrcode: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestQrcode callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestQrcode callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestQrcode_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestQrcode: fieldId: string => Promise<QrcodeResult>
+        requestQrcode: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestQrcode callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestQrcode callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestQrcode_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestQrcode' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestQrcode' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestQrcode',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // requestBiometric: fieldId: string => Promise<void>
-    requestBiometric: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestBiometric callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestBiometric callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestBiometric_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestBiometric: fieldId: string => Promise<void>
+        requestBiometric: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestBiometric callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestBiometric callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestBiometric_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestBiometric' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestBiometric' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestBiometric',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // requestConnectivityStatus:  => Promise<void>
-    requestConnectivityStatus: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestConnectivityStatus callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestConnectivityStatus callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestConnectivityStatus_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestConnectivityStatus:  => Promise<void>
+        requestConnectivityStatus: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestConnectivityStatus callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestConnectivityStatus callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestConnectivityStatus_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestConnectivityStatus' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestConnectivityStatus' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestConnectivityStatus',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // requestSyncStatus:  => Promise<void>
-    requestSyncStatus: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestSyncStatus callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestSyncStatus callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestSyncStatus_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestSyncStatus:  => Promise<void>
+        requestSyncStatus: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestSyncStatus callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestSyncStatus callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestSyncStatus_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestSyncStatus' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestSyncStatus' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestSyncStatus',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // runLocalModel: fieldId: string, modelId: string, input: Record<string, unknown> => Promise<void>
-    runLocalModel: function (fieldId, modelId, input) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('runLocalModel callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'runLocalModel callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'runLocalModel_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // runLocalModel: fieldId: string, modelId: string, input: Record<string, unknown> => Promise<void>
+        runLocalModel: function(fieldId, modelId, input) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('runLocalModel callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('runLocalModel callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'runLocalModel_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'runLocalModel' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'runLocalModel' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'runLocalModel',
             messageId,
-            fieldId: fieldId,
+                        fieldId: fieldId,
             modelId: modelId,
-            input: input,
-          }),
-        );
-      });
-    },
+            input: input
+          }));
+          
+          });
+        },
 
-    // getCurrentUser:  => Promise<{ username: string; displayName?: string; role?: "read-only" | "read-write" | "admin"; }>
-    getCurrentUser: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getCurrentUser callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getCurrentUser callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getCurrentUser_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getCurrentUser:  => Promise<{ username: string; displayName?: string; role?: "read-only" | "read-write" | "admin"; }>
+        getCurrentUser: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getCurrentUser callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getCurrentUser callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getCurrentUser_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getCurrentUser' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getCurrentUser' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getCurrentUser',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // getThemeMode:  => Promise<"light" | "dark" | "system">
-    getThemeMode: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getThemeMode callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getThemeMode callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getThemeMode_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getThemeMode:  => Promise<"light" | "dark" | "system">
+        getThemeMode: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getThemeMode callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getThemeMode callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getThemeMode_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getThemeMode' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getThemeMode' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getThemeMode',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // getAttachmentUri: fileName: string | AttachmentDisplayDescriptor => Promise<string>
-    getAttachmentUri: function (fileName) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getAttachmentUri callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getAttachmentUri callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getAttachmentUri_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getAttachmentUri: fileName: string | AttachmentDisplayDescriptor => Promise<string>
+        getAttachmentUri: function(fileName) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getAttachmentUri callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getAttachmentUri callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getAttachmentUri_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getAttachmentUri' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getAttachmentUri' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getAttachmentUri',
             messageId,
-            fileName: fileName,
-          }),
-        );
-      });
-    },
+                        fileName: fileName
+          }));
+          
+          });
+        },
 
-    // getAttachmentsUri:  => Promise<string>
-    getAttachmentsUri: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getAttachmentsUri callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getAttachmentsUri callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getAttachmentsUri_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getAttachmentsUri:  => Promise<string>
+        getAttachmentsUri: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getAttachmentsUri callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getAttachmentsUri callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getAttachmentsUri_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getAttachmentsUri' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getAttachmentsUri' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getAttachmentsUri',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // getCustomAppUri:  => Promise<string>
-    getCustomAppUri: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getCustomAppUri callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getCustomAppUri callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getCustomAppUri_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getCustomAppUri:  => Promise<string>
+        getCustomAppUri: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getCustomAppUri callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getCustomAppUri callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getCustomAppUri_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getCustomAppUri' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getCustomAppUri' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getCustomAppUri',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // getFormSpecsUri:  => Promise<string>
-    getFormSpecsUri: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getFormSpecsUri callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getFormSpecsUri callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getFormSpecsUri_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getFormSpecsUri:  => Promise<string>
+        getFormSpecsUri: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getFormSpecsUri callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getFormSpecsUri callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getFormSpecsUri_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getFormSpecsUri' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getFormSpecsUri' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getFormSpecsUri',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
   };
-
+  
   // Register the callback handler with the window object
   globalThis.formulusCallbacks = {};
-
+  
   // Notify that the interface is ready
   console.log('Formulus interface initialized');
-  globalThis.__formulusBridgeInitialized = true;
+  (globalThis).__formulusBridgeInitialized = true;
 
   // Simple API availability check for internal use
   function requestApiReinjection() {
     console.log('Formulus: Requesting re-injection from host...');
     if (globalThis.ReactNativeWebView) {
-      globalThis.ReactNativeWebView.postMessage(
-        JSON.stringify({
-          type: 'requestApiReinjection',
-          timestamp: Date.now(),
-        }),
-      );
+      globalThis.ReactNativeWebView.postMessage(JSON.stringify({
+        type: 'requestApiReinjection',
+        timestamp: Date.now()
+      }));
     }
   }
   globalThis.__formulusRequestApiReinjection = requestApiReinjection;
 
   // Notify React Native that the interface is ready
   if (globalThis.ReactNativeWebView) {
-    globalThis.ReactNativeWebView.postMessage(
-      JSON.stringify({
-        type: 'onFormulusReady',
-      }),
-    );
+    globalThis.ReactNativeWebView.postMessage(JSON.stringify({
+      type: 'onFormulusReady'
+    }));
   }
-
+  
   // Make the API available globally in browser environments
   if (typeof window !== 'undefined') {
     window.formulus = globalThis.formulus;
   }
+  
 })();

--- a/formulus-formplayer/src/mocks/webview-mock.ts
+++ b/formulus-formplayer/src/mocks/webview-mock.ts
@@ -5,17 +5,10 @@ import {
   QrcodeResult,
   FileResult,
   AudioResult,
+  LocationResult,
 } from '../types/FormulusInterfaceDefinition';
 
-// Local lightweight types for location/video results used only in the
-// development mock. The shared Formulus interface no longer exposes
-// these, but the mock helpers still refer to them.
-type LocationResult = {
-  fieldId: string;
-  status: 'success' | 'cancelled' | 'error';
-  message?: string;
-  data?: any;
-};
+// Local lightweight type for video results used only in the development mock.
 
 type VideoResult = {
   fieldId: string;

--- a/formulus-formplayer/src/renderers/GPSQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/GPSQuestionRenderer.tsx
@@ -52,8 +52,7 @@ const GPSQuestionRenderer: React.FC<GPSQuestionRendererProps> = props => {
   const [error, setError] = useState<string | null>(null);
   const formulusClient = useRef(FormulusClient.getInstance());
 
-  const fieldId =
-    path.replace(/\//g, '_').replace(/^_/, '') || 'gps_field';
+  const fieldId = path.replace(/\//g, '_').replace(/^_/, '') || 'gps_field';
 
   // Parse existing location data if present
   useEffect(() => {
@@ -65,7 +64,6 @@ const GPSQuestionRenderer: React.FC<GPSQuestionRendererProps> = props => {
           typeof parsed.latitude === 'number' &&
           typeof parsed.longitude === 'number'
         ) {
-          // eslint-disable-next-line react-hooks/set-state-in-effect
           setLocationData(parsed);
           return;
         }

--- a/formulus-formplayer/src/renderers/GPSQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/GPSQuestionRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { rankWith, ControlProps, formatIs } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import {
@@ -20,15 +20,13 @@ import {
 } from '@mui/icons-material';
 import QuestionShell from '../components/QuestionShell';
 import { tokens } from '../theme/tokens-adapter';
+import FormulusClient from '../services/FormulusInterface';
+import type { LocationResult } from '../types/FormulusInterfaceDefinition';
 
 // Helper to parse pixel values from tokens
 const parsePx = (value: string): number => {
   return parseInt(value.replace('px', ''), 10);
 };
-// GPS is now captured automatically by the native app for all forms.
-// This renderer is kept only for backward-compatibility with existing
-// form schemas that still reference the "gps" format. It no longer
-// actively requests location from the native side.
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface GPSQuestionRendererProps extends ControlProps {
@@ -52,32 +50,84 @@ const GPSQuestionRenderer: React.FC<GPSQuestionRendererProps> = props => {
     null,
   );
   const [error, setError] = useState<string | null>(null);
+  const formulusClient = useRef(FormulusClient.getInstance());
+
+  const fieldId =
+    path.replace(/\//g, '_').replace(/^_/, '') || 'gps_field';
 
   // Parse existing location data if present
   useEffect(() => {
     if (data && typeof data === 'string') {
       try {
         const parsed = JSON.parse(data);
-        if (parsed && parsed.latitude && parsed.longitude) {
+        if (
+          parsed &&
+          typeof parsed.latitude === 'number' &&
+          typeof parsed.longitude === 'number'
+        ) {
           // eslint-disable-next-line react-hooks/set-state-in-effect
           setLocationData(parsed);
+          return;
         }
       } catch (e) {
         console.warn('Failed to parse existing location data:', e);
       }
     }
+    setLocationData(null);
   }, [data]);
 
-  const handleCaptureLocation = async () => {
-    // GPS is now handled automatically by the native app and attached to
-    // observations outside of the form. This button is kept only so that
-    // existing forms with a GPS question do not break visually.
+  const handleCaptureLocation = useCallback(async () => {
+    if (!enabled) return;
+
     setIsCapturing(true);
-    setError(
-      'GPS location is now captured automatically by the app and does not need to be recorded here.',
-    );
-    setTimeout(() => setIsCapturing(false), 500);
-  };
+    setError(null);
+
+    try {
+      const result: LocationResult =
+        await formulusClient.current.requestLocation(fieldId);
+
+      if (result.status === 'success' && result.data) {
+        const stored: LocationDisplayData = {
+          latitude: result.data.latitude,
+          longitude: result.data.longitude,
+          accuracy: result.data.accuracy,
+          altitude: result.data.altitude ?? undefined,
+          altitudeAccuracy: result.data.altitudeAccuracy ?? undefined,
+          timestamp: result.data.timestamp,
+        };
+        setLocationData(stored);
+        handleChange(path, JSON.stringify(stored));
+      } else {
+        const msg =
+          result.message ||
+          (result.status === 'cancelled'
+            ? 'Location capture was cancelled'
+            : 'Could not capture location');
+        throw new Error(msg);
+      }
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'status' in err) {
+        const lr = err as LocationResult;
+        if (lr.status === 'cancelled') {
+          setError(null);
+        } else if (lr.status === 'error') {
+          setError(lr.message || 'Location capture failed');
+        } else {
+          setError('Location capture failed');
+        }
+      } else {
+        const msg =
+          err instanceof Error
+            ? err.message
+            : typeof err === 'string'
+              ? err
+              : 'Location capture failed. Check permissions and try again.';
+        setError(msg);
+      }
+    } finally {
+      setIsCapturing(false);
+    }
+  }, [enabled, fieldId, handleChange, path]);
 
   const handleDeleteLocation = () => {
     setLocationData(null);
@@ -121,7 +171,7 @@ const GPSQuestionRenderer: React.FC<GPSQuestionRendererProps> = props => {
             : errors
           : null)
       }
-      helperText="GPS is captured automatically; use this only if the form requires manual capture."
+      helperText="Tap to capture this point with the device GPS. The observation may also include a separate location when you submit."
       metadata={
         process.env.NODE_ENV === 'development' ? (
           <Box

--- a/formulus-formplayer/src/services/FormulusInterface.ts
+++ b/formulus-formplayer/src/services/FormulusInterface.ts
@@ -14,6 +14,7 @@ import {
   QrcodeResult,
   FileResult,
   AudioResult,
+  LocationResult,
 } from '../types/FormulusInterfaceDefinition';
 
 import {
@@ -149,11 +150,9 @@ class FormulusClient {
   }
 
   /**
-   * Request location from the Formulus RN app.
-   * The shared interface no longer returns a typed LocationResult; this
-   * simply forwards the request and returns the underlying Promise<void>.
+   * Request location from the Formulus RN app (native GPS for this field).
    */
-  public async requestLocation(fieldId: string): Promise<void> {
+  public async requestLocation(fieldId: string): Promise<LocationResult> {
     console.log('Requesting location for field', fieldId);
     await this.tryEnsureFormulus();
     if (this.formulus) {

--- a/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
+++ b/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
@@ -174,12 +174,26 @@ export interface FileResultData {
 }
 
 /**
+ * GPS / location capture result (in-form field), from native GeolocationService.
+ */
+export interface LocationResultData {
+  type: 'location';
+  latitude: number;
+  longitude: number;
+  accuracy?: number;
+  altitude?: number | null;
+  altitudeAccuracy?: number | null;
+  timestamp: string;
+}
+
+/**
  * Type aliases for specific action results
  */
 export type CameraResult = ActionResult<CameraResultData>;
 export type AudioResult = ActionResult<AudioResultData>;
 export type QrcodeResult = ActionResult<QrcodeResultData>;
 export type FileResult = ActionResult<FileResultData>;
+export type LocationResult = ActionResult<LocationResultData>;
 
 /**
  * @deprecated Use ActionResult<CameraResultData> instead
@@ -360,11 +374,11 @@ export interface FormulusInterface {
   requestCamera(fieldId: string): Promise<CameraResult>;
 
   /**
-   * Request location for a field
+   * Request location for a field (captures into the form GPS field).
    * @param {string} fieldId - The ID of the field
-   * @returns {Promise<void>}
+   * @returns {Promise<LocationResult>} Promise that resolves with location result or rejects on error
    */
-  requestLocation(fieldId: string): Promise<void>;
+  requestLocation(fieldId: string): Promise<LocationResult>;
 
   /**
    * Request file selection for a field

--- a/formulus/android/app/src/main/assets/formplayer_dist/formulus-load.js
+++ b/formulus/android/app/src/main/assets/formplayer_dist/formulus-load.js
@@ -88,7 +88,7 @@
                 isDraft: options.isDraft,
                 includeDeleted: options.includeDeleted,
                 whereClause: options.whereClause,
-              })
+              }),
             );
           });
         };

--- a/formulus/assets/webview/FormulusInjectionScript.js
+++ b/formulus/assets/webview/FormulusInjectionScript.js
@@ -1,51 +1,38 @@
 // Auto-generated from FormulusInterfaceDefinition.ts
 // Do not edit directly - this file will be overwritten
-// Last generated: 2026-04-17T14:59:47.429Z
+// Last generated: 2026-05-02T14:24:11.519Z
 
-(function () {
+(function() {
   // Enhanced API availability detection and recovery
   function getFormulus() {
     // Check multiple locations where the API might exist
-    return (
-      globalThis.formulus ||
-      (typeof window !== 'undefined' ? window.formulus : undefined)
-    );
+    return globalThis.formulus || (typeof window !== 'undefined' ? window.formulus : undefined);
   }
 
   function isFormulusAvailable() {
     const api = getFormulus();
-    return (
-      api && typeof api === 'object' && typeof api.getVersion === 'function'
-    );
+    return api && typeof api === 'object' && typeof api.getVersion === 'function';
   }
 
   // Idempotent guard to avoid double-initialization when scripts are reinjected
-  if (globalThis.__formulusBridgeInitialized) {
+  if ((globalThis).__formulusBridgeInitialized) {
     if (isFormulusAvailable()) {
-      console.debug(
-        'Formulus bridge already initialized and functional. Skipping duplicate injection.',
-      );
+      console.debug('Formulus bridge already initialized and functional. Skipping duplicate injection.');
       return;
     } else {
-      console.warn(
-        'Formulus bridge flag is set but API is not functional. Proceeding with re-injection...',
-      );
+      console.warn('Formulus bridge flag is set but API is not functional. Proceeding with re-injection...');
     }
   }
 
   // If API already exists and is functional, skip injection
   if (isFormulusAvailable()) {
-    console.debug(
-      'Formulus interface already exists and is functional. Skipping injection.',
-    );
+    console.debug('Formulus interface already exists and is functional. Skipping injection.');
     return;
   }
 
   // If API exists but is not functional, log warning and proceed with re-injection
   if (getFormulus()) {
-    console.warn(
-      'Formulus interface exists but appears non-functional. Re-injecting...',
-    );
+    console.warn('Formulus interface exists but appears non-functional. Re-injecting...');
   }
 
   // Helper function to handle callbacks
@@ -61,7 +48,7 @@
 
   // Initialize callbacks
   const callbacks = {};
-
+  
   // Global function to handle responses from React Native
   function handleMessage(event) {
     try {
@@ -74,1542 +61,1201 @@
         // console.warn('Global handleMessage: Received message with unexpected data type:', typeof event.data, event.data);
         return; // Or handle error, but for now, just return to avoid breaking others.
       }
-
+      
       // Handle callbacks
-      if (
-        data.type === 'callback' &&
-        data.callbackId &&
-        callbacks[data.callbackId]
-      ) {
+      if (data.type === 'callback' && data.callbackId && callbacks[data.callbackId]) {
         handleCallback(callbacks[data.callbackId], data.data);
         delete callbacks[data.callbackId];
       }
-
+      
       // Handle specific callbacks
-
-      if (
-        data.type === 'onFormulusReady' &&
-        globalThis.formulusCallbacks?.onFormulusReady
-      ) {
+      
+      
+      if (data.type === 'onFormulusReady' && globalThis.formulusCallbacks?.onFormulusReady) {
         handleCallback(globalThis.formulusCallbacks.onFormulusReady);
       }
     } catch (e) {
-      console.error(
-        'Global handleMessage: Error processing message:',
-        e,
-        'Raw event.data:',
-        event.data,
-      );
+      console.error('Global handleMessage: Error processing message:', e, 'Raw event.data:', event.data);
     }
   }
-
+  
   // Set up message listener
   document.addEventListener('message', handleMessage);
   window.addEventListener('message', handleMessage);
 
   // Initialize the formulus interface
   globalThis.formulus = {
-    // getVersion:  => Promise<string>
-    getVersion: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getVersion callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getVersion callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getVersion_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getVersion:  => Promise<string>
+        getVersion: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getVersion callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getVersion callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getVersion_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getVersion' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getVersion' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getVersion',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // getAvailableForms:  => Promise<FormInfo[]>
-    getAvailableForms: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getAvailableForms callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getAvailableForms callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getAvailableForms_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getAvailableForms:  => Promise<FormInfo[]>
+        getAvailableForms: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getAvailableForms callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getAvailableForms callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getAvailableForms_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getAvailableForms' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getAvailableForms' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getAvailableForms',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // openFormplayer: formType: string, params: Record<string, unknown>, savedData: Record<string, unknown>, options: { subObservationMode?: boolean; } => Promise<FormCompletionResult>
-    openFormplayer: function (formType, params, savedData, options) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('openFormplayer callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'openFormplayer callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'openFormplayer_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // openFormplayer: formType: string, params: Record<string, unknown>, savedData: Record<string, unknown>, options: { subObservationMode?: boolean; } => Promise<FormCompletionResult>
+        openFormplayer: function(formType, params, savedData, options) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('openFormplayer callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('openFormplayer callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'openFormplayer_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'openFormplayer' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'openFormplayer' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'openFormplayer',
             messageId,
-            formType: formType,
+                        formType: formType,
             params: params,
             savedData: savedData,
-            options: options,
-          }),
-        );
-      });
-    },
+            options: options
+          }));
+          
+          });
+        },
 
-    // getObservations: formType: string, isDraft: boolean, includeDeleted: boolean => Promise<FormObservation[]>
-    getObservations: function (formType, isDraft, includeDeleted) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getObservations callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getObservations callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getObservations_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getObservations: formType: string, isDraft: boolean, includeDeleted: boolean => Promise<FormObservation[]>
+        getObservations: function(formType, isDraft, includeDeleted) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getObservations callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getObservations callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getObservations_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getObservations' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getObservations' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getObservations',
             messageId,
-            formType: formType,
+                        formType: formType,
             isDraft: isDraft,
-            includeDeleted: includeDeleted,
-          }),
-        );
-      });
-    },
+            includeDeleted: includeDeleted
+          }));
+          
+          });
+        },
 
-    // getObservationsByQuery: options: { formType: string; isDraft?: boolean; includeDeleted?: boolean; whereClause?: string; } => Promise<FormObservation[]>
-    getObservationsByQuery: function (options) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getObservationsByQuery callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getObservationsByQuery callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getObservationsByQuery_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getObservationsByQuery: options: { formType: string; isDraft?: boolean; includeDeleted?: boolean; whereClause?: string; } => Promise<FormObservation[]>
+        getObservationsByQuery: function(options) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getObservationsByQuery callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getObservationsByQuery callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getObservationsByQuery_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getObservationsByQuery' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getObservationsByQuery' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getObservationsByQuery',
             messageId,
-            options: options,
-          }),
-        );
-      });
-    },
+                        options: options
+          }));
+          
+          });
+        },
 
-    // submitObservation: formType: string, finalData: Record<string, unknown> => Promise<string>
-    submitObservation: function (formType, finalData) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('submitObservation callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'submitObservation callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'submitObservation_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // submitObservation: formType: string, finalData: Record<string, unknown> => Promise<string>
+        submitObservation: function(formType, finalData) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('submitObservation callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('submitObservation callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'submitObservation_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'submitObservation' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'submitObservation' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'submitObservation',
             messageId,
-            formType: formType,
-            finalData: finalData,
-          }),
-        );
-      });
-    },
+                        formType: formType,
+            finalData: finalData
+          }));
+          
+          });
+        },
 
-    // updateObservation: observationId: string, formType: string, finalData: Record<string, unknown> => Promise<string>
-    updateObservation: function (observationId, formType, finalData) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('updateObservation callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'updateObservation callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'updateObservation_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // updateObservation: observationId: string, formType: string, finalData: Record<string, unknown> => Promise<string>
+        updateObservation: function(observationId, formType, finalData) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('updateObservation callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('updateObservation callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'updateObservation_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'updateObservation' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'updateObservation' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'updateObservation',
             messageId,
-            observationId: observationId,
+                        observationId: observationId,
             formType: formType,
-            finalData: finalData,
-          }),
-        );
-      });
-    },
+            finalData: finalData
+          }));
+          
+          });
+        },
 
-    // requestCamera: fieldId: string => Promise<CameraResult>
-    requestCamera: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestCamera callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestCamera callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestCamera_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestCamera: fieldId: string => Promise<CameraResult>
+        requestCamera: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestCamera callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestCamera callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestCamera_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestCamera' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestCamera' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestCamera',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // requestLocation: fieldId: string => Promise<void>
-    requestLocation: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestLocation callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestLocation callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestLocation_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestLocation: fieldId: string => Promise<LocationResult>
+        requestLocation: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestLocation callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestLocation callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestLocation_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestLocation' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestLocation' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestLocation',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // requestFile: fieldId: string => Promise<FileResult>
-    requestFile: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestFile callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestFile callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestFile_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestFile: fieldId: string => Promise<FileResult>
+        requestFile: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestFile callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestFile callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestFile_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestFile' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestFile' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestFile',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // launchIntent: fieldId: string, intentSpec: Record<string, unknown> => Promise<void>
-    launchIntent: function (fieldId, intentSpec) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('launchIntent callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'launchIntent callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'launchIntent_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // launchIntent: fieldId: string, intentSpec: Record<string, unknown> => Promise<void>
+        launchIntent: function(fieldId, intentSpec) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('launchIntent callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('launchIntent callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'launchIntent_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'launchIntent' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'launchIntent' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'launchIntent',
             messageId,
-            fieldId: fieldId,
-            intentSpec: intentSpec,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId,
+            intentSpec: intentSpec
+          }));
+          
+          });
+        },
 
-    // callSubform: fieldId: string, formType: string, options: Record<string, unknown> => Promise<void>
-    callSubform: function (fieldId, formType, options) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('callSubform callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'callSubform callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'callSubform_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // callSubform: fieldId: string, formType: string, options: Record<string, unknown> => Promise<void>
+        callSubform: function(fieldId, formType, options) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('callSubform callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('callSubform callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'callSubform_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'callSubform' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'callSubform' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'callSubform',
             messageId,
-            fieldId: fieldId,
+                        fieldId: fieldId,
             formType: formType,
-            options: options,
-          }),
-        );
-      });
-    },
+            options: options
+          }));
+          
+          });
+        },
 
-    // requestAudio: fieldId: string => Promise<AudioResult>
-    requestAudio: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestAudio callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestAudio callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestAudio_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestAudio: fieldId: string => Promise<AudioResult>
+        requestAudio: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestAudio callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestAudio callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestAudio_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestAudio' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestAudio' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestAudio',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // requestQrcode: fieldId: string => Promise<QrcodeResult>
-    requestQrcode: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestQrcode callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestQrcode callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestQrcode_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestQrcode: fieldId: string => Promise<QrcodeResult>
+        requestQrcode: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestQrcode callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestQrcode callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestQrcode_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestQrcode' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestQrcode' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestQrcode',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // requestBiometric: fieldId: string => Promise<void>
-    requestBiometric: function (fieldId) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestBiometric callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestBiometric callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestBiometric_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestBiometric: fieldId: string => Promise<void>
+        requestBiometric: function(fieldId) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestBiometric callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestBiometric callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestBiometric_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestBiometric' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestBiometric' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestBiometric',
             messageId,
-            fieldId: fieldId,
-          }),
-        );
-      });
-    },
+                        fieldId: fieldId
+          }));
+          
+          });
+        },
 
-    // requestConnectivityStatus:  => Promise<void>
-    requestConnectivityStatus: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestConnectivityStatus callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestConnectivityStatus callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestConnectivityStatus_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestConnectivityStatus:  => Promise<void>
+        requestConnectivityStatus: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestConnectivityStatus callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestConnectivityStatus callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestConnectivityStatus_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestConnectivityStatus' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestConnectivityStatus' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestConnectivityStatus',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // requestSyncStatus:  => Promise<void>
-    requestSyncStatus: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('requestSyncStatus callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'requestSyncStatus callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'requestSyncStatus_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // requestSyncStatus:  => Promise<void>
+        requestSyncStatus: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('requestSyncStatus callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('requestSyncStatus callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'requestSyncStatus_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'requestSyncStatus' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'requestSyncStatus' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'requestSyncStatus',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // runLocalModel: fieldId: string, modelId: string, input: Record<string, unknown> => Promise<void>
-    runLocalModel: function (fieldId, modelId, input) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('runLocalModel callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'runLocalModel callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'runLocalModel_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // runLocalModel: fieldId: string, modelId: string, input: Record<string, unknown> => Promise<void>
+        runLocalModel: function(fieldId, modelId, input) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('runLocalModel callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('runLocalModel callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'runLocalModel_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'runLocalModel' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'runLocalModel' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'runLocalModel',
             messageId,
-            fieldId: fieldId,
+                        fieldId: fieldId,
             modelId: modelId,
-            input: input,
-          }),
-        );
-      });
-    },
+            input: input
+          }));
+          
+          });
+        },
 
-    // getCurrentUser:  => Promise<{ username: string; displayName?: string; role?: "read-only" | "read-write" | "admin"; }>
-    getCurrentUser: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getCurrentUser callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getCurrentUser callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getCurrentUser_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getCurrentUser:  => Promise<{ username: string; displayName?: string; role?: "read-only" | "read-write" | "admin"; }>
+        getCurrentUser: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getCurrentUser callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getCurrentUser callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getCurrentUser_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getCurrentUser' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getCurrentUser' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getCurrentUser',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // getThemeMode:  => Promise<"light" | "dark" | "system">
-    getThemeMode: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getThemeMode callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getThemeMode callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getThemeMode_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getThemeMode:  => Promise<"light" | "dark" | "system">
+        getThemeMode: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getThemeMode callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getThemeMode callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getThemeMode_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getThemeMode' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getThemeMode' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getThemeMode',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // getAttachmentUri: fileName: string | AttachmentDisplayDescriptor => Promise<string>
-    getAttachmentUri: function (fileName) {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getAttachmentUri callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getAttachmentUri callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getAttachmentUri_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getAttachmentUri: fileName: string | AttachmentDisplayDescriptor => Promise<string>
+        getAttachmentUri: function(fileName) {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getAttachmentUri callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getAttachmentUri callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getAttachmentUri_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getAttachmentUri' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getAttachmentUri' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getAttachmentUri',
             messageId,
-            fileName: fileName,
-          }),
-        );
-      });
-    },
+                        fileName: fileName
+          }));
+          
+          });
+        },
 
-    // getAttachmentsUri:  => Promise<string>
-    getAttachmentsUri: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getAttachmentsUri callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getAttachmentsUri callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getAttachmentsUri_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getAttachmentsUri:  => Promise<string>
+        getAttachmentsUri: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getAttachmentsUri callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getAttachmentsUri callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getAttachmentsUri_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getAttachmentsUri' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getAttachmentsUri' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getAttachmentsUri',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // getCustomAppUri:  => Promise<string>
-    getCustomAppUri: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getCustomAppUri callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getCustomAppUri callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getCustomAppUri_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getCustomAppUri:  => Promise<string>
+        getCustomAppUri: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getCustomAppUri callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getCustomAppUri callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getCustomAppUri_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getCustomAppUri' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getCustomAppUri' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getCustomAppUri',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
 
-    // getFormSpecsUri:  => Promise<string>
-    getFormSpecsUri: function () {
-      return new Promise((resolve, reject) => {
-        const messageId =
-          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-
-        // Add response handler for methods that return values
-
-        const callback = event => {
-          try {
-            let data;
-            if (typeof event.data === 'string') {
-              data = JSON.parse(event.data);
-            } else if (typeof event.data === 'object' && event.data !== null) {
-              data = event.data; // Already an object
-            } else {
-              // console.warn('getFormSpecsUri callback: Received response with unexpected data type:', typeof event.data, event.data);
-              window.removeEventListener('message', callback); // Clean up listener
-              reject(
-                new Error(
-                  'getFormSpecsUri callback: Received response with unexpected data type. Raw: ' +
-                    String(event.data),
-                ),
-              );
-              return;
-            }
-            if (
-              data.type === 'getFormSpecsUri_response' &&
-              data.messageId === messageId
-            ) {
-              window.removeEventListener('message', callback);
-              if (data.error) {
-                reject(new Error(data.error));
+        // getFormSpecsUri:  => Promise<string>
+        getFormSpecsUri: function() {
+          return new Promise((resolve, reject) => {
+          const messageId = 'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+          
+          // Add response handler for methods that return values
+          
+          const callback = (event) => {
+            try {
+              let data;
+              if (typeof event.data === 'string') {
+                data = JSON.parse(event.data);
+              } else if (typeof event.data === 'object' && event.data !== null) {
+                data = event.data; // Already an object
               } else {
-                resolve(data.result);
+                // console.warn('getFormSpecsUri callback: Received response with unexpected data type:', typeof event.data, event.data);
+                window.removeEventListener('message', callback); // Clean up listener
+                reject(new Error('getFormSpecsUri callback: Received response with unexpected data type. Raw: ' + String(event.data)));
+                return;
               }
+              if (data.type === 'getFormSpecsUri_response' && data.messageId === messageId) {
+                window.removeEventListener('message', callback);
+                if (data.error) {
+                  reject(new Error(data.error));
+                } else {
+                  resolve(data.result);
+                }
+              }
+            } catch (e) {
+              console.error("'getFormSpecsUri' callback: Error processing response:" , e, "Raw event.data:", event.data);
+              window.removeEventListener('message', callback); // Ensure listener is removed on error too
+              reject(e);
             }
-          } catch (e) {
-            console.error(
-              "'getFormSpecsUri' callback: Error processing response:",
-              e,
-              'Raw event.data:',
-              event.data,
-            );
-            window.removeEventListener('message', callback); // Ensure listener is removed on error too
-            reject(e);
-          }
-        };
-        window.addEventListener('message', callback);
-
-        // Send the message to React Native
-        globalThis.ReactNativeWebView.postMessage(
-          JSON.stringify({
+          };
+          window.addEventListener('message', callback);
+          
+          
+          // Send the message to React Native
+          globalThis.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'getFormSpecsUri',
             messageId,
-          }),
-        );
-      });
-    },
+            
+          }));
+          
+          });
+        },
   };
-
+  
   // Register the callback handler with the window object
   globalThis.formulusCallbacks = {};
-
+  
   // Notify that the interface is ready
   console.log('Formulus interface initialized');
-  globalThis.__formulusBridgeInitialized = true;
+  (globalThis).__formulusBridgeInitialized = true;
 
   // Simple API availability check for internal use
   function requestApiReinjection() {
     console.log('Formulus: Requesting re-injection from host...');
     if (globalThis.ReactNativeWebView) {
-      globalThis.ReactNativeWebView.postMessage(
-        JSON.stringify({
-          type: 'requestApiReinjection',
-          timestamp: Date.now(),
-        }),
-      );
+      globalThis.ReactNativeWebView.postMessage(JSON.stringify({
+        type: 'requestApiReinjection',
+        timestamp: Date.now()
+      }));
     }
   }
   globalThis.__formulusRequestApiReinjection = requestApiReinjection;
 
   // Notify React Native that the interface is ready
   if (globalThis.ReactNativeWebView) {
-    globalThis.ReactNativeWebView.postMessage(
-      JSON.stringify({
-        type: 'onFormulusReady',
-      }),
-    );
+    globalThis.ReactNativeWebView.postMessage(JSON.stringify({
+      type: 'onFormulusReady'
+    }));
   }
-
+  
   // Make the API available globally in browser environments
   if (typeof window !== 'undefined') {
     window.formulus = globalThis.formulus;
   }
+  
 })();

--- a/formulus/assets/webview/formulus-api.js
+++ b/formulus/assets/webview/formulus-api.js
@@ -1,16 +1,16 @@
 /**
  * Formulus API Interface (JavaScript Version)
- *
+ * 
  * This file provides type information and documentation for the Formulus API
  * that's available in the WebView context as `globalThis.formulus`.
- *
+ * 
  * This file is auto-generated from FormulusInterfaceDefinition.ts
- * Last generated: 2026-04-17T14:59:47.704Z
- *
+ * Last generated: 2026-05-02T14:24:11.899Z
+ * 
  * @example
  * // In your JavaScript file:
  * /// <reference path="./formulus-api.js" />
- *
+ * 
  * // Now you'll get autocompletion and type hints in IDEs that support JSDoc
  * globalThis.formulus.getVersion().then(version => {
  *   console.log('Formulus version:', version);
@@ -29,213 +29,214 @@
  */
 const FormulusAPI = {
   /**
-   * Get the current version of the Formulus API
-   * /
-   * @returns {Promise<string>} The API version
-   */
-  getVersion: function () {},
+ * Get the current version of the Formulus API
+ * /
+ * @returns {Promise<string>} The API version
+ */
+  getVersion: function() {},
 
   /**
-   * Get a list of available forms
-   * /
-   * @returns {Promise<FormInfo[]>} Array of form information objects
-   */
-  getAvailableForms: function () {},
+ * Get a list of available forms
+ * /
+ * @returns {Promise<FormInfo[]>} Array of form information objects
+ */
+  getAvailableForms: function() {},
 
   /**
-   * Open Formplayer with the specified form
-   * /
-   * @param {string} formType - The identifier of the formtype to open
-   * @param {Object} params - Additional parameters for form initialization
-   * @param {Object} savedData - Previously saved form data (for editing)
-   * @returns {Promise<FormCompletionResult>} Promise that resolves when the form is completed/closed with result details
-   */
-  openFormplayer: function (formType, params, savedData, options) {},
+ * Open Formplayer with the specified form
+ * /
+ * @param {string} formType - The identifier of the formtype to open
+ * @param {Object} params - Additional parameters for form initialization
+ * @param {Object} savedData - Previously saved form data (for editing)
+ * @returns {Promise<FormCompletionResult>} Promise that resolves when the form is completed/closed with result details
+ */
+  openFormplayer: function(formType, params, savedData, options) {},
 
   /**
-   * Get observations for a specific form
-   * /
-   * @param {string} formType - The identifier of the formtype
-   * @returns {Promise<FormObservation[]>} Array of form observations
-   */
-  getObservations: function (formType, isDraft, includeDeleted) {},
+ * Get observations for a specific form
+ * /
+ * @param {string} formType - The identifier of the formtype
+ * @returns {Promise<FormObservation[]>} Array of form observations
+ */
+  getObservations: function(formType, isDraft, includeDeleted) {},
 
   /**
-   * Get observations with optional WHERE clause filtering (for dynamic choice lists).
-   * Supports format: data.field = 'value' AND data.other = 'value'
-   * Age filtering via age_from_dob(data.dob) is handled client-side in formplayer.
-   * /
-   * @returns {Promise<FormObservation[]>} Array of filtered observations
-   */
-  getObservationsByQuery: function (options) {},
+ * Get observations with optional WHERE clause filtering (for dynamic choice lists).
+ * Supports format: data.field = 'value' AND data.other = 'value'
+ * Age filtering via age_from_dob(data.dob) is handled client-side in formplayer.
+ * /
+ * @returns {Promise<FormObservation[]>} Array of filtered observations
+ */
+  getObservationsByQuery: function(options) {},
 
   /**
-   * Submit a completed form
-   * /
-   * @param {string} formType - The identifier of the formtype
-   * @param {Object} finalData - The final form data to submit
-   * @returns {Promise<string>} The observationId of the submitted form
-   */
-  submitObservation: function (formType, finalData) {},
+ * Submit a completed form
+ * /
+ * @param {string} formType - The identifier of the formtype
+ * @param {Object} finalData - The final form data to submit
+ * @returns {Promise<string>} The observationId of the submitted form
+ */
+  submitObservation: function(formType, finalData) {},
 
   /**
-   * Update an existing form
-   * /
-   * @param {string} observationId - The identifier of the observation
-   * @param {string} formType - The identifier of the formtype
-   * @param {Object} finalData - The final form data to update
-   * @returns {Promise<string>} The observationId of the updated form
-   */
-  updateObservation: function (observationId, formType, finalData) {},
+ * Update an existing form
+ * /
+ * @param {string} observationId - The identifier of the observation
+ * @param {string} formType - The identifier of the formtype
+ * @param {Object} finalData - The final form data to update
+ * @returns {Promise<string>} The observationId of the updated form
+ */
+  updateObservation: function(observationId, formType, finalData) {},
 
   /**
-   * Request camera access for a field
-   * /
-   * @param {string} fieldId - The ID of the field
-   * @returns {Promise<CameraResult>} Promise that resolves with camera result or rejects on error/cancellation
-   */
-  requestCamera: function (fieldId) {},
+ * Request camera access for a field
+ * /
+ * @param {string} fieldId - The ID of the field
+ * @returns {Promise<CameraResult>} Promise that resolves with camera result or rejects on error/cancellation
+ */
+  requestCamera: function(fieldId) {},
 
   /**
-   * Request location for a field
-   * /
-   * @param {string} fieldId - The ID of the field
-   * @returns {Promise<void>}
-   */
-  requestLocation: function (fieldId) {},
+ * Request location for a field (captures into the form GPS field).
+ * /
+ * @param {string} fieldId - The ID of the field
+ * @returns {Promise<LocationResult>} Promise that resolves with location result or rejects on error
+ */
+  requestLocation: function(fieldId) {},
 
   /**
-   * Request file selection for a field
-   * /
-   * @param {string} fieldId - The ID of the field
-   * @returns {Promise<FileResult>} Promise that resolves with file result or rejects on error/cancellation
-   */
-  requestFile: function (fieldId) {},
+ * Request file selection for a field
+ * /
+ * @param {string} fieldId - The ID of the field
+ * @returns {Promise<FileResult>} Promise that resolves with file result or rejects on error/cancellation
+ */
+  requestFile: function(fieldId) {},
 
   /**
-   * Launch an external intent
-   * /
-   * @param {string} fieldId - The ID of the field
-   * @param {Object} intentSpec - The intent specification
-   * @returns {Promise<void>}
-   */
-  launchIntent: function (fieldId, intentSpec) {},
+ * Launch an external intent
+ * /
+ * @param {string} fieldId - The ID of the field
+ * @param {Object} intentSpec - The intent specification
+ * @returns {Promise<void>} 
+ */
+  launchIntent: function(fieldId, intentSpec) {},
 
   /**
-   * Call a subform
-   * /
-   * @param {string} fieldId - The ID of the field
-   * @param {string} formType - The ID of the subform
-   * @param {Object} options - Additional options for the subform
-   * @returns {Promise<void>}
-   */
-  callSubform: function (fieldId, formType, options) {},
+ * Call a subform
+ * /
+ * @param {string} fieldId - The ID of the field
+ * @param {string} formType - The ID of the subform
+ * @param {Object} options - Additional options for the subform
+ * @returns {Promise<void>} 
+ */
+  callSubform: function(fieldId, formType, options) {},
 
   /**
-   * Request audio recording for a field
-   * /
-   * @param {string} fieldId - The ID of the field
-   * @returns {Promise<AudioResult>} Promise that resolves with audio result or rejects on error/cancellation
-   */
-  requestAudio: function (fieldId) {},
+ * Request audio recording for a field
+ * /
+ * @param {string} fieldId - The ID of the field
+ * @returns {Promise<AudioResult>} Promise that resolves with audio result or rejects on error/cancellation
+ */
+  requestAudio: function(fieldId) {},
 
   /**
-   * Request QR code scanning for a field
-   * /
-   * @param {string} fieldId - The ID of the field
-   * @returns {Promise<QrcodeResult>} Promise that resolves with QR code result or rejects on error/cancellation
-   */
-  requestQrcode: function (fieldId) {},
+ * Request QR code scanning for a field
+ * /
+ * @param {string} fieldId - The ID of the field
+ * @returns {Promise<QrcodeResult>} Promise that resolves with QR code result or rejects on error/cancellation
+ */
+  requestQrcode: function(fieldId) {},
 
   /**
-   * Request biometric authentication
-   * /
-   * @param {string} fieldId - The ID of the field
-   * @returns {Promise<void>}
-   */
-  requestBiometric: function (fieldId) {},
+ * Request biometric authentication
+ * /
+ * @param {string} fieldId - The ID of the field
+ * @returns {Promise<void>} 
+ */
+  requestBiometric: function(fieldId) {},
 
   /**
-   * Request the current connectivity status
-   * /
-   * @returns {Promise<void>}
-   */
-  requestConnectivityStatus: function () {},
+ * Request the current connectivity status
+ * /
+ * @returns {Promise<void>} 
+ */
+  requestConnectivityStatus: function() {},
 
   /**
-   * Request the current sync status
-   * /
-   * @returns {Promise<void>}
-   */
-  requestSyncStatus: function () {},
+ * Request the current sync status
+ * /
+ * @returns {Promise<void>} 
+ */
+  requestSyncStatus: function() {},
 
   /**
-   * Run a local ML model
-   * /
-   * @param {string} fieldId - The ID of the field
-   * @param {string} modelId - The ID of the model to run
-   * @param {Object} input - The input data for the model
-   * @returns {Promise<void>}
-   */
-  runLocalModel: function (fieldId, modelId, input) {},
+ * Run a local ML model
+ * /
+ * @param {string} fieldId - The ID of the field
+ * @param {string} modelId - The ID of the model to run
+ * @param {Object} input - The input data for the model
+ * @returns {Promise<void>} 
+ */
+  runLocalModel: function(fieldId, modelId, input) {},
 
   /**
-   * Get information about the currently authenticated user.
-   * When no one is logged in, resolves with `{ username: '' }` (does not reject).
-   * /
-   * @returns {Promise<{username: string, displayName?: string, role?: 'read-only' | 'read-write' | 'admin'}
-   */
-  getCurrentUser: function () {},
+ * Get information about the currently authenticated user.
+ * When no one is logged in, resolves with `{ username: '' }` (does not reject).
+ * /
+ * @returns {Promise<{username: string, displayName?: string, role?: 'read-only' | 'read-write' | 'admin'} 
+ */
+  getCurrentUser: function() {},
 
   /**
-   * Get the current theme mode (System / Light / Dark) so custom apps can match the host app.
-   * /
-   * @returns {Promise<'light' | 'dark' | 'system'>} Current theme mode; 'system' means follow device preference.
-   */
-  getThemeMode: function () {},
+ * Get the current theme mode (System / Light / Dark) so custom apps can match the host app.
+ * /
+ * @returns {Promise<'light' | 'dark' | 'system'>} Current theme mode; 'system' means follow device preference.
+ */
+  getThemeMode: function() {},
 
   /**
-   * Resolve an attachment to a WebView-loadable URL (`file://`, `http(s):`, or host-specific).
-   * **String `fileName`:** basename only (e.g. `photo.filename`). Lookup order, first hit wins:
-   * 1. `attachments/draft/<name>`   — unsaved capture (formplayer preview)
-   * 2. `attachments/synced/<name>`  — canonical committed / downloaded copy
-   * 3. `attachments/pending/<name>` — queued for upload (fallback only)
-   * Legacy locations (`attachments/<name>` and `attachments/pending_upload/<name>`) are also checked.
-   * Path segments and ".." are rejected.
-   * **`AttachmentDisplayDescriptor`:** `{ filename }` basename only (same lookup as a string argument).
-   * /
-   * @returns {Promise<string | null>} Display URL, or `null` if none
-   */
-  getAttachmentUri: function (fileName) {},
+ * Resolve an attachment to a WebView-loadable URL (`file://`, `http(s):`, or host-specific).
+ * **String `fileName`:** basename only (e.g. `photo.filename`). Lookup order, first hit wins:
+ * 1. `attachments/draft/<name>`   — unsaved capture (formplayer preview)
+ * 2. `attachments/synced/<name>`  — canonical committed / downloaded copy
+ * 3. `attachments/pending/<name>` — queued for upload (fallback only)
+ * Legacy locations (`attachments/<name>` and `attachments/pending_upload/<name>`) are also checked.
+ * Path segments and ".." are rejected.
+ * **`AttachmentDisplayDescriptor`:** `{ filename }` basename only (same lookup as a string argument).
+ * /
+ * @returns {Promise<string | null>} Display URL, or `null` if none
+ */
+  getAttachmentUri: function(fileName) {},
 
   /**
-   * Base `file://` URL for the canonical attachments directory (trailing slash).
-   * Returns the `synced/` subfolder — only committed/downloaded files are
-   * iterable from here. Drafts and the upload queue are excluded by design so
-   * custom apps can safely list this directory.
-   * **Breaking change (v2 layout):** this used to return the `attachments/`
-   * parent directory, which mixed committed files with `draft/` and
-   * `pending_upload/` subfolders. Custom apps that iterate this URL will now
-   * see only fully-committed attachments.
-   * /
-   * @returns {Promise<string>} e.g. `file:///.../attachments/synced/`
-   */
-  getAttachmentsUri: function () {},
+ * Base `file://` URL for the canonical attachments directory (trailing slash).
+ * Returns the `synced/` subfolder — only committed/downloaded files are
+ * iterable from here. Drafts and the upload queue are excluded by design so
+ * custom apps can safely list this directory.
+ * **Breaking change (v2 layout):** this used to return the `attachments/`
+ * parent directory, which mixed committed files with `draft/` and
+ * `pending_upload/` subfolders. Custom apps that iterate this URL will now
+ * see only fully-committed attachments.
+ * /
+ * @returns {Promise<string>} e.g. `file:///.../attachments/synced/`
+ */
+  getAttachmentsUri: function() {},
 
   /**
-   * Base `file://` URL for the custom app bundle root (`DocumentDirectory/app/`, trailing slash).
-   * /
-   * @returns {Promise<string>} App directory URL for extensions, question_types, etc.
-   */
-  getCustomAppUri: function () {},
+ * Base `file://` URL for the custom app bundle root (`DocumentDirectory/app/`, trailing slash).
+ * /
+ * @returns {Promise<string>} App directory URL for extensions, question_types, etc.
+ */
+  getCustomAppUri: function() {},
 
   /**
-   * Primary `file://` URL for downloaded form specs (`DocumentDirectory/forms/`, trailing slash).
-   * Some bundles also use files under the custom app `forms/` subdirectory.
-   * /
-   * @returns {Promise<string>} Forms directory URL
-   */
-  getFormSpecsUri: function () {},
+ * Primary `file://` URL for downloaded form specs (`DocumentDirectory/forms/`, trailing slash).
+ * Some bundles also use files under the custom app `forms/` subdirectory.
+ * /
+ * @returns {Promise<string>} Forms directory URL
+ */
+  getFormSpecsUri: function() {},
+
 };
 
 // Make the API available globally in browser environments

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -174,12 +174,26 @@ export interface FileResultData {
 }
 
 /**
+ * GPS / location capture result (in-form field), from native GeolocationService.
+ */
+export interface LocationResultData {
+  type: 'location';
+  latitude: number;
+  longitude: number;
+  accuracy?: number;
+  altitude?: number | null;
+  altitudeAccuracy?: number | null;
+  timestamp: string;
+}
+
+/**
  * Type aliases for specific action results
  */
 export type CameraResult = ActionResult<CameraResultData>;
 export type AudioResult = ActionResult<AudioResultData>;
 export type QrcodeResult = ActionResult<QrcodeResultData>;
 export type FileResult = ActionResult<FileResultData>;
+export type LocationResult = ActionResult<LocationResultData>;
 
 /**
  * @deprecated Use ActionResult<CameraResultData> instead
@@ -360,11 +374,11 @@ export interface FormulusInterface {
   requestCamera(fieldId: string): Promise<CameraResult>;
 
   /**
-   * Request location for a field
+   * Request location for a field (captures into the form GPS field).
    * @param {string} fieldId - The ID of the field
-   * @returns {Promise<void>}
+   * @returns {Promise<LocationResult>} Promise that resolves with location result or rejects on error
    */
-  requestLocation(fieldId: string): Promise<void>;
+  requestLocation(fieldId: string): Promise<LocationResult>;
 
   /**
    * Request file selection for a field

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -622,7 +622,15 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
       });
     },
 
-    onRequestLocation: async (fieldId: string): Promise<unknown> => {
+    onRequestLocation: async (
+      payload: string | { fieldId?: string },
+    ): Promise<unknown> => {
+      const fieldId =
+        typeof payload === 'string'
+          ? payload
+          : typeof payload?.fieldId === 'string'
+            ? payload.fieldId
+            : '';
       console.log('Request location handler called', fieldId);
 
       // eslint-disable-next-line no-async-promise-executor
@@ -657,13 +665,13 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
         } catch (error) {
           console.error('Location capture failed:', error);
 
-          const errorResult = {
-            fieldId,
-            status: 'error' as const,
-            message: 'Location capture failed',
-          };
-
-          reject(errorResult);
+          const message =
+            error instanceof Error ? error.message : 'Location capture failed';
+          reject(
+            new Error(
+              fieldId ? `${message} (field: ${fieldId})` : message,
+            ),
+          );
         }
       });
     },

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -668,9 +668,7 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
           const message =
             error instanceof Error ? error.message : 'Location capture failed';
           reject(
-            new Error(
-              fieldId ? `${message} (field: ${fieldId})` : message,
-            ),
+            new Error(fieldId ? `${message} (field: ${fieldId})` : message),
           );
         }
       });


### PR DESCRIPTION
## Description

Enables **in-form GPS capture** for JSON Forms fields that use `format: "gps"`. Tapping capture calls the existing **React Native → WebView `requestLocation`** bridge, then stores coordinates (and related fields) as a **JSON string** on that control path. **Observation-level `geolocation` on save is unchanged** (you can still have both).

## Notes / non-goals

- Does **not** remove or replace observation `geolocation` on submit.
- Forms that do not define a GPS field are unaffected.