### PR TITLE
fix(formplayer): align SwipeLayout paging with JsonForms isVisible

### DIFF
--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -201,13 +201,7 @@ const SwipeLayoutRenderer = ({
   useEffect(() => {
     if (layouts.length === 0) return;
     if (
-      pageIsVisibleInSwipe(
-        layouts[currentPage],
-        data,
-        path ?? '',
-        ajv,
-        config,
-      )
+      pageIsVisibleInSwipe(layouts[currentPage], data, path ?? '', ajv, config)
     ) {
       return;
     }
@@ -222,7 +216,16 @@ const SwipeLayoutRenderer = ({
     if (prev !== undefined) {
       onPageChange(prev);
     }
-  }, [currentPage, data, layouts, visiblePageIndices, onPageChange, path, ajv, config]);
+  }, [
+    currentPage,
+    data,
+    layouts,
+    visiblePageIndices,
+    onPageChange,
+    path,
+    ajv,
+    config,
+  ]);
 
   // ----- Required-field validation -----
 

--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -12,7 +12,9 @@ import {
   useJsonForms,
 } from '@jsonforms/react';
 import {
+  ControlElement,
   ControlProps,
+  createAjv,
   rankWith,
   uiTypeIs,
   RankedTester,
@@ -25,78 +27,11 @@ import { primaryKeyboardEnterKeyHint } from '../utils/keyboardEnterKeyHint';
 import { draftService } from '../services/DraftService';
 import FormProgressBar from '../components/FormProgressBar';
 import FormLayout from '../components/FormLayout';
-
-// ---------------------------------------------------------------------------
-// Page visibility helpers
-// ---------------------------------------------------------------------------
-
-/** Resolve a data value from a JSON Pointer scope (e.g. "#/properties/sexo"). */
-const resolveDataValue = (scope: string, data: any): any => {
-  if (!scope || !data) return undefined;
-  const parts = scope.replace(/^#\/properties\//, '').split('/');
-  let value = data;
-  for (const part of parts) {
-    if (value != null && typeof value === 'object') {
-      value = value[part];
-    } else {
-      return undefined;
-    }
-  }
-  return value;
-};
-
-/** Evaluate a JSON Schema condition object against a concrete value. */
-const evaluateConditionSchema = (schema: any, value: any): boolean => {
-  if (!schema) return true;
-
-  if ('const' in schema) return value === schema.const;
-  if ('enum' in schema)
-    return Array.isArray(schema.enum) && schema.enum.includes(value);
-  if ('not' in schema) return !evaluateConditionSchema(schema.not, value);
-  if ('pattern' in schema && typeof value === 'string')
-    return new RegExp(schema.pattern).test(value);
-  if ('minimum' in schema && typeof value === 'number')
-    return value >= schema.minimum;
-  if ('maximum' in schema && typeof value === 'number')
-    return value <= schema.maximum;
-
-  return true;
-};
-
-/** Check whether a single UI‑schema element is visible given current data. */
-const isElementVisible = (element: any, data: any): boolean => {
-  if (!element?.rule) return true;
-
-  const { effect, condition } = element.rule;
-  if (!condition?.scope || !condition?.schema) return true;
-
-  const value = resolveDataValue(condition.scope, data);
-  const conditionMet = evaluateConditionSchema(condition.schema, value);
-
-  if (effect === 'SHOW') return conditionMet;
-  if (effect === 'HIDE') return !conditionMet;
-  // ENABLE / DISABLE do not affect visibility
-  return true;
-};
-
-/**
- * Determine whether a page (typically a VerticalLayout) has any visible
- * content.  A page is hidden only when **every** child element is hidden by a
- * rule.  Finalize pages and pages without children are always visible.
- */
-const isPageVisible = (page: any, data: any): boolean => {
-  if (!page) return false;
-  if (page.type === 'Finalize') return true;
-
-  // The page itself may carry a rule
-  if (page.rule && !isElementVisible(page, data)) return false;
-
-  // Pages without child elements (e.g. a bare Control) are always visible
-  if (!page.elements || page.elements.length === 0) return true;
-
-  // Visible if at least one child is visible
-  return page.elements.some((el: any) => isElementVisible(el, data));
-};
+import {
+  collectVisibleControlsInSubtree,
+  pageIsVisibleInSwipe,
+  visiblePageIndicesFromLayouts,
+} from './swipeLayoutVisibility';
 
 // ---------------------------------------------------------------------------
 // Testers
@@ -163,9 +98,12 @@ const SwipeLayoutRenderer = ({
     null,
   );
   const [snackbarMessage, setSnackbarMessage] = useState<string>('');
-  const { core } = useJsonForms();
+  const { core, config } = useJsonForms();
   const parentFormContext = useFormContext();
   const { formInitData } = parentFormContext;
+
+  const fallbackAjv = useMemo(() => createAjv(), []);
+  const ajv = core?.ajv ?? fallbackAjv;
 
   const uiType = (uischema as any).type;
   const isExplicitSwipeLayout = uiType === 'SwipeLayout';
@@ -223,10 +161,14 @@ const SwipeLayoutRenderer = ({
 
   /** Indices of pages that are currently visible given the form data. */
   const visiblePageIndices = useMemo(() => {
-    return layouts
-      .map((_: any, idx: number) => idx)
-      .filter((idx: number) => isPageVisible(layouts[idx], data));
-  }, [layouts, data]);
+    return visiblePageIndicesFromLayouts(
+      layouts,
+      data,
+      path ?? '',
+      ajv,
+      config,
+    );
+  }, [layouts, data, path, ajv, config]);
 
   /** Next visible page after `currentPage`, or null. */
   const nextVisiblePage = useMemo((): number | null => {
@@ -258,7 +200,17 @@ const SwipeLayoutRenderer = ({
   // prior page), jump to the nearest visible page.
   useEffect(() => {
     if (layouts.length === 0) return;
-    if (isPageVisible(layouts[currentPage], data)) return;
+    if (
+      pageIsVisibleInSwipe(
+        layouts[currentPage],
+        data,
+        path ?? '',
+        ajv,
+        config,
+      )
+    ) {
+      return;
+    }
 
     // Prefer advancing forward, fall back to going backward
     const next = visiblePageIndices.find((i: number) => i > currentPage);
@@ -270,7 +222,7 @@ const SwipeLayoutRenderer = ({
     if (prev !== undefined) {
       onPageChange(prev);
     }
-  }, [currentPage, data, layouts, visiblePageIndices, onPageChange]);
+  }, [currentPage, data, layouts, visiblePageIndices, onPageChange, path, ajv, config]);
 
   // ----- Required-field validation -----
 
@@ -307,28 +259,19 @@ const SwipeLayoutRenderer = ({
       return false;
     };
 
-    const getPageControls = (element: any): any[] => {
-      const controls: any[] = [];
-      if (element.type === 'Control' && element.scope) {
-        controls.push(element);
-      }
-      if (element.elements && Array.isArray(element.elements)) {
-        element.elements.forEach((el: any) => {
-          controls.push(...getPageControls(el));
-        });
-      }
-      return controls;
-    };
-
-    // Only validate controls that are actually visible
-    const pageControls = getPageControls(currentPageElement).filter(control =>
-      isElementVisible(control, data),
+    const pageControls = collectVisibleControlsInSubtree(
+      currentPageElement,
+      data,
+      path ?? '',
+      ajv,
+      config,
     );
 
     pageControls.forEach(control => {
-      if (!control.scope) return;
+      const c = control as ControlElement;
+      if (!c.scope) return;
 
-      const fieldPath = control.scope;
+      const fieldPath = c.scope;
       const fieldSchema = getFieldSchema(fieldPath);
       if (!fieldSchema) return;
 
@@ -377,7 +320,7 @@ const SwipeLayoutRenderer = ({
     });
 
     return missingFields;
-  }, [core, data, layouts, currentPage]);
+  }, [core, data, layouts, currentPage, path, ajv, config]);
 
   // ----- Navigation -----
 

--- a/formulus-formplayer/src/renderers/swipeLayoutVisibility.test.ts
+++ b/formulus-formplayer/src/renderers/swipeLayoutVisibility.test.ts
@@ -33,7 +33,9 @@ describe('pageIsVisibleInSwipe', () => {
       ],
     };
     const data = { bar: 'no', foo: '' };
-    expect(pageIsVisibleInSwipe(page as any, data, '', ajv, config)).toBe(false);
+    expect(pageIsVisibleInSwipe(page as any, data, '', ajv, config)).toBe(
+      false,
+    );
   });
 
   it('returns true when nested Control is visible under Group', () => {
@@ -80,10 +82,22 @@ describe('pageIsVisibleInSwipe', () => {
       ],
     };
     expect(
-      pageIsVisibleInSwipe(page as any, { title: '', detail: '' }, '', ajv, config),
+      pageIsVisibleInSwipe(
+        page as any,
+        { title: '', detail: '' },
+        '',
+        ajv,
+        config,
+      ),
     ).toBe(false);
     expect(
-      pageIsVisibleInSwipe(page as any, { title: 'a', detail: '' }, '', ajv, config),
+      pageIsVisibleInSwipe(
+        page as any,
+        { title: 'a', detail: '' },
+        '',
+        ajv,
+        config,
+      ),
     ).toBe(true);
   });
 
@@ -112,10 +126,22 @@ describe('pageIsVisibleInSwipe', () => {
       ],
     };
     expect(
-      pageIsVisibleInSwipe(page as any, { flag: null, name: '' }, '', ajv, config),
+      pageIsVisibleInSwipe(
+        page as any,
+        { flag: null, name: '' },
+        '',
+        ajv,
+        config,
+      ),
     ).toBe(true);
     expect(
-      pageIsVisibleInSwipe(page as any, { flag: 'set', name: '' }, '', ajv, config),
+      pageIsVisibleInSwipe(
+        page as any,
+        { flag: 'set', name: '' },
+        '',
+        ajv,
+        config,
+      ),
     ).toBe(false);
   });
 
@@ -139,16 +165,14 @@ describe('pageIsVisibleInSwipe', () => {
           schema: { const: true },
         },
       },
-      elements: [
-        { type: 'Control', scope: '#/properties/foo' },
-      ],
+      elements: [{ type: 'Control', scope: '#/properties/foo' }],
     };
-    expect(pageIsVisibleInSwipe(page as any, { on: false, foo: 1 }, '', ajv, config)).toBe(
-      false,
-    );
-    expect(pageIsVisibleInSwipe(page as any, { on: true, foo: 1 }, '', ajv, config)).toBe(
-      true,
-    );
+    expect(
+      pageIsVisibleInSwipe(page as any, { on: false, foo: 1 }, '', ajv, config),
+    ).toBe(false);
+    expect(
+      pageIsVisibleInSwipe(page as any, { on: true, foo: 1 }, '', ajv, config),
+    ).toBe(true);
   });
 });
 
@@ -174,14 +198,14 @@ describe('visiblePageIndicesFromLayouts', () => {
       { type: 'Finalize' },
     ];
     const dataOne = { toggle: 'one', a: 1 };
-    expect(visiblePageIndicesFromLayouts(layouts as any, dataOne, '', ajv, config)).toEqual([
-      0, 1,
-    ]);
+    expect(
+      visiblePageIndicesFromLayouts(layouts as any, dataOne, '', ajv, config),
+    ).toEqual([0, 1]);
 
     const dataTwo = { toggle: 'two', a: 1 };
-    expect(visiblePageIndicesFromLayouts(layouts as any, dataTwo, '', ajv, config)).toEqual([
-      1,
-    ]);
+    expect(
+      visiblePageIndicesFromLayouts(layouts as any, dataTwo, '', ajv, config),
+    ).toEqual([1]);
   });
 });
 
@@ -208,7 +232,13 @@ describe('collectVisibleControlsInSubtree', () => {
       ],
     };
     const data = { always: 1, toggle: 'y', conditional: 2 };
-    const controls = collectVisibleControlsInSubtree(page as any, data, '', ajv, config);
+    const controls = collectVisibleControlsInSubtree(
+      page as any,
+      data,
+      '',
+      ajv,
+      config,
+    );
     expect(controls).toHaveLength(1);
     expect((controls[0] as any).scope).toBe('#/properties/always');
   });

--- a/formulus-formplayer/src/renderers/swipeLayoutVisibility.test.ts
+++ b/formulus-formplayer/src/renderers/swipeLayoutVisibility.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import { createAjv } from '@jsonforms/core';
+import {
+  collectVisibleControlsInSubtree,
+  pageIsVisibleInSwipe,
+  visiblePageIndicesFromLayouts,
+} from './swipeLayoutVisibility';
+
+const ajv = createAjv();
+const config = {};
+
+describe('pageIsVisibleInSwipe', () => {
+  it('returns false when nested Group only contains Controls hidden by SHOW + const (AJV)', () => {
+    const page = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Group',
+          elements: [
+            {
+              type: 'Control',
+              scope: '#/properties/foo',
+              rule: {
+                effect: 'SHOW',
+                condition: {
+                  scope: '#/properties/bar',
+                  schema: { const: 'yes' },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const data = { bar: 'no', foo: '' };
+    expect(pageIsVisibleInSwipe(page as any, data, '', ajv, config)).toBe(false);
+  });
+
+  it('returns true when nested Control is visible under Group', () => {
+    const page = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Group',
+          elements: [
+            {
+              type: 'Control',
+              scope: '#/properties/foo',
+              rule: {
+                effect: 'SHOW',
+                condition: {
+                  scope: '#/properties/bar',
+                  schema: { const: 'yes' },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const data = { bar: 'yes', foo: 'x' };
+    expect(pageIsVisibleInSwipe(page as any, data, '', ajv, config)).toBe(true);
+  });
+
+  it('respects SHOW + minLength (AJV) for nested Control', () => {
+    const page = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Control',
+          scope: '#/properties/detail',
+          rule: {
+            effect: 'SHOW',
+            condition: {
+              scope: '#/properties/title',
+              schema: { type: 'string', minLength: 1 },
+            },
+          },
+        },
+      ],
+    };
+    expect(
+      pageIsVisibleInSwipe(page as any, { title: '', detail: '' }, '', ajv, config),
+    ).toBe(false);
+    expect(
+      pageIsVisibleInSwipe(page as any, { title: 'a', detail: '' }, '', ajv, config),
+    ).toBe(true);
+  });
+
+  it('respects SHOW + anyOf schema (AJV) for nested Control', () => {
+    const page = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Group',
+          elements: [
+            {
+              type: 'Control',
+              scope: '#/properties/name',
+              rule: {
+                effect: 'SHOW',
+                condition: {
+                  scope: '#/properties/flag',
+                  schema: {
+                    anyOf: [{ const: null }, { const: '' }, { const: false }],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    expect(
+      pageIsVisibleInSwipe(page as any, { flag: null, name: '' }, '', ajv, config),
+    ).toBe(true);
+    expect(
+      pageIsVisibleInSwipe(page as any, { flag: 'set', name: '' }, '', ajv, config),
+    ).toBe(false);
+  });
+
+  it('treats Finalize page as always visible', () => {
+    const page = { type: 'Finalize' };
+    expect(pageIsVisibleInSwipe(page as any, {}, '', ajv, config)).toBe(true);
+  });
+
+  it('returns true for empty VerticalLayout (legacy swipe behavior)', () => {
+    const page = { type: 'VerticalLayout', elements: [] };
+    expect(pageIsVisibleInSwipe(page as any, {}, '', ajv, config)).toBe(true);
+  });
+
+  it('hides page when VerticalLayout has SHOW rule that fails', () => {
+    const page = {
+      type: 'VerticalLayout',
+      rule: {
+        effect: 'SHOW',
+        condition: {
+          scope: '#/properties/on',
+          schema: { const: true },
+        },
+      },
+      elements: [
+        { type: 'Control', scope: '#/properties/foo' },
+      ],
+    };
+    expect(pageIsVisibleInSwipe(page as any, { on: false, foo: 1 }, '', ajv, config)).toBe(
+      false,
+    );
+    expect(pageIsVisibleInSwipe(page as any, { on: true, foo: 1 }, '', ajv, config)).toBe(
+      true,
+    );
+  });
+});
+
+describe('visiblePageIndicesFromLayouts', () => {
+  it('filters out pages with no visible interactive content', () => {
+    const layouts = [
+      {
+        type: 'VerticalLayout',
+        elements: [
+          {
+            type: 'Control',
+            scope: '#/properties/a',
+            rule: {
+              effect: 'SHOW',
+              condition: {
+                scope: '#/properties/toggle',
+                schema: { const: 'one' },
+              },
+            },
+          },
+        ],
+      },
+      { type: 'Finalize' },
+    ];
+    const dataOne = { toggle: 'one', a: 1 };
+    expect(visiblePageIndicesFromLayouts(layouts as any, dataOne, '', ajv, config)).toEqual([
+      0, 1,
+    ]);
+
+    const dataTwo = { toggle: 'two', a: 1 };
+    expect(visiblePageIndicesFromLayouts(layouts as any, dataTwo, '', ajv, config)).toEqual([
+      1,
+    ]);
+  });
+});
+
+describe('collectVisibleControlsInSubtree', () => {
+  it('collects only Controls that JsonForms would show', () => {
+    const page = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Control',
+          scope: '#/properties/always',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/conditional',
+          rule: {
+            effect: 'SHOW',
+            condition: {
+              scope: '#/properties/toggle',
+              schema: { const: 'x' },
+            },
+          },
+        },
+      ],
+    };
+    const data = { always: 1, toggle: 'y', conditional: 2 };
+    const controls = collectVisibleControlsInSubtree(page as any, data, '', ajv, config);
+    expect(controls).toHaveLength(1);
+    expect((controls[0] as any).scope).toBe('#/properties/always');
+  });
+});

--- a/formulus-formplayer/src/renderers/swipeLayoutVisibility.ts
+++ b/formulus-formplayer/src/renderers/swipeLayoutVisibility.ts
@@ -1,9 +1,5 @@
 import type Ajv from 'ajv';
-import {
-  isControl,
-  isVisible,
-  type UISchemaElement,
-} from '@jsonforms/core';
+import { isControl, isVisible, type UISchemaElement } from '@jsonforms/core';
 
 /**
  * Same visibility semantics as JsonForms renderers (see mapStateToControlProps /
@@ -48,7 +44,15 @@ function subtreeHasVisibleInteractiveContent(
   }
   const childPath = dispatchPathForLayoutChild(dispatchPath);
   for (const child of children) {
-    if (subtreeHasVisibleInteractiveContent(child, rootData, childPath, ajv, config)) {
+    if (
+      subtreeHasVisibleInteractiveContent(
+        child,
+        rootData,
+        childPath,
+        ajv,
+        config,
+      )
+    ) {
       return true;
     }
   }
@@ -89,8 +93,14 @@ export function pageIsVisibleInSwipe(
   }
 
   const childPath = dispatchPathForLayoutChild(dispatchPath);
-  return typed.elements.some((child) =>
-    subtreeHasVisibleInteractiveContent(child, rootData, childPath, ajv, config),
+  return typed.elements.some(child =>
+    subtreeHasVisibleInteractiveContent(
+      child,
+      rootData,
+      childPath,
+      ajv,
+      config,
+    ),
   );
 }
 
@@ -103,7 +113,7 @@ export function visiblePageIndicesFromLayouts(
 ): number[] {
   return layouts
     .map((_, idx) => idx)
-    .filter((idx) =>
+    .filter(idx =>
       pageIsVisibleInSwipe(
         layouts[idx],
         rootData,

--- a/formulus-formplayer/src/renderers/swipeLayoutVisibility.ts
+++ b/formulus-formplayer/src/renderers/swipeLayoutVisibility.ts
@@ -1,0 +1,147 @@
+import type Ajv from 'ajv';
+import {
+  isControl,
+  isVisible,
+  type UISchemaElement,
+} from '@jsonforms/core';
+
+/**
+ * Same visibility semantics as JsonForms renderers (see mapStateToControlProps /
+ * mapStateToLayoutProps): `dispatchPath` is the path from the parent JsonFormsDispatch,
+ * not the composed data path.
+ */
+export function jsonFormsIsVisible(
+  element: UISchemaElement,
+  rootData: unknown,
+  dispatchPath: string,
+  ajv: Ajv,
+  config: unknown,
+): boolean {
+  return isVisible(element, rootData, dispatchPath, ajv, config);
+}
+
+/**
+ * Material layout renderers pass the same `path` to every child
+ * (see @jsonforms/material-renderers `renderLayoutElements`).
+ * Array / detail layouts may differ; extend here if formplayer adds those inside swipe pages.
+ */
+export function dispatchPathForLayoutChild(parentDispatchPath: string): string {
+  return parentDispatchPath ?? '';
+}
+
+function subtreeHasVisibleInteractiveContent(
+  element: UISchemaElement,
+  rootData: unknown,
+  dispatchPath: string,
+  ajv: Ajv,
+  config: unknown,
+): boolean {
+  if (!jsonFormsIsVisible(element, rootData, dispatchPath, ajv, config)) {
+    return false;
+  }
+  if (isControl(element)) {
+    return true;
+  }
+  const children = (element as { elements?: UISchemaElement[] }).elements;
+  if (!Array.isArray(children) || children.length === 0) {
+    return false;
+  }
+  const childPath = dispatchPathForLayoutChild(dispatchPath);
+  for (const child of children) {
+    if (subtreeHasVisibleInteractiveContent(child, rootData, childPath, ajv, config)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Whether a swipe "screen" should participate in next/prev/progress.
+ * - Finalize is always included (matches legacy SwipeLayout behavior).
+ * - Label-only screens do not count as interactive; nested Groups are walked.
+ */
+export function pageIsVisibleInSwipe(
+  page: UISchemaElement,
+  rootData: unknown,
+  dispatchPath: string,
+  ajv: Ajv,
+  config: unknown,
+): boolean {
+  if (!page) {
+    return false;
+  }
+  const typed = page as { type?: string; elements?: UISchemaElement[] };
+
+  if (typed.type === 'Finalize') {
+    return true;
+  }
+
+  if (!jsonFormsIsVisible(page, rootData, dispatchPath, ajv, config)) {
+    return false;
+  }
+
+  if (isControl(page)) {
+    return true;
+  }
+
+  if (!typed.elements || typed.elements.length === 0) {
+    return true;
+  }
+
+  const childPath = dispatchPathForLayoutChild(dispatchPath);
+  return typed.elements.some((child) =>
+    subtreeHasVisibleInteractiveContent(child, rootData, childPath, ajv, config),
+  );
+}
+
+export function visiblePageIndicesFromLayouts(
+  layouts: UISchemaElement[],
+  rootData: unknown,
+  swipeDispatchPath: string,
+  ajv: Ajv,
+  config: unknown,
+): number[] {
+  return layouts
+    .map((_, idx) => idx)
+    .filter((idx) =>
+      pageIsVisibleInSwipe(
+        layouts[idx],
+        rootData,
+        swipeDispatchPath,
+        ajv,
+        config,
+      ),
+    );
+}
+
+/** Depth-first list of Controls that JsonForms would treat as visible. */
+export function collectVisibleControlsInSubtree(
+  root: UISchemaElement,
+  rootData: unknown,
+  dispatchPath: string,
+  ajv: Ajv,
+  config: unknown,
+): UISchemaElement[] {
+  const controls: UISchemaElement[] = [];
+
+  function walk(el: UISchemaElement, path: string) {
+    if (!jsonFormsIsVisible(el, rootData, path, ajv, config)) {
+      return;
+    }
+    if (isControl(el)) {
+      controls.push(el);
+      return;
+    }
+    const els = (el as { elements?: UISchemaElement[] }).elements;
+    if (!Array.isArray(els)) {
+      return;
+    }
+    const childPath = dispatchPathForLayoutChild(path);
+    for (const c of els) {
+      walk(c, childPath);
+    }
+  }
+
+  walk(root, dispatchPath);
+  return controls;
+}


### PR DESCRIPTION
## Align SwipeLayout with JsonForms visibility

### Description

Swipe navigation (which pages exist, progress, auto-skip, and “required on this page”) was driven by **custom** condition evaluation that only matched a subset of JsonForms behavior. Complex UI rules (`AND` / `OR`, full JSON Schema via AJV, nested layouts) could disagree with what JsonForms actually renders, so surveys could show wrong steps or counts compared to the same `rule` definitions elsewhere.

### What changed

- **`swipeLayoutVisibility.ts`** (new): centralizes visibility using `@jsonforms/core` **`isVisible`**, with the same **`ajv`** and **`config`** as the rest of the form (`useJsonForms`), and **`dispatchPath`** semantics aligned with material layout renderers (same path passed to layout children unless we extend for array/detail layouts later).
- **`pageIsVisibleInSwipe`**: a page counts for swipe flow if JsonForms would show it **and** it has **visible interactive content** (DFS over nested `Group` / layouts; **`Control`** counts; label-only pages do not). **`Finalize`** stays always included to match prior behavior.
- **`visiblePageIndicesFromLayouts`** and **`collectVisibleControlsInSubtree`** support paging, progress, auto-skip, and required-field checks on the **currently visible** controls only.
- **`SwipeLayoutRenderer.tsx`**: wires the above in place of the old local visibility helpers; uses **`core.ajv`** with a **`createAjv()`** fallback when needed.
- **`swipeLayoutVisibility.test.ts`**: Vitest coverage for nested groups, `SHOW` + const, `Finalize`, and related helpers.

Forward navigation when required fields are missing still surfaces feedback (e.g. snackbar / modal copy) without hard-blocking advance, consistent with the chosen UX for this pass.

### How to test

- Open a form with **`SwipeLayout`** and rich **`rule`** trees (e.g. `type: "AND"`, enums, nested `VerticalLayout` / `Group`).
- Toggle answers and confirm **next/prev**, **progress**, and **skipped empty pages** track the same visible screens JsonForms would show.
- Run formplayer tests: `vitest` (or your package script) including `swipeLayoutVisibility.test.ts`.

Closes #625