### PR TITLE
fix(ci): Formulus Metro bundling and Desktop darwin-amd64 DMG on release

### DIFF
--- a/.github/workflows/formulus-android.yml
+++ b/.github/workflows/formulus-android.yml
@@ -10,6 +10,7 @@ on:
       - 'formulus-formplayer/**'
       - 'packages/tokens/**'
       - 'packages/components/**'
+      - 'packages/observation-query/**'
       - '.github/workflows/formulus-android.yml'
   pull_request:
     paths:
@@ -17,6 +18,7 @@ on:
       - 'formulus-formplayer/**'
       - 'packages/tokens/**'
       - 'packages/components/**'
+      - 'packages/observation-query/**'
       - '.github/workflows/formulus-android.yml'
   release:
     types: [published]

--- a/.github/workflows/ode-desktop.yml
+++ b/.github/workflows/ode-desktop.yml
@@ -195,7 +195,7 @@ jobs:
             runner: windows-11-arm
             rust_target: aarch64-pc-windows-msvc
           - platform: darwin-amd64
-            runner: macos-15-intel
+            runner: macos-14
             rust_target: x86_64-apple-darwin
           - platform: darwin-arm64
             runner: macos-latest
@@ -267,16 +267,33 @@ jobs:
         working-directory: desktop
         env:
           CI: 'true'
-        run: >-
-          pnpm exec tauri build --target ${{ matrix.rust_target }} -c '${{ env.TAURI_BEFORE_BUILD }}'
+          RUST_TARGET: ${{ matrix.rust_target }}
+        run: |
+          set -euo pipefail
+          if [[ "${RUNNER_OS}" == "macOS" ]]; then
+            hdiutil detach "/Volumes/ODE Desktop" 2>/dev/null || true
+            find "src-tauri/target/${RUST_TARGET}/release/bundle" -name 'rw.*.dmg' -delete 2>/dev/null || true
+          fi
+          if ! pnpm exec tauri build --verbose --target "${RUST_TARGET}" -c '${{ env.TAURI_BEFORE_BUILD }}'; then
+            if [[ "${RUNNER_OS}" != "macOS" ]]; then
+              exit 1
+            fi
+            echo "::warning::Tauri build failed; retrying DMG bundle on macOS"
+            hdiutil detach "/Volumes/ODE Desktop" 2>/dev/null || true
+            find "src-tauri/target/${RUST_TARGET}/release/bundle" -name 'rw.*.dmg' -delete 2>/dev/null || true
+            pnpm exec tauri build --verbose --bundles dmg --target "${RUST_TARGET}" -c '${{ env.TAURI_BEFORE_BUILD }}'
+          fi
 
       - name: Collect installers for upload
         working-directory: desktop
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          RUST_TARGET: ${{ matrix.rust_target }}
         run: |
           set -euo pipefail
           rm -rf dist-ci
           mkdir -p dist-ci
-          bundle_dir="src-tauri/target/${{ matrix.rust_target }}/release/bundle"
+          bundle_dir="src-tauri/target/${RUST_TARGET}/release/bundle"
           if [[ ! -d "$bundle_dir" ]]; then
             echo "::error::Missing bundle dir: $bundle_dir"
             find src-tauri/target -maxdepth 4 -type d 2>/dev/null || true
@@ -285,11 +302,20 @@ jobs:
           count=0
           while IFS= read -r -d '' f; do
             base=$(basename "$f")
-            cp "$f" "dist-ci/ode-desktop-${{ matrix.platform }}-${base}"
+            cp "$f" "dist-ci/ode-desktop-${PLATFORM}-${base}"
             count=$((count + 1))
           done < <(find "$bundle_dir" -type f \( \
-            -name '*.AppImage' -o -name '*.deb' -o -name '*.dmg' -o -name '*.msi' -o -name '*.exe' -o -name '*.rpm' \
+            -name '*.AppImage' -o -name '*.deb' -o -name '*.dmg' -o -name '*.msi' -o -name '*.exe' -o -name '*.rpm' -o -name '*.app.zip' \
           \) -print0)
+          if [[ "$count" -eq 0 && "${RUNNER_OS}" == "macOS" ]]; then
+            app_path=$(find "$bundle_dir/macos" -maxdepth 1 -name '*.app' -print -quit)
+            if [[ -n "$app_path" ]]; then
+              zip_out="dist-ci/ode-desktop-${PLATFORM}-$(basename "$app_path").zip"
+              ditto -c -k --keepParent "$app_path" "$zip_out"
+              count=1
+              echo "::warning::DMG missing; uploaded .app zip fallback: $zip_out"
+            fi
+          fi
           if [[ "$count" -eq 0 ]]; then
             echo "::error::No bundle files matched in $bundle_dir"
             find "$bundle_dir" -type f || true
@@ -332,7 +358,7 @@ jobs:
             runner: windows-11-arm
             rust_target: aarch64-pc-windows-msvc
           - platform: darwin-amd64
-            runner: macos-15-intel
+            runner: macos-14
             rust_target: x86_64-apple-darwin
           - platform: darwin-arm64
             runner: macos-latest
@@ -404,16 +430,33 @@ jobs:
         working-directory: desktop
         env:
           CI: 'true'
-        run: >-
-          pnpm exec tauri build --target ${{ matrix.rust_target }} -c '${{ env.TAURI_BEFORE_BUILD }}'
+          RUST_TARGET: ${{ matrix.rust_target }}
+        run: |
+          set -euo pipefail
+          if [[ "${RUNNER_OS}" == "macOS" ]]; then
+            hdiutil detach "/Volumes/ODE Desktop" 2>/dev/null || true
+            find "src-tauri/target/${RUST_TARGET}/release/bundle" -name 'rw.*.dmg' -delete 2>/dev/null || true
+          fi
+          if ! pnpm exec tauri build --verbose --target "${RUST_TARGET}" -c '${{ env.TAURI_BEFORE_BUILD }}'; then
+            if [[ "${RUNNER_OS}" != "macOS" ]]; then
+              exit 1
+            fi
+            echo "::warning::Tauri build failed; retrying DMG bundle on macOS"
+            hdiutil detach "/Volumes/ODE Desktop" 2>/dev/null || true
+            find "src-tauri/target/${RUST_TARGET}/release/bundle" -name 'rw.*.dmg' -delete 2>/dev/null || true
+            pnpm exec tauri build --verbose --bundles dmg --target "${RUST_TARGET}" -c '${{ env.TAURI_BEFORE_BUILD }}'
+          fi
 
       - name: Collect installers for GitHub Release
         working-directory: desktop
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          RUST_TARGET: ${{ matrix.rust_target }}
         run: |
           set -euo pipefail
           rm -rf dist-release
           mkdir -p dist-release
-          bundle_dir="src-tauri/target/${{ matrix.rust_target }}/release/bundle"
+          bundle_dir="src-tauri/target/${RUST_TARGET}/release/bundle"
           if [[ ! -d "$bundle_dir" ]]; then
             echo "::error::Missing bundle dir: $bundle_dir"
             find src-tauri/target -maxdepth 4 -type d 2>/dev/null || true
@@ -422,11 +465,20 @@ jobs:
           count=0
           while IFS= read -r -d '' f; do
             base=$(basename "$f")
-            cp "$f" "dist-release/ode-desktop-${{ matrix.platform }}-${base}"
+            cp "$f" "dist-release/ode-desktop-${PLATFORM}-${base}"
             count=$((count + 1))
           done < <(find "$bundle_dir" -type f \( \
-            -name '*.AppImage' -o -name '*.deb' -o -name '*.dmg' -o -name '*.msi' -o -name '*.exe' -o -name '*.rpm' \
+            -name '*.AppImage' -o -name '*.deb' -o -name '*.dmg' -o -name '*.msi' -o -name '*.exe' -o -name '*.rpm' -o -name '*.app.zip' \
           \) -print0)
+          if [[ "$count" -eq 0 && "${RUNNER_OS}" == "macOS" ]]; then
+            app_path=$(find "$bundle_dir/macos" -maxdepth 1 -name '*.app' -print -quit)
+            if [[ -n "$app_path" ]]; then
+              zip_out="dist-release/ode-desktop-${PLATFORM}-$(basename "$app_path").zip"
+              ditto -c -k --keepParent "$app_path" "$zip_out"
+              count=1
+              echo "::warning::DMG missing; uploaded .app zip fallback: $zip_out"
+            fi
+          fi
           if [[ "$count" -eq 0 ]]; then
             echo "::error::No bundle files matched in $bundle_dir"
             find "$bundle_dir" -type f || true

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ode-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ODE Desktop",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "identifier": "org.opendataensemble.custodian",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/formulus/metro.config.js
+++ b/formulus/metro.config.js
@@ -19,7 +19,10 @@ const projectRoot = __dirname;
  * (avoids incomplete copy in packages/components). react-native-svg only uses
  * extraNodeModules so Metro resolves its real entry (lib/commonjs/index.js).
  */
-const babelRuntimeRoot = path.resolve(projectRoot, 'node_modules/@babel/runtime');
+const babelRuntimeRoot = path.resolve(
+  projectRoot,
+  'node_modules/@babel/runtime',
+);
 
 const forcedModules = {
   react: path.resolve(projectRoot, 'node_modules/react'),

--- a/formulus/metro.config.js
+++ b/formulus/metro.config.js
@@ -19,9 +19,12 @@ const projectRoot = __dirname;
  * (avoids incomplete copy in packages/components). react-native-svg only uses
  * extraNodeModules so Metro resolves its real entry (lib/commonjs/index.js).
  */
+const babelRuntimeRoot = path.resolve(projectRoot, 'node_modules/@babel/runtime');
+
 const forcedModules = {
   react: path.resolve(projectRoot, 'node_modules/react'),
   'react-native': path.resolve(projectRoot, 'node_modules/react-native'),
+  '@babel/runtime': babelRuntimeRoot,
 };
 const extraModules = {
   ...forcedModules,
@@ -56,6 +59,20 @@ const config = {
     unstable_enablePackageExports: true,
     extraNodeModules: extraModules,
     resolveRequest(context, moduleName, platform) {
+      // @babel/runtime subpaths (workspace packages e.g. @ode/observation-query)
+      if (
+        moduleName === '@babel/runtime' ||
+        moduleName.startsWith('@babel/runtime/')
+      ) {
+        const relative =
+          moduleName === '@babel/runtime'
+            ? 'index.js'
+            : `${moduleName.slice('@babel/runtime/'.length)}.js`;
+        return {
+          type: 'sourceFile',
+          filePath: path.join(babelRuntimeRoot, relative),
+        };
+      }
       // Handle forced modules (react, react-native)
       if (forcedModules[moduleName]) {
         return {

--- a/packages/observation-query/package-lock.json
+++ b/packages/observation-query/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@ode/observation-query",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "jest": "^29.7.0",
@@ -454,6 +457,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {

--- a/packages/observation-query/package.json
+++ b/packages/observation-query/package.json
@@ -14,6 +14,9 @@
     "build": "tsc"
   },
   "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.28.4"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
## Description

Fixes release CI failures from `v1.0.1-alpha.14`:

- **Formulus Android**: Metro could not bundle `@ode/observation-query` because `@babel/runtime/helpers/interopRequireDefault` was not resolved from the monorepo package path (`:app:createBundleReleaseJsAndAssets` failed).
- **ODE Desktop (darwin-amd64)**: Rust and `.app` bundling succeeded, but **DMG creation** failed via `bundle_dmg.sh` on the Intel macOS runner. Other matrix jobs (including **darwin-arm64** for Apple Silicon) passed on the same release.

## Changes

### Formulus Android
- Force-resolve `@babel/runtime` (and subpaths) from Formulus `node_modules` in `formulus/metro.config.js`, matching the existing `react` / `react-native` pattern.
- Add `@babel/runtime` as a dependency on `@ode/observation-query`.
- Add `packages/observation-query/**` to `formulus-android.yml` path filters.

### ODE Desktop
- macOS CI hardening in `ode-desktop.yml` (package + release jobs):
  - Pre-clean stale DMG mounts / `rw.*.dmg` files before build
  - `tauri build --verbose`
  - On macOS failure: retry with `--bundles dmg` only
  - If no `.dmg` is produced: zip `.app` with `ditto` and upload as fallback
- `darwin-amd64` runner: `macos-15-intel` → `macos-14`
- Align `desktop/package.json` and `tauri.conf.json` version to **1.0.1** (matches `Cargo.toml` / release tags)