### PR TITLE
fix(desktop): bound parallel JSON reads during import validation

### DIFF
--- a/desktop/src/lib/importSummary.ts
+++ b/desktop/src/lib/importSummary.ts
@@ -147,19 +147,71 @@ export function summarizeImportFiles(
   };
 }
 
+/** Run async work on `items` with at most `concurrency` in flight (order preserved). */
+export async function mapPool<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const n = items.length;
+  if (n === 0) {
+    return [];
+  }
+  const results: R[] = new Array(n);
+  let next = 0;
+  const limit = Math.max(1, Math.min(concurrency, n));
+
+  async function slot(): Promise<void> {
+    while (true) {
+      const i = next++;
+      if (i >= n) {
+        return;
+      }
+      results[i] = await worker(items[i], i);
+    }
+  }
+
+  await Promise.all(Array.from({ length: limit }, () => slot()));
+  return results;
+}
+
+const DEFAULT_JSON_READ_CONCURRENCY = 12;
+
+export async function parseObservationJsonFiles(
+  files: readonly File[],
+  concurrency = DEFAULT_JSON_READ_CONCURRENCY,
+): Promise<ParsedObservationFile[]> {
+  return mapPool(files, concurrency, (file, _i) =>
+    parseObservationJsonFile(file),
+  );
+}
+
 export async function parseObservationJsonFile(
   file: File,
 ): Promise<ParsedObservationFile> {
   const fileName = file.name;
+  let text: string;
   try {
-    const text = await file.text();
+    text = await file.text();
+  } catch (e) {
+    const hint =
+      e instanceof Error && e.name === 'NotReadableError'
+        ? ' (try validating again; parallel read limit)'
+        : '';
+    return {
+      fileName,
+      observations: [],
+      error: `Could not read file${hint}`,
+    };
+  }
+  try {
     const root = JSON.parse(text) as unknown;
     const { observations, error } = extractObservationsFromJson(root, fileName);
     if (error) {
       return { fileName, observations: [], error };
     }
     return { fileName, observations };
-  } catch {
+  } catch (_e) {
     return { fileName, observations: [], error: 'Invalid JSON' };
   }
 }

--- a/desktop/src/pages/ImportPage.tsx
+++ b/desktop/src/pages/ImportPage.tsx
@@ -8,7 +8,7 @@ import {
 import type { BundleFormSpec } from '../types/domain';
 import {
   flattenObservations,
-  parseObservationJsonFile,
+  parseObservationJsonFiles,
   summarizeImportFiles,
 } from '../lib/importSummary';
 import {
@@ -117,8 +117,8 @@ export function ImportPage() {
     setMessage(null);
     setError(null);
     try {
-      const parsed = await Promise.all(
-        stagedJson.map(s => parseObservationJsonFile(s.file)),
+      const parsed = await parseObservationJsonFiles(
+        stagedJson.map(s => s.file),
       );
       const formTypes = new Set<string>();
       for (const p of parsed) {


### PR DESCRIPTION
## Description
Large drops of observation JSON files could trigger **`NotReadableError`** (Invalid JSON) when the UI read every file’s contents at once via **`File.text()`**. This change caps how many reads run in parallel so validation stays reliable on big batches.

### What changed
- **`desktop/src/lib/importSummary.ts`** Added **`mapPool`** (bounded concurrency, default **12**) and routed **`parseObservationJsonFiles`** through it. **`parseObservationJsonFile`** still parses JSON and surfaces read failures; **`NotReadableError`** keeps a short hint to retry validation after load settles.
- **`desktop/src/pages/ImportPage.tsx`** Validation continues to use **`parseObservationJsonFiles`** for staged JSON; wiring stays aligned with the helper above.

### How to verify
1. Build/run ODE Desktop, open **Import**, stage **hundreds** of observation `.json` files (plus attachments if you like).
2. Run **Validate** (or the flow that parses staged JSON).
3. Confirm no mass **`NotReadableError`** / bogus “invalid JSON” from read contention; failures should only reflect real read/parse issues.