### PR TITLE
fix: restore observation-index query results on mobile

### DIFF
--- a/formulus/src/database/__tests__/observationIndex.test.ts
+++ b/formulus/src/database/__tests__/observationIndex.test.ts
@@ -22,6 +22,7 @@ jest.mock('../../services/AppConfigService', () => ({
   __esModule: true,
   default: {
     getInstance: jest.fn(() => ({
+      loadConfig: jest.fn(async () => undefined),
       getConfig: jest.fn(() => ({
         observationIndexes: [
           { key: 'p_id', path: '$.p_id' },

--- a/formulus/src/database/repositories/WatermelonDBRepo.ts
+++ b/formulus/src/database/repositories/WatermelonDBRepo.ts
@@ -50,6 +50,9 @@ export class WatermelonDBRepo implements LocalRepoInterface {
     this.database = database;
     this.observationsCollection =
       database.get<ObservationModel>('observations');
+    // Touch the index service early so the `bundleUpdated` listener and the
+    // initial-rebuild bootstrap kick off before any sync activity.
+    ObservationIndexService.getInstance(this.database);
   }
 
   /**
@@ -251,9 +254,10 @@ export class WatermelonDBRepo implements LocalRepoInterface {
     filter?: ObservationFilter;
   }): Promise<Observation[]> {
     try {
-      const indexKeys = indexKeysFromConfig(
-        ObservationIndexService.getInstance(this.database).getIndexDefs(),
-      );
+      const indexService = ObservationIndexService.getInstance(this.database);
+      await indexService.ensureInitialRebuild();
+
+      const indexKeys = indexKeysFromConfig(indexService.getIndexDefs());
       const compiled = compileObservationQuery({
         dialect: 'formulus',
         jsonColumn: 'data',
@@ -599,17 +603,15 @@ export class WatermelonDBRepo implements LocalRepoInterface {
     });
 
     const indexService = ObservationIndexService.getInstance(this.database);
-    for (const change of changes) {
-      const dataJson =
+    const indexRows = changes.map(change => ({
+      observationId: change.observationId,
+      formType: change.formType,
+      dataJson:
         typeof change.data === 'string'
           ? change.data
-          : JSON.stringify(change.data);
-      await indexService.incrementalReindex(
-        change.observationId,
-        change.formType,
-        dataJson,
-      );
-    }
+          : JSON.stringify(change.data),
+    }));
+    await indexService.incrementalReindexMany(indexRows);
 
     return count;
   }

--- a/formulus/src/database/repositories/__tests__/WatermelonDBRepo.test.ts
+++ b/formulus/src/database/repositories/__tests__/WatermelonDBRepo.test.ts
@@ -17,13 +17,22 @@ jest.mock('../../../api/synkronus/Auth', () => ({
 
 jest.mock('../../../services/ObservationIndexService', () => {
   const incrementalReindex = jest.fn(async () => undefined);
+  const incrementalReindexMany = jest.fn(async () => undefined);
   const getIndexDefs = jest.fn(() => []);
+  const ensureInitialRebuild = jest.fn(async () => undefined);
+  const rebuildAllIndexes = jest.fn(async () => ({
+    generation: 1,
+    lastRebuildAt: null,
+  }));
   return {
     __esModule: true,
     default: {
       getInstance: jest.fn(() => ({
         incrementalReindex,
+        incrementalReindexMany,
         getIndexDefs,
+        ensureInitialRebuild,
+        rebuildAllIndexes,
       })),
     },
   };

--- a/formulus/src/services/ObservationIndexService.ts
+++ b/formulus/src/services/ObservationIndexService.ts
@@ -1,6 +1,15 @@
 /**
  * Maintains local observation_index EAV rows (never synced).
  * Rebuild uses snapshot generation swap; incremental updates on save/sync.
+ *
+ * Implementation notes:
+ *  - All write paths collect SQL into an array and flush once via
+ *    `db.adapter.unsafeExecute({ sqls })` inside a single `db.write(...)`
+ *    block. This avoids nested `db.write` calls, which deadlock under
+ *    WatermelonDB's serial WorkQueue.
+ *  - `ensureInitialRebuild()` runs on first instantiation to populate the
+ *    index for users who already have synced rows from before indexing
+ *    landed.
  */
 import { Database, Q } from '@nozbe/watermelondb';
 import { database } from '../database/database';
@@ -10,6 +19,7 @@ import { appEvents } from '../webview/FormulusMessageHandlers';
 import type { ObservationIndexDef } from '../types/AppConfig';
 
 type SqlArg = string | number | boolean | null;
+type SqlStatement = [string, SqlArg[]];
 
 function formTypeMatches(formType: string, patterns?: string[]): boolean {
   if (!patterns?.length) return true;
@@ -50,17 +60,25 @@ function extractScalar(dataJson: string, path: string): unknown {
 export class ObservationIndexService {
   private static instance: ObservationIndexService;
   private readonly db: Database;
+  private initialRebuildPromise: Promise<void> | null = null;
+  private initialRebuildFinished = false;
 
   private constructor(db: Database) {
     this.db = db;
     appEvents.addListener('bundleUpdated', () => {
-      void this.rebuildAllIndexes().catch(err => {
-        console.warn(
-          '[ObservationIndexService] rebuild after bundle failed:',
-          err,
-        );
-      });
+      void (async () => {
+        try {
+          await AppConfigService.getInstance().loadConfig(/* force */ true);
+          await this.rebuildAllIndexes();
+        } catch (err) {
+          console.warn(
+            '[ObservationIndexService] rebuild after bundle failed:',
+            err,
+          );
+        }
+      })();
     });
+    void this.ensureInitialRebuild();
   }
 
   static getInstance(db: Database = database): ObservationIndexService {
@@ -73,6 +91,10 @@ export class ObservationIndexService {
   getIndexDefs(): ObservationIndexDef[] {
     const cfg = AppConfigService.getInstance().getConfig();
     return (cfg?.observationIndexes ?? []).filter(d => d.key && d.path);
+  }
+
+  getInitialRebuildFinished(): boolean {
+    return this.initialRebuildFinished;
   }
 
   async getStatus(): Promise<{
@@ -93,27 +115,80 @@ export class ObservationIndexService {
     };
   }
 
+  /**
+   * Run a one-time rebuild on app boot when the index looks empty or
+   * unstamped. Memoised so repeated callers share a single in-flight
+   * rebuild. Waits for `AppConfigService.loadConfig()` so the rebuild uses
+   * up-to-date index defs.
+   */
+  ensureInitialRebuild(): Promise<void> {
+    if (this.initialRebuildPromise) return this.initialRebuildPromise;
+    this.initialRebuildPromise = (async () => {
+      try {
+        await AppConfigService.getInstance()
+          .loadConfig()
+          .catch(err => {
+            console.warn(
+              '[ObservationIndexService] loadConfig before initial rebuild failed:',
+              err,
+            );
+          });
+
+        const status = await this.getStatus();
+        const indexCountRows = await this.query<{ cnt: number }>(
+          'SELECT COUNT(*) AS cnt FROM observation_index',
+        );
+        const indexCount = indexCountRows[0]?.cnt ?? 0;
+
+        const obsCountRows = await this.query<{ cnt: number }>(
+          'SELECT COUNT(*) AS cnt FROM observations',
+        );
+        const observationCount = obsCountRows[0]?.cnt ?? 0;
+
+        const skipBecausePopulated =
+          Boolean(status.lastRebuildAt) && indexCount > 0;
+        const skipBecauseEmptyInstall =
+          observationCount === 0 && Boolean(status.lastRebuildAt);
+
+        if (skipBecausePopulated) {
+          this.initialRebuildFinished = true;
+          return;
+        }
+
+        if (skipBecauseEmptyInstall) {
+          this.initialRebuildFinished = true;
+          return;
+        }
+
+        await this.rebuildAllIndexes();
+        this.initialRebuildFinished = true;
+      } catch (err) {
+        console.warn('[ObservationIndexService] initial rebuild failed:', err);
+        // Allow a future caller to retry.
+        this.initialRebuildPromise = null;
+      }
+    })();
+    return this.initialRebuildPromise;
+  }
+
   async rebuildAllIndexes(): Promise<{
     generation: number;
     lastRebuildAt: string | null;
   }> {
     const defs = this.getIndexDefs();
+    // Always rebuild in-place on generation 1. The previous 1↔2 swap wrote
+    // index rows to the new generation but the meta active_generation UPDATE
+    // did not persist on device (runtime logs: gen-2 rows, activeGeneration=1).
+    const gen = 1;
     return this.db.write(async () => {
-      const activeRows = await this.query<{ active_generation: number }>(
-        'SELECT active_generation FROM observation_index_meta WHERE id = ?',
-        ['meta'],
-      );
-      const active = activeRows[0]?.active_generation ?? 1;
-      const newGen = active === 1 ? 2 : 1;
-
-      await this.execute(
-        'UPDATE observation_index_meta SET building_generation = ? WHERE id = ?',
-        [newGen, 'meta'],
-      );
-      await this.execute(
-        'DELETE FROM observation_index WHERE index_generation = ?',
-        [newGen],
-      );
+      await this.db.adapter.unsafeExecute({
+        sqls: [
+          [
+            `INSERT OR IGNORE INTO observation_index_meta(id, active_generation) VALUES (?, ?)`,
+            ['meta', gen],
+          ],
+        ],
+      });
 
       const observations = await this.query<{
         id: string;
@@ -121,31 +196,42 @@ export class ObservationIndexService {
         data: string;
       }>('SELECT id, form_type, data FROM observations');
 
+      const sqls: SqlStatement[] = [];
+      sqls.push(['DELETE FROM observation_index', []]);
+
       for (const obs of observations) {
-        await this.reindexObservationRow(
+        this.collectReindexStatements(
           obs.id,
           obs.form_type ?? '',
           obs.data,
           defs,
-          newGen,
+          gen,
+          sqls,
         );
       }
 
-      await this.recreateSqliteIndexes(defs);
+      this.collectSqliteIndexStatements(defs, sqls);
 
-      await this.execute(
-        'DELETE FROM observation_index WHERE index_generation != ?',
-        [newGen],
-      );
-      await this.execute(
-        `UPDATE observation_index_meta
-         SET active_generation = ?, building_generation = NULL, last_rebuild_at = datetime('now')
-         WHERE id = ?`,
-        [newGen, 'meta'],
-      );
+      await this.flush(sqls);
 
-      const status = await this.getStatus();
-      return { generation: newGen, lastRebuildAt: status.lastRebuildAt };
+      // Stamp meta in a separate execute; batched meta UPDATE was not sticking.
+      await this.db.adapter.unsafeExecute({
+        sqls: [
+          [
+            `UPDATE observation_index_meta
+             SET active_generation = ?, building_generation = NULL, last_rebuild_at = datetime('now')
+             WHERE id = ?`,
+            [gen, 'meta'],
+          ],
+        ],
+      });
+
+      const metaAfter = await this.getStatus();
+
+      return {
+        generation: gen,
+        lastRebuildAt: metaAfter.lastRebuildAt,
+      };
     });
   }
 
@@ -156,63 +242,114 @@ export class ObservationIndexService {
   ): Promise<void> {
     const defs = this.getIndexDefs();
     if (!defs.length) return;
-    const status = await this.getStatus();
     await this.db.write(async () => {
-      await this.reindexObservationRow(
+      const generation = await this.readActiveGeneration();
+      const sqls: SqlStatement[] = [];
+      this.collectReindexStatements(
         observationId,
         formType,
         dataJson,
         defs,
-        status.activeGeneration,
+        generation,
+        sqls,
       );
+      await this.flush(sqls);
     });
   }
 
-  private async reindexObservationRow(
+  /**
+   * Reindex many observations in a single batched write. Used by sync paths
+   * that ingest large numbers of rows.
+   */
+  async incrementalReindexMany(
+    rows: Array<{ observationId: string; formType: string; dataJson: string }>,
+  ): Promise<void> {
+    const defs = this.getIndexDefs();
+    if (!defs.length || rows.length === 0) return;
+    await this.db.write(async () => {
+      const generation = await this.readActiveGeneration();
+      const sqls: SqlStatement[] = [];
+      for (const r of rows) {
+        this.collectReindexStatements(
+          r.observationId,
+          r.formType,
+          r.dataJson,
+          defs,
+          generation,
+          sqls,
+        );
+      }
+      await this.flush(sqls);
+    });
+  }
+
+  /**
+   * Read the active generation while a writer is in flight. Used by
+   * incremental paths so they don't pin a stale generation when a rebuild
+   * commits a swap concurrently.
+   */
+  private async readActiveGeneration(): Promise<number> {
+    const rows = await this.query<{ active_generation: number }>(
+      'SELECT active_generation FROM observation_index_meta WHERE id = ?',
+      ['meta'],
+    );
+    return rows[0]?.active_generation ?? 1;
+  }
+
+  private collectReindexStatements(
     observationId: string,
     formType: string,
     dataJson: string,
     defs: ObservationIndexDef[],
     generation: number,
-  ): Promise<void> {
-    await this.execute(
+    out: SqlStatement[],
+  ): void {
+    out.push([
       'DELETE FROM observation_index WHERE observation_id = ? AND index_generation = ?',
       [observationId, generation],
-    );
+    ]);
     for (const def of defs) {
       if (!formTypeMatches(formType, def.formTypes)) continue;
       const val = extractScalar(dataJson, def.path);
       if (val == null) continue;
       const { valueText, valueNum } = scalarToColumns(val, def.valueType);
       const rowId = `${observationId}:${def.key}:${generation}`;
-      await this.execute(
+      out.push([
         `INSERT OR REPLACE INTO observation_index
          (id, observation_id, index_key, index_generation, value_text, value_num)
          VALUES (?, ?, ?, ?, ?, ?)`,
         [rowId, observationId, def.key, generation, valueText, valueNum],
-      );
+      ]);
     }
   }
 
-  private async recreateSqliteIndexes(
+  private collectSqliteIndexStatements(
     defs: ObservationIndexDef[],
-  ): Promise<void> {
+    out: SqlStatement[],
+  ): void {
     for (const def of defs) {
       const safeKey = def.key.replace(/[^a-zA-Z0-9_]/g, '_');
       const idxName = `idx_${safeKey}_text`;
-      await this.execute(`DROP INDEX IF EXISTS ${idxName}`);
-      await this.execute(
+      out.push([`DROP INDEX IF EXISTS ${idxName}`, []]);
+      out.push([
         `CREATE INDEX IF NOT EXISTS ${idxName} ON observation_index(value_text) WHERE index_key = '${def.key.replace(/'/g, "''")}'`,
-      );
+        [],
+      ]);
       if (def.enableExpressionIndex !== false) {
         const exprName = `data_${safeKey}`;
         const jsonPath = def.path.startsWith('$.') ? def.path : `$.${def.path}`;
-        await this.execute(`DROP INDEX IF EXISTS ${exprName}`);
-        await this.execute(
+        out.push([`DROP INDEX IF EXISTS ${exprName}`, []]);
+        out.push([
           `CREATE INDEX IF NOT EXISTS ${exprName} ON observations(json_extract(data, '${jsonPath.replace(/'/g, "''")}'))`,
-        );
+          [],
+        ]);
       }
     }
+  }
+
+  private async flush(sqls: SqlStatement[]): Promise<void> {
+    if (sqls.length === 0) return;
+    await this.db.adapter.unsafeExecute({ sqls });
   }
 
   private observationsQuery() {
@@ -226,14 +363,6 @@ export class ObservationIndexService {
     return (await this.observationsQuery()
       .query(Q.unsafeSqlQuery(sql, args))
       .unsafeFetchRaw()) as T[];
-  }
-
-  private async execute(sql: string, args: SqlArg[] = []): Promise<void> {
-    await this.db.write(async () => {
-      await this.db.adapter.unsafeExecute({
-        sqls: [[sql, args]],
-      });
-    });
   }
 }
 

--- a/packages/observation-query/fixtures/wildcard_form_type.json
+++ b/packages/observation-query/fixtures/wildcard_form_type.json
@@ -1,0 +1,14 @@
+{
+  "name": "wildcard_form_type",
+  "jsonColumn": "data",
+  "formType": "*",
+  "includeDeleted": false,
+  "indexKeys": ["hh_id"],
+  "filter": {
+    "field": "data.hh_id",
+    "op": "eq",
+    "value": "HH-42"
+  },
+  "expectedSqlFragments": ["index_key", "value_text"],
+  "expectError": false
+}

--- a/packages/observation-query/src/compiler.test.ts
+++ b/packages/observation-query/src/compiler.test.ts
@@ -39,6 +39,55 @@ function loadFixtures(): FixtureFile[] {
     .map((f) => JSON.parse(fs.readFileSync(path.join(fixturesDir, f), 'utf8')) as FixtureFile);
 }
 
+describe('ObservationQueryCompiler form_type wildcard', () => {
+  it("omits the form_type = ? predicate when formType is '*'", () => {
+    const result = compileObservationQuery({
+      dialect: 'formulus',
+      jsonColumn: 'data',
+      tableAlias: 'observations',
+      observationsTable: 'observations',
+      indexKeys: new Set<string>(),
+      formType: '*',
+      includeDeleted: false,
+      filter: { field: 'data.hh_id', op: 'eq', value: 'HH-42' },
+    });
+    expect('sql' in result).toBe(true);
+    if (!('sql' in result)) return;
+    expect(result.sql).not.toContain('form_type');
+    expect(result.params).not.toContain('*');
+  });
+
+  it('omits the form_type predicate when formType is missing', () => {
+    const result = compileObservationQuery({
+      dialect: 'formulus',
+      jsonColumn: 'data',
+      tableAlias: 'observations',
+      observationsTable: 'observations',
+      indexKeys: new Set<string>(),
+      includeDeleted: false,
+    });
+    expect('sql' in result).toBe(true);
+    if (!('sql' in result)) return;
+    expect(result.sql).not.toContain('form_type');
+  });
+
+  it('keeps the form_type predicate for a concrete form type', () => {
+    const result = compileObservationQuery({
+      dialect: 'formulus',
+      jsonColumn: 'data',
+      tableAlias: 'observations',
+      observationsTable: 'observations',
+      indexKeys: new Set<string>(),
+      formType: 'household',
+      includeDeleted: false,
+    });
+    expect('sql' in result).toBe(true);
+    if (!('sql' in result)) return;
+    expect(result.sql).toContain('form_type = ?');
+    expect(result.params[0]).toBe('household');
+  });
+});
+
 describe('ObservationQueryCompiler fixtures', () => {
   const fixtures = loadFixtures();
 

--- a/packages/observation-query/src/compiler.ts
+++ b/packages/observation-query/src/compiler.ts
@@ -154,7 +154,7 @@ function compileCondition(
 
   const idxTable = options.indexTable ?? 'observation_index';
   const keyPh = pushParam(params, indexKey);
-  const genClause = `idx.index_generation = (SELECT active_generation FROM observation_index_meta LIMIT 1)`;
+  const genClause = `idx.index_generation = COALESCE((SELECT active_generation FROM observation_index_meta WHERE id = 'meta'), 1)`;
 
   if (cond.op === 'in') {
     const values = Array.isArray(cond.value) ? cond.value : [];
@@ -257,8 +257,14 @@ export function compileObservationQuery(
   const dialect = options.dialect ?? 'desktop';
   const observationsTable = options.observationsTable ?? 'observations';
   const warnings: string[] = [];
-  const whereParts: string[] = [`${alias}.form_type = ?`];
-  const params: Array<string | number | null> = [options.formType ?? ''];
+  const whereParts: string[] = [];
+  const params: Array<string | number | null> = [];
+
+  const formType = options.formType;
+  if (formType && formType !== '*') {
+    whereParts.push(`${alias}.form_type = ?`);
+    params.push(formType);
+  }
 
   if (!options.includeDeleted) {
     if (dialect === 'formulus') {
@@ -277,7 +283,9 @@ export function compileObservationQuery(
     params.push(...compiled.params);
   }
 
-  const sql = `SELECT ${alias}.* FROM ${observationsTable} ${alias} WHERE ${whereParts.join(' AND ')}`;
+  const whereClause =
+    whereParts.length > 0 ? ` WHERE ${whereParts.join(' AND ')}` : '';
+  const sql = `SELECT ${alias}.* FROM ${observationsTable} ${alias}${whereClause}`;
   return { sql, params, warnings };
 }
 


### PR DESCRIPTION


## Description

Fixes empty observation query results on Formulus (Android/iOS) after observation indexing landed in #635. Indexed filters such as “households by village” or “people by household” returned zero rows even when synced data existed locally.

## Problem

After #635, apps using indexed observation queries saw empty lists on Formulus mobile:

- Home screen: no households for a selected village
- Detail screens: no people for a household
- Unfiltered queries could still return rows, pointing to the index/query path rather than missing sync data

Verified on device with runtime logging: observations present in DB, index rows written, but compiled queries returned `resultCount: 0`.

## Root causes

1. **Nested `db.write` deadlock in `ObservationIndexService`**  
   `rebuildAllIndexes` / `incrementalReindex` opened `db.write`, then `execute()` opened another `db.write`. WatermelonDB serializes writes, so the inner write never ran and index rows often failed to persist.

2. **Generation mismatch on rebuild**  
   Rebuild wrote index rows to generation 2 while `observation_index_meta.active_generation` stayed at 1. Queries filtered on gen 1 → no matches despite populated index table.

3. **`formType: '*'` treated as literal in `@ode/observation-query`**  
   TypeScript compiler emitted `form_type = '*'`, breaking cross-form queries (e.g. Household/Person screens using `queryFormType(api, '*', …)`). Desktop Rust compiler already skipped `*`; TS did not.

4. **Meta subquery NULL vs defaulted status**  
   `getStatus()` defaulted `activeGeneration` to 1 when the meta row was missing, but the compiler used `(SELECT active_generation FROM observation_index_meta …)` without `COALESCE` → `index_generation = NULL` → no index matches.

5. **Race on first query (secondary)**  
   UI could query before the initial index rebuild completed on devices that already had synced observations from before indexing existed.

## Solution

### Formulus: `ObservationIndexService`
- Batch all index SQL into a single `unsafeExecute` per `db.write` block (no nested writes)
- Add `ensureInitialRebuild()` to bootstrap/rebuild when the index is empty or unstamped; memoised and waits for `AppConfigService.loadConfig()`
- Rebuild in-place on generation 1 (drop 1↔2 swap that caused gen mismatch on device)
- Ensure meta row exists via `INSERT OR IGNORE`; stamp meta in a separate execute
- Add `incrementalReindexMany()` for batched post-sync reindexing
- Reload config before rebuild on `bundleUpdated`

### Formulus: `WatermelonDBRepo`
- Eagerly init `ObservationIndexService` in constructor
- `queryObservations` awaits `ensureInitialRebuild()` before compiling
- `applyServerChanges` uses batched `incrementalReindexMany` instead of per-row awaits

### Shared: `@ode/observation-query` compiler
- Skip `form_type` filter when `formType` is `'*'` or missing (align with desktop)
- Use `COALESCE((SELECT active_generation FROM observation_index_meta WHERE id = 'meta'), 1)` in index generation clause

## Notes

- Index tables remain intentionally without WatermelonDB models (local-only, not synced) by design per #635.