### PR TITLE
fix: Formulus/honest sync progress and clearer Sync UI

### DIFF
--- a/formulus/src/api/synkronus/index.ts
+++ b/formulus/src/api/synkronus/index.ts
@@ -31,6 +31,12 @@ import {
 } from '../../errors/RepositoryResetRequiredError';
 import type { AxiosError, AxiosResponse } from 'axios';
 import { effectiveRepositoryGenerationForRequest } from './repositoryGenerationRequest';
+import {
+  formatCountProgress,
+  type SynkronusSyncOptions,
+  type SyncProgress,
+  type SyncProgressReporter,
+} from '../../sync/syncProgress';
 
 const REPOSITORY_GENERATION_STORAGE_KEY = '@repository_generation';
 
@@ -89,6 +95,19 @@ interface DownloadResult {
   message: string;
   filePath: string;
   bytesWritten: number;
+}
+
+function throwIfSyncCancelled(isCancelled?: () => boolean): void {
+  if (isCancelled?.()) {
+    throw new Error('Sync cancelled');
+  }
+}
+
+function reportSyncProgress(
+  reporter: SyncProgressReporter | undefined,
+  progress: SyncProgress,
+): void {
+  reporter?.(progress);
 }
 
 class SynkronusApi {
@@ -394,8 +413,13 @@ class SynkronusApi {
   /**
    * Process attachment manifest operations (download/delete) based on server response
    */
-  private async processAttachmentManifest(): Promise<void> {
+  private async processAttachmentManifest(
+    options?: SynkronusSyncOptions,
+  ): Promise<void> {
+    const report = options?.onProgress;
+    const isCancelled = options?.isCancelled;
     try {
+      throwIfSyncCancelled(isCancelled);
       const lastAttachmentVersion =
         Number(await AsyncStorage.getItem('@last_attachment_version')) || 0;
       const clientId = await clientIdService.getClientId();
@@ -404,6 +428,14 @@ class SynkronusApi {
         console.warn('No client ID available, skipping attachment sync');
         return;
       }
+
+      reportSyncProgress(report, {
+        phase: 'pull_attachments',
+        current: 0,
+        total: 0,
+        indeterminate: true,
+        details: 'Checking for attachments…',
+      });
 
       console.debug(
         `Getting attachment manifest since version ${lastAttachmentVersion}`,
@@ -450,22 +482,57 @@ class SynkronusApi {
           '@last_attachment_version',
           manifest.current_version.toString(),
         );
+        reportSyncProgress(report, {
+          phase: 'pull_attachments',
+          current: 1,
+          total: 1,
+          details: 'Up to date',
+        });
         return;
       }
 
       // Process operations
       const downloadOps = operations.filter(op => op.operation === 'download');
       const deleteOps = operations.filter(op => op.operation === 'delete');
+      const totalSteps = deleteOps.length + downloadOps.length;
 
       console.debug(
         `Processing ${downloadOps.length} downloads, ${deleteOps.length} deletions`,
       );
 
+      let doneSteps = 0;
+      const bumpProgress = (currentItem?: string) => {
+        reportSyncProgress(report, {
+          phase: 'pull_attachments',
+          current: doneSteps,
+          total: Math.max(totalSteps, 1),
+          details: formatCountProgress(doneSteps, totalSteps),
+          currentItem,
+        });
+      };
+
+      bumpProgress();
+
       // Process deletions first
-      await this.processAttachmentDeletions(deleteOps);
+      for (const op of deleteOps) {
+        throwIfSyncCancelled(isCancelled);
+        await this.processAttachmentDeletions([op]);
+        doneSteps += 1;
+        bumpProgress(op.attachment_id);
+      }
 
       // Process downloads
-      await this.processAttachmentDownloads(downloadOps);
+      await this.processAttachmentDownloads(downloadOps, {
+        ...options,
+        startDone: doneSteps,
+        totalSteps,
+        onStepComplete: (attachmentId: string) => {
+          doneSteps += 1;
+          bumpProgress(attachmentId);
+        },
+      });
+      doneSteps = totalSteps;
+      bumpProgress();
 
       // Update last processed version
       await AsyncStorage.setItem(
@@ -529,7 +596,13 @@ class SynkronusApi {
    */
   private async processAttachmentDownloads(
     downloadOps: AttachmentOperation[],
+    options?: SynkronusSyncOptions & {
+      startDone?: number;
+      totalSteps?: number;
+      onStepComplete?: (attachmentId: string) => void;
+    },
   ): Promise<void> {
+    const isCancelled = options?.isCancelled;
     const syncedDirectory = syncedRoot();
     await RNFS.mkdir(syncedDirectory);
 
@@ -537,7 +610,7 @@ class SynkronusApi {
     // download_url is generated server-side and may point at localhost, which
     // fails on real devices.
     const config = await this.getConfig();
-    const base = config.basePath.replace(/\/$/, '');
+    const base = (config.basePath ?? '').replace(/\/$/, '');
     const urls = downloadOps.map(
       op => `${base}/api/attachments/${encodeURIComponent(op.attachment_id)}`,
     );
@@ -551,6 +624,23 @@ class SynkronusApi {
     // corrupt — re-fetching is always the correct action.
     const results = await this.downloadRawFiles(urls, localPaths, undefined, {
       overwrite: true,
+      isCancelled,
+      onFileStart: (index: number) => {
+        const op = downloadOps[index];
+        reportSyncProgress(options?.onProgress, {
+          phase: 'pull_attachments',
+          current: (options?.startDone ?? 0) + index,
+          total: options?.totalSteps ?? downloadOps.length,
+          details: formatCountProgress(
+            (options?.startDone ?? 0) + index,
+            options?.totalSteps ?? downloadOps.length,
+          ),
+          currentItem: op.attachment_id,
+        });
+      },
+      onFileComplete: (index: number) => {
+        options?.onStepComplete?.(downloadOps[index].attachment_id);
+      },
     });
 
     results.forEach((result, index) => {
@@ -655,7 +745,12 @@ class SynkronusApi {
     urls: string[],
     localFilePaths: string[],
     progressCallback?: (progressPercent: number) => void,
-    options?: { overwrite?: boolean },
+    options?: {
+      overwrite?: boolean;
+      isCancelled?: () => boolean;
+      onFileStart?: (index: number) => void;
+      onFileComplete?: (index: number) => void;
+    },
   ): Promise<DownloadResult[]> {
     const results: DownloadResult[] = [];
     if (urls.length !== localFilePaths.length) {
@@ -683,8 +778,10 @@ class SynkronusApi {
     };
 
     for (let i = 0; i < totalFiles; i++) {
+      throwIfSyncCancelled(options?.isCancelled);
       const url = urls[i];
       const localFilePath = localFilePaths[i];
+      options?.onFileStart?.(i);
       try {
         console.debug(`Downloading file: ${url}`);
         const result = await this.downloadRawFile(
@@ -707,6 +804,7 @@ class SynkronusApi {
           bytesWritten: 0,
         });
       }
+      options?.onFileComplete?.(i);
       const progressPercent = Math.round((i / totalFiles) * 100);
       progressCallback?.(progressPercent);
     }
@@ -797,7 +895,11 @@ class SynkronusApi {
 
   private async uploadAttachments(
     attachments: string[],
+    options?: SynkronusSyncOptions,
   ): Promise<DownloadResult[]> {
+    const report = options?.onProgress;
+    const isCancelled = options?.isCancelled;
+    const total = attachments.length;
     if (attachments.length === 0) {
       console.debug('No attachments to upload');
       return [];
@@ -812,7 +914,17 @@ class SynkronusApi {
     await RNFS.mkdir(syncedDirectory);
     await RNFS.mkdir(pendingDirectory);
 
+    let done = 0;
     for (const attachmentId of attachments) {
+      throwIfSyncCancelled(isCancelled);
+      reportSyncProgress(report, {
+        phase: 'push_attachments',
+        current: done,
+        total: Math.max(total, 1),
+        details: formatCountProgress(done, total),
+        currentItem: attachmentId,
+      });
+
       const pendingFilePath = `${pendingDirectory}/${attachmentId}`;
       const syncedFilePath = `${syncedDirectory}/${attachmentId}`;
 
@@ -903,6 +1015,14 @@ class SynkronusApi {
           bytesWritten: 0,
         });
       }
+      done += 1;
+      reportSyncProgress(report, {
+        phase: 'push_attachments',
+        current: done,
+        total: Math.max(total, 1),
+        details: formatCountProgress(done, total),
+        currentItem: attachmentId,
+      });
     }
 
     console.debug('Attachments upload completed', results);
@@ -959,7 +1079,12 @@ class SynkronusApi {
    *
    * @returns {Promise<number>} The current version of the observations pulled from the server
    */
-  private async pullObservations(includeAttachments: boolean = false) {
+  private async pullObservations(
+    includeAttachments: boolean = false,
+    options?: SynkronusSyncOptions,
+  ) {
+    const report = options?.onProgress;
+    const isCancelled = options?.isCancelled;
     const clientId = await clientIdService.getClientId();
     let since = Number(await AsyncStorage.getItem('@last_seen_version'));
     if (!since) since = 0;
@@ -970,8 +1095,19 @@ class SynkronusApi {
     let res;
     let currentSince = since;
     let totalServerRecordsThisPull = 0;
+    let pullPage = 0;
+
+    reportSyncProgress(report, {
+      phase: 'pull_observations',
+      current: 0,
+      total: 0,
+      indeterminate: true,
+      details: 'Connecting…',
+    });
 
     do {
+      throwIfSyncCancelled(isCancelled);
+      pullPage += 1;
       const clientGen = await this.getRepositoryGenerationForRequestOrNull();
       logRepositoryGenerationSync('syncPull request', {
         clientXRepositoryGeneration: clientGen ?? '(omitted)',
@@ -1034,10 +1170,18 @@ class SynkronusApi {
       const pulledChanges = await repo.applyServerChanges(domainObservations); // ingest observations into WatermelonDB
       console.debug(`Applied ${pulledChanges} changes to local database`);
 
-      if (includeAttachments) {
-        // Process attachment manifest for incremental sync
-        await this.processAttachmentManifest();
-      }
+      reportSyncProgress(report, {
+        phase: 'pull_observations',
+        current: pullPage,
+        total: 0,
+        indeterminate: true,
+        details:
+          totalServerRecordsThisPull > 0
+            ? `${totalServerRecordsThisPull.toLocaleString()} records downloaded`
+            : res.data.has_more
+              ? `Downloading (page ${pullPage})…`
+              : 'Downloading…',
+      });
 
       console.debug('Pulled observations: ', domainObservations);
 
@@ -1047,6 +1191,20 @@ class SynkronusApi {
         console.debug(`Continuing pagination from version ${currentSince}`);
       }
     } while (res.data.has_more);
+
+    if (includeAttachments) {
+      await this.processAttachmentManifest(options);
+    }
+
+    reportSyncProgress(report, {
+      phase: 'pull_observations',
+      current: 1,
+      total: 1,
+      details:
+        totalServerRecordsThisPull > 0
+          ? `${totalServerRecordsThisPull.toLocaleString()} records`
+          : 'Up to date',
+    });
 
     logRepositoryGenerationSync('syncPull all pages done', {
       totalServerRecordsReceived: totalServerRecordsThisPull,
@@ -1081,11 +1239,17 @@ class SynkronusApi {
    * @param includeAttachments Whether to upload attachments associated with the observations
    * @returns The current version of the data (if no records are pushed, the last seen version is returned)
    */
-  async pushObservations(includeAttachments: boolean = false): Promise<number> {
+  async pushObservations(
+    includeAttachments: boolean = false,
+    options?: SynkronusSyncOptions,
+  ): Promise<number> {
+    const report = options?.onProgress;
+    const isCancelled = options?.isCancelled;
     const api = await this.getApi();
     const transmissionId = randomId();
 
     try {
+      throwIfSyncCancelled(isCancelled);
       // 1. Get pending changes from watermelondb
       const repo = databaseService.getLocalRepo();
       const localChanges = await repo.getPendingChanges();
@@ -1101,7 +1265,10 @@ class SynkronusApi {
         );
 
         if (attachments.length > 0) {
-          attachmentUploadResults = await this.uploadAttachments(attachments);
+          attachmentUploadResults = await this.uploadAttachments(
+            attachments,
+            options,
+          );
 
           // Check for upload failures
           const failedUploads = attachmentUploadResults.filter(
@@ -1125,9 +1292,17 @@ class SynkronusApi {
         }
       }
 
+      throwIfSyncCancelled(isCancelled);
+
       // 3. Check if we have observations to push
       if (localChanges.length === 0) {
         console.debug('No local changes to push');
+        reportSyncProgress(report, {
+          phase: 'push_observations',
+          current: 1,
+          total: 1,
+          details: 'Nothing to upload',
+        });
         const skipGen = await this.getRepositoryGenerationForRequestOrNull();
         const lastSeen =
           (await AsyncStorage.getItem('@last_seen_version')) ?? '(missing)';
@@ -1173,6 +1348,14 @@ class SynkronusApi {
       logRepositoryGenerationSync('syncPush request', {
         clientXRepositoryGeneration: pushClientGen ?? '(omitted)',
         observationCount: localChanges.length,
+      });
+
+      reportSyncProgress(report, {
+        phase: 'push_observations',
+        current: 0,
+        total: 1,
+        indeterminate: true,
+        details: `Uploading ${localChanges.length} observation${localChanges.length === 1 ? '' : 's'}…`,
       });
 
       console.debug(
@@ -1228,6 +1411,13 @@ class SynkronusApi {
         );
       }
 
+      reportSyncProgress(report, {
+        phase: 'push_observations',
+        current: 1,
+        total: 1,
+        details: 'Upload complete',
+      });
+
       return res.data.current_version;
     } catch (error: unknown) {
       logAxiosErrorForRepoGen('syncPush', error);
@@ -1246,7 +1436,10 @@ class SynkronusApi {
   /**
    * Syncs Observations with the server using the pull/push functionality
    */
-  async syncObservations(includeAttachments: boolean = false) {
+  async syncObservations(
+    includeAttachments: boolean = false,
+    options?: SynkronusSyncOptions,
+  ) {
     console.debug(
       includeAttachments
         ? 'Syncing observations with attachments'
@@ -1261,9 +1454,10 @@ class SynkronusApi {
       effectiveClientGen: effectiveGen ?? '(omitted)',
       includeAttachments,
     });
-    const version = await this.pullObservations(includeAttachments);
+    const version = await this.pullObservations(includeAttachments, options);
     console.debug('Pull completed @ data version ' + version);
-    await this.pushObservations(includeAttachments);
+    throwIfSyncCancelled(options?.isCancelled);
+    await this.pushObservations(includeAttachments, options);
     console.debug('Push completed');
     const storageAfter = await AsyncStorage.getItem(
       REPOSITORY_GENERATION_STORAGE_KEY,

--- a/formulus/src/contexts/SyncContext.tsx
+++ b/formulus/src/contexts/SyncContext.tsx
@@ -7,12 +7,9 @@ import React, {
 } from 'react';
 import { syncService as syncServiceInstance } from '../services/SyncService';
 
-export interface SyncProgress {
-  current: number;
-  total: number;
-  phase: 'pull' | 'push' | 'attachments_download' | 'attachments_upload';
-  details?: string;
-}
+export type { SyncProgress, SyncProgressPhase } from '../sync/syncProgress';
+export type { SyncProgressReporter } from '../sync/syncProgress';
+import type { SyncProgress } from '../sync/syncProgress';
 
 export interface SyncState {
   isActive: boolean;

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -265,15 +265,7 @@ const SyncScreen = () => {
       startSync(true);
       setActiveOperation('sync');
 
-      const syncPromise = syncService.syncObservations(true);
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(
-          () => reject(new Error('Sync timed out after 30 minutes')),
-          30 * 60 * 1000,
-        );
-      });
-
-      await Promise.race([syncPromise, timeoutPromise]);
+      await syncService.syncObservations(true);
       await refreshAfterOperation();
     } catch (error) {
       if (isRepositoryResetRequiredError(error)) {

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -43,6 +43,11 @@ import {
   isNumericAppBundleVersionString,
   normalizeAppBundleVersion,
 } from '../utils/appBundleVersion';
+import { syncProgressPercent } from '../sync/syncProgress';
+import {
+  getSyncProgressCardTitle,
+  getSyncProgressPercentLabel,
+} from '../sync/syncProgressUi';
 
 type ActiveOperation = 'sync' | 'update' | 'sync_then_update' | null;
 
@@ -521,11 +526,7 @@ const SyncScreen = () => {
       return;
     }
 
-    const { current, total } = syncState.progress;
-    const percent =
-      total && total > 0
-        ? Math.max(0, Math.min(100, (current / total) * 100))
-        : 0;
+    const percent = syncProgressPercent(syncState.progress) ?? 0;
 
     Animated.timing(animatedProgress, {
       toValue: percent,
@@ -555,12 +556,6 @@ const SyncScreen = () => {
     updatePendingObservations,
     checkForUpdates,
   ]);
-
-  const getProgressTitle = (): string => {
-    if (activeOperation === 'sync_then_update') return 'Syncing & Updating';
-    if (activeOperation === 'update') return 'Updating App Bundle';
-    return 'Syncing Data';
-  };
 
   const isSyncButtonActive =
     activeOperation === 'sync' || activeOperation === 'sync_then_update';
@@ -614,6 +609,16 @@ const SyncScreen = () => {
   const showBundleProgress =
     syncState.isActive && syncState.progress && activeOperation === 'update';
 
+  const progressPercentLabel =
+    syncState.progress && syncState.isActive
+      ? getSyncProgressPercentLabel(syncState.progress)
+      : '';
+  const progressShowsIndeterminate =
+    syncState.progress?.indeterminate === true ||
+    (syncState.progress != null &&
+      syncState.progress.total <= 0 &&
+      syncProgressPercent(syncState.progress) == null);
+
   const progressCard =
     syncState.isActive && syncState.progress ? (
       <View
@@ -626,13 +631,20 @@ const SyncScreen = () => {
           },
         ]}>
         <View style={styles.progressHeader}>
-          <Icon name="sync" size={20} color={themeColors.primary as string} />
+          {progressShowsIndeterminate ? (
+            <ActivityIndicator
+              size="small"
+              color={themeColors.primary as string}
+            />
+          ) : (
+            <Icon name="sync" size={20} color={themeColors.primary as string} />
+          )}
           <Text
             style={[
               styles.progressTitle,
               { color: themeColors.onSurface as string },
             ]}>
-            {getProgressTitle()}
+            {getSyncProgressCardTitle(syncState.progress, activeOperation)}
           </Text>
         </View>
         <View
@@ -649,28 +661,51 @@ const SyncScreen = () => {
               styles.progressFill,
               {
                 backgroundColor: themeColors.primary as string,
-                width: animatedProgress.interpolate({
-                  inputRange: [0, 100],
-                  outputRange: ['0%', '100%'],
-                }),
+                width: progressShowsIndeterminate
+                  ? '30%'
+                  : animatedProgress.interpolate({
+                      inputRange: [0, 100],
+                      outputRange: ['0%', '100%'],
+                    }),
+                opacity: progressShowsIndeterminate ? 0.55 : 1,
               },
             ]}
           />
         </View>
-        <Text
-          style={[
-            styles.progressText,
-            {
-              color: isDark
-                ? (themeColors.onSurface as string)
-                : (colors.neutral[700] as string),
-            },
-          ]}>
-          {Math.round(
-            (syncState.progress.current / syncState.progress.total) * 100,
-          )}
-          %
-        </Text>
+        {progressPercentLabel ? (
+          <Text
+            style={[
+              styles.progressText,
+              {
+                color: isDark
+                  ? (themeColors.onSurface as string)
+                  : (colors.neutral[700] as string),
+              },
+            ]}>
+            {progressPercentLabel}
+          </Text>
+        ) : null}
+        {syncState.progress.details ? (
+          <Text
+            style={[
+              styles.progressSubtext,
+              { color: mutedForeground },
+            ]}
+            numberOfLines={1}>
+            {syncState.progress.details}
+          </Text>
+        ) : null}
+        {syncState.progress.currentItem ? (
+          <Text
+            style={[
+              styles.progressItemText,
+              { color: mutedForeground },
+            ]}
+            numberOfLines={1}
+            ellipsizeMode="middle">
+            {syncState.progress.currentItem}
+          </Text>
+        ) : null}
         {syncState.canCancel && (
           <Button
             title="Cancel"
@@ -1315,7 +1350,18 @@ const styles = StyleSheet.create({
   progressText: {
     fontSize: odeTypography.caption,
     textAlign: 'center',
+    marginBottom: 4,
+  },
+  progressSubtext: {
+    fontSize: odeTypography.caption,
+    textAlign: 'center',
+    marginBottom: 2,
+  },
+  progressItemText: {
+    fontSize: odeTypography.caption,
+    textAlign: 'center',
     marginBottom: 12,
+    fontFamily: 'monospace',
   },
   errorCard: {
     marginBottom: odeSpacing.md,

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -46,7 +46,10 @@ import {
 import { syncProgressPercent } from '../sync/syncProgress';
 import {
   getSyncProgressCardTitle,
+  getSyncProgressDetailsForDisplay,
   getSyncProgressPercentLabel,
+  shouldShowSyncProgressCurrentItem,
+  shouldShowSyncProgressPercent,
 } from '../sync/syncProgressUi';
 
 type ActiveOperation = 'sync' | 'update' | 'sync_then_update' | null;
@@ -601,10 +604,17 @@ const SyncScreen = () => {
   const showBundleProgress =
     syncState.isActive && syncState.progress && activeOperation === 'update';
 
+  const progress = syncState.progress;
   const progressPercentLabel =
-    syncState.progress && syncState.isActive
-      ? getSyncProgressPercentLabel(syncState.progress)
+    progress && syncState.isActive && shouldShowSyncProgressPercent(progress)
+      ? getSyncProgressPercentLabel(progress)
       : '';
+  const progressDetailsLabel =
+    progress && syncState.isActive
+      ? getSyncProgressDetailsForDisplay(progress)
+      : undefined;
+  const progressShowsCurrentItem =
+    progress != null && shouldShowSyncProgressCurrentItem(progress);
   const progressShowsIndeterminate =
     syncState.progress?.indeterminate === true ||
     (syncState.progress != null &&
@@ -677,17 +687,25 @@ const SyncScreen = () => {
             {progressPercentLabel}
           </Text>
         ) : null}
-        {syncState.progress.details ? (
+        {progressDetailsLabel ? (
           <Text
             style={[
-              styles.progressSubtext,
-              { color: mutedForeground },
+              progressPercentLabel
+                ? styles.progressSubtext
+                : styles.progressText,
+              {
+                color: progressPercentLabel
+                  ? mutedForeground
+                  : isDark
+                    ? (themeColors.onSurface as string)
+                    : (colors.neutral[700] as string),
+              },
             ]}
             numberOfLines={1}>
-            {syncState.progress.details}
+            {progressDetailsLabel}
           </Text>
         ) : null}
-        {syncState.progress.currentItem ? (
+        {progressShowsCurrentItem && progress?.currentItem ? (
           <Text
             style={[
               styles.progressItemText,
@@ -695,7 +713,7 @@ const SyncScreen = () => {
             ]}
             numberOfLines={1}
             ellipsizeMode="middle">
-            {syncState.progress.currentItem}
+            {progress.currentItem}
           </Text>
         ) : null}
         {syncState.canCancel && (

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -707,10 +707,7 @@ const SyncScreen = () => {
         ) : null}
         {progressShowsCurrentItem && progress?.currentItem ? (
           <Text
-            style={[
-              styles.progressItemText,
-              { color: mutedForeground },
-            ]}
+            style={[styles.progressItemText, { color: mutedForeground }]}
             numberOfLines={1}
             ellipsizeMode="middle">
             {progress.currentItem}

--- a/formulus/src/services/NotificationService.ts
+++ b/formulus/src/services/NotificationService.ts
@@ -3,7 +3,11 @@ import notifee, {
   AndroidImportance,
   AndroidForegroundServiceType,
 } from '@notifee/react-native';
-import { SyncProgress } from '../contexts/SyncContext';
+import type { SyncProgress } from '../sync/syncProgress';
+import {
+  syncProgressPercent,
+  syncProgressPhaseTitle,
+} from '../sync/syncProgress';
 
 class NotificationService {
   private syncNotificationId = 'sync_progress';
@@ -28,23 +32,38 @@ class NotificationService {
   async showSyncProgress(progress: SyncProgress) {
     if (!this.foregroundServiceRunning) return;
 
-    const percentage =
-      progress.total > 0
-        ? Math.round((progress.current / progress.total) * 100)
-        : 0;
+    const percentage = syncProgressPercent(progress);
+    const indeterminate =
+      progress.indeterminate === true || progress.total <= 0;
+    const title = syncProgressPhaseTitle(progress.phase);
+    const bodyParts: string[] = [];
+    if (progress.details?.trim()) {
+      bodyParts.push(progress.details.trim());
+    }
+    if (progress.currentItem?.trim()) {
+      bodyParts.push(progress.currentItem.trim());
+    }
+    const body =
+      bodyParts.length > 0
+        ? bodyParts.join(' · ')
+        : indeterminate
+          ? 'In progress…'
+          : percentage != null
+            ? `${percentage}%`
+            : 'In progress…';
 
     try {
       await notifee.displayNotification({
         id: this.syncNotificationId,
-        title: this.getPhaseText(progress.phase),
-        body: `${percentage}%`,
+        title,
+        body,
         android: {
           channelId: this.channelId,
           ongoing: true,
           progress: {
             max: 100,
-            current: percentage,
-            indeterminate: progress.total === 0,
+            current: percentage ?? 0,
+            indeterminate,
           },
         },
       });
@@ -59,8 +78,8 @@ class NotificationService {
 
     await notifee.displayNotification({
       id: this.syncNotificationId,
-      title: 'Syncing...',
-      body: 'Starting...',
+      title: 'Syncing…',
+      body: 'Starting…',
       android: {
         channelId: this.channelId,
         asForegroundService: true,
@@ -165,21 +184,6 @@ class NotificationService {
 
   async clearAllSyncNotifications() {
     await notifee.cancelAllNotifications();
-  }
-
-  private getPhaseText(phase: SyncProgress['phase']): string {
-    switch (phase) {
-      case 'pull':
-        return 'Downloading data';
-      case 'push':
-        return 'Uploading observations';
-      case 'attachments_download':
-        return 'Updating app bundle';
-      case 'attachments_upload':
-        return 'Uploading attachments';
-      default:
-        return 'Syncing';
-    }
   }
 }
 

--- a/formulus/src/services/NotificationService.ts
+++ b/formulus/src/services/NotificationService.ts
@@ -8,6 +8,10 @@ import {
   syncProgressPercent,
   syncProgressPhaseTitle,
 } from '../sync/syncProgress';
+import {
+  getSyncProgressDetailsForDisplay,
+  shouldShowSyncProgressCurrentItem,
+} from '../sync/syncProgressUi';
 
 class NotificationService {
   private syncNotificationId = 'sync_progress';
@@ -37,10 +41,14 @@ class NotificationService {
       progress.indeterminate === true || progress.total <= 0;
     const title = syncProgressPhaseTitle(progress.phase);
     const bodyParts: string[] = [];
-    if (progress.details?.trim()) {
-      bodyParts.push(progress.details.trim());
+    const displayDetails = getSyncProgressDetailsForDisplay(progress);
+    if (displayDetails) {
+      bodyParts.push(displayDetails);
     }
-    if (progress.currentItem?.trim()) {
+    if (
+      shouldShowSyncProgressCurrentItem(progress) &&
+      progress.currentItem?.trim()
+    ) {
       bodyParts.push(progress.currentItem.trim());
     }
     const body =

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -432,8 +432,6 @@ export class SyncService {
               current: normalized,
               total: 100,
               phase: 'app_bundle',
-              details: `${normalized}%`,
-              currentItem: 'Form bundle',
             });
           }),
         'download app bundle',

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -1,7 +1,8 @@
 import { synkronusApi } from '../api/synkronus';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { appEvents } from '../webview/FormulusMessageHandlers';
-import { SyncProgress } from '../contexts/SyncContext';
+import type { SyncProgress } from '../sync/syncProgress';
+import type { SynkronusSyncOptions } from '../sync/syncProgress';
 import { notificationService } from './NotificationService';
 import { getUserFacingAppBundleUpdateErrorMessage } from './appBundleUpdateErrors';
 import { FormService } from './FormService';
@@ -206,78 +207,22 @@ export class SyncService {
 
     try {
       await notificationService.startForegroundService();
-      // Phase 1: Pull - Get manifest and download changes
+
+      const syncOptions: SynkronusSyncOptions = {
+        onProgress: progress => this.updateProgress(progress),
+        isCancelled: () => this.shouldCancel,
+      };
+
       this.updateProgress({
         current: 0,
-        total: 4,
-        phase: 'pull',
-        details: 'Fetching manifest...',
+        total: 0,
+        phase: 'pull_observations',
+        indeterminate: true,
+        details: 'Starting…',
       });
-
-      if (this.shouldCancel) {
-        notificationService
-          .showSyncCanceled()
-          .catch(error =>
-            console.warn('Failed to show sync canceled notification:', error),
-          );
-        throw new Error('Sync cancelled');
-      }
-
-      // Phase 2: Pull - Download observations
-      this.updateProgress({
-        current: 1,
-        total: 4,
-        phase: 'pull',
-        details: 'Downloading observations...',
-      });
-
-      if (this.shouldCancel) {
-        notificationService
-          .showSyncCanceled()
-          .catch(error =>
-            console.warn('Failed to show sync canceled notification:', error),
-          );
-        throw new Error('Sync cancelled');
-      }
-
-      // Phase 3: Push - Upload local changes
-      this.updateProgress({
-        current: 2,
-        total: 4,
-        phase: 'push',
-        details: 'Uploading observations...',
-      });
-
-      if (this.shouldCancel) {
-        notificationService
-          .showSyncCanceled()
-          .catch(error =>
-            console.warn('Failed to show sync canceled notification:', error),
-          );
-        throw new Error('Sync cancelled');
-      }
-
-      // Phase 4: Attachments (if enabled)
-      if (includeAttachments) {
-        this.updateProgress({
-          current: 3,
-          total: 4,
-          phase: 'attachments_upload',
-          details: 'Syncing attachments...',
-        });
-
-        if (this.shouldCancel) {
-          notificationService
-            .showSyncCanceled()
-            .catch(error =>
-              console.warn('Failed to show sync canceled notification:', error),
-            );
-          throw new Error('Sync cancelled');
-        }
-      }
 
       const finalVersion = await this.withAutoLoginRetry(
-        () => synkronusApi.syncObservations(includeAttachments),
+        () => synkronusApi.syncObservations(includeAttachments, syncOptions),
         'sync observations',
       );
 
@@ -292,10 +237,10 @@ export class SyncService {
       );
 
       this.updateProgress({
-        current: 4,
-        total: 4,
-        phase: 'push',
-        details: 'Sync completed',
+        current: 1,
+        total: 1,
+        phase: 'push_observations',
+        details: 'Complete',
       });
       await AsyncStorage.setItem('@last_seen_version', finalVersion.toString());
 
@@ -316,6 +261,18 @@ export class SyncService {
       return finalVersion;
     } catch (error) {
       console.error('Sync failed', error);
+      if (
+        error instanceof Error &&
+        error.message === 'Sync cancelled' &&
+        this.shouldCancel
+      ) {
+        notificationService
+          .showSyncCanceled()
+          .catch(notifError =>
+            console.warn('Failed to show sync canceled notification:', notifError),
+          );
+        throw error;
+      }
       const errorMessage = getUserFacingSyncErrorMessage(error);
       this.updateStatus(`Sync failed: ${errorMessage}`);
 
@@ -407,8 +364,8 @@ export class SyncService {
     this.updateProgress({
       current: 0,
       total: 100,
-      phase: 'attachments_download',
-      details: 'Preparing app bundle download...',
+      phase: 'app_bundle',
+      details: 'Preparing download…',
     });
 
     try {
@@ -442,8 +399,8 @@ export class SyncService {
       this.updateProgress({
         current: 100,
         total: 100,
-        phase: 'attachments_download',
-        details: 'App bundle sync completed',
+        phase: 'app_bundle',
+        details: 'Complete',
       });
 
       appEvents.emit('bundleUpdated');
@@ -474,8 +431,9 @@ export class SyncService {
             this.updateProgress({
               current: normalized,
               total: 100,
-              phase: 'attachments_download',
-              details: `Downloading app bundle... ${normalized}%`,
+              phase: 'app_bundle',
+              details: `${normalized}%`,
+              currentItem: 'Form bundle',
             });
           }),
         'download app bundle',

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -269,7 +269,10 @@ export class SyncService {
         notificationService
           .showSyncCanceled()
           .catch(notifError =>
-            console.warn('Failed to show sync canceled notification:', notifError),
+            console.warn(
+              'Failed to show sync canceled notification:',
+              notifError,
+            ),
           );
         throw error;
       }

--- a/formulus/src/sync/__tests__/syncProgress.test.ts
+++ b/formulus/src/sync/__tests__/syncProgress.test.ts
@@ -1,0 +1,40 @@
+import {
+  formatCountProgress,
+  syncProgressPercent,
+  syncProgressPhaseTitle,
+} from '../syncProgress';
+
+describe('syncProgress', () => {
+  it('formats count progress', () => {
+    expect(formatCountProgress(3, 10)).toBe('3 of 10');
+    expect(formatCountProgress(0, 0)).toBe('');
+  });
+
+  it('returns null percent when indeterminate', () => {
+    expect(
+      syncProgressPercent({
+        phase: 'pull_observations',
+        current: 0,
+        total: 0,
+        indeterminate: true,
+      }),
+    ).toBeNull();
+  });
+
+  it('computes percent for attachment steps', () => {
+    expect(
+      syncProgressPercent({
+        phase: 'pull_attachments',
+        current: 5,
+        total: 10,
+      }),
+    ).toBe(50);
+  });
+
+  it('titles phases for UI', () => {
+    expect(syncProgressPhaseTitle('pull_attachments')).toBe(
+      'Downloading attachments',
+    );
+    expect(syncProgressPhaseTitle('app_bundle')).toBe('Updating forms');
+  });
+});

--- a/formulus/src/sync/__tests__/syncProgressUi.test.ts
+++ b/formulus/src/sync/__tests__/syncProgressUi.test.ts
@@ -1,0 +1,52 @@
+import {
+  getSyncProgressDetailsForDisplay,
+  shouldShowSyncProgressCurrentItem,
+  shouldShowSyncProgressPercent,
+} from '../syncProgressUi';
+
+describe('syncProgressUi', () => {
+  it('maps records to observations for pull_observations display only', () => {
+    expect(
+      getSyncProgressDetailsForDisplay({
+        phase: 'pull_observations',
+        current: 0,
+        total: 0,
+        indeterminate: true,
+        details: '1,500 records downloaded',
+      }),
+    ).toBe('1,500 observations downloaded');
+  });
+
+  it('leaves attachment count text unchanged', () => {
+    expect(
+      getSyncProgressDetailsForDisplay({
+        phase: 'pull_attachments',
+        current: 10,
+        total: 100,
+        details: '10 of 100',
+      }),
+    ).toBe('10 of 100');
+  });
+
+  it('hides percent and filename for attachment phases', () => {
+    const progress = {
+      phase: 'pull_attachments' as const,
+      current: 43,
+      total: 100,
+      details: '1497 of 3515',
+      currentItem: 'file.jpg',
+    };
+    expect(shouldShowSyncProgressPercent(progress)).toBe(false);
+    expect(shouldShowSyncProgressCurrentItem(progress)).toBe(false);
+  });
+
+  it('hides percent for app bundle (bar only)', () => {
+    expect(
+      shouldShowSyncProgressPercent({
+        phase: 'app_bundle',
+        current: 95,
+        total: 100,
+      }),
+    ).toBe(false);
+  });
+});

--- a/formulus/src/sync/syncProgress.ts
+++ b/formulus/src/sync/syncProgress.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared sync progress model for observation sync, attachments, and app bundle.
+ */
+
+export type SyncProgressPhase =
+  | 'pull_observations'
+  | 'pull_attachments'
+  | 'push_attachments'
+  | 'push_observations'
+  /** Form definitions / custom app ZIP (not observation attachments). */
+  | 'app_bundle';
+
+export interface SyncProgress {
+  current: number;
+  total: number;
+  phase: SyncProgressPhase;
+  /** Secondary line, e.g. "12 of 340". */
+  details?: string;
+  /** Current file or item label (attachment id / bundle step). */
+  currentItem?: string;
+  /** When true, UI hides a numeric percent and shows activity only. */
+  indeterminate?: boolean;
+}
+
+export type SyncProgressReporter = (progress: SyncProgress) => void;
+
+export interface SynkronusSyncOptions {
+  onProgress?: SyncProgressReporter;
+  isCancelled?: () => boolean;
+}
+
+export function formatCountProgress(done: number, total: number): string {
+  if (total <= 0) {
+    return '';
+  }
+  return `${Math.min(done, total)} of ${total}`;
+}
+
+export function syncProgressPercent(progress: SyncProgress): number | null {
+  if (progress.indeterminate || progress.total <= 0) {
+    return null;
+  }
+  return Math.round(
+    Math.max(0, Math.min(100, (progress.current / progress.total) * 100)),
+  );
+}
+
+export function syncProgressPhaseTitle(phase: SyncProgressPhase): string {
+  switch (phase) {
+    case 'pull_observations':
+      return 'Syncing observations';
+    case 'pull_attachments':
+      return 'Downloading attachments';
+    case 'push_attachments':
+      return 'Uploading attachments';
+    case 'push_observations':
+      return 'Uploading changes';
+    case 'app_bundle':
+      return 'Updating forms';
+    default:
+      return 'Syncing';
+  }
+}

--- a/formulus/src/sync/syncProgressUi.ts
+++ b/formulus/src/sync/syncProgressUi.ts
@@ -1,0 +1,30 @@
+import type { SyncProgress } from './syncProgress';
+import {
+  syncProgressPercent,
+  syncProgressPhaseTitle,
+} from './syncProgress';
+
+/** Headline for the in-app progress card (phase-specific). */
+export function getSyncProgressCardTitle(
+  progress: SyncProgress,
+  activeOperation: 'sync' | 'update' | 'sync_then_update' | null,
+): string {
+  if (activeOperation === 'sync_then_update') {
+    if (progress.phase === 'app_bundle') {
+      return 'Syncing & updating forms';
+    }
+    return 'Syncing & updating';
+  }
+  if (activeOperation === 'update') {
+    return syncProgressPhaseTitle('app_bundle');
+  }
+  return syncProgressPhaseTitle(progress.phase);
+}
+
+export function getSyncProgressPercentLabel(progress: SyncProgress): string {
+  const pct = syncProgressPercent(progress);
+  if (pct == null) {
+    return '';
+  }
+  return `${pct}%`;
+}

--- a/formulus/src/sync/syncProgressUi.ts
+++ b/formulus/src/sync/syncProgressUi.ts
@@ -1,8 +1,54 @@
-import type { SyncProgress } from './syncProgress';
+import type { SyncProgress, SyncProgressPhase } from './syncProgress';
 import {
   syncProgressPercent,
   syncProgressPhaseTitle,
 } from './syncProgress';
+
+const ATTACHMENT_PHASES: SyncProgressPhase[] = [
+  'pull_attachments',
+  'push_attachments',
+];
+
+/** User-facing details; maps legacy "records" copy to "observations" for pull only. */
+export function getSyncProgressDetailsForDisplay(
+  progress: SyncProgress,
+): string | undefined {
+  const raw = progress.details?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  if (progress.phase === 'pull_observations') {
+    return raw
+      .replace(/\brecords downloaded\b/gi, 'observations downloaded')
+      .replace(/\brecords\b/gi, 'observations');
+  }
+  return raw;
+}
+
+export function shouldShowSyncProgressPercent(progress: SyncProgress): boolean {
+  if (ATTACHMENT_PHASES.includes(progress.phase)) {
+    return false;
+  }
+  if (progress.phase === 'app_bundle') {
+    return false;
+  }
+  if (progress.indeterminate) {
+    return false;
+  }
+  return syncProgressPercent(progress) != null;
+}
+
+export function shouldShowSyncProgressCurrentItem(
+  progress: SyncProgress,
+): boolean {
+  if (
+    ATTACHMENT_PHASES.includes(progress.phase) ||
+    progress.phase === 'app_bundle'
+  ) {
+    return false;
+  }
+  return Boolean(progress.currentItem?.trim());
+}
 
 /** Headline for the in-app progress card (phase-specific). */
 export function getSyncProgressCardTitle(

--- a/formulus/src/sync/syncProgressUi.ts
+++ b/formulus/src/sync/syncProgressUi.ts
@@ -1,8 +1,5 @@
 import type { SyncProgress, SyncProgressPhase } from './syncProgress';
-import {
-  syncProgressPercent,
-  syncProgressPhaseTitle,
-} from './syncProgress';
+import { syncProgressPercent, syncProgressPhaseTitle } from './syncProgress';
 
 const ATTACHMENT_PHASES: SyncProgressPhase[] = [
   'pull_attachments',


### PR DESCRIPTION


## Description

Observation sync previously showed misleading progress: the bar jumped to ~75% immediately, then sat there for a long time while pull/attachments/push ran. A **30-minute UI-only timeout** could report “Sync failed” while work continued in the background.

This PR wires progress to **real sync work**, improves the Sync screen and notifications, and removes the misleading timeout.

### Progress reporting
- Progress is emitted from `synkronusApi` during pull, attachment manifest/download/upload, and push (not fake 4-step milestones in `SyncService`).
- New shared model: `formulus/src/sync/syncProgress.ts` with phases: `pull_observations`, `pull_attachments`, `push_attachments`, `push_observations`, `app_bundle`.
- Attachment manifest runs **once after all observation pull pages** (not on every pull page).
- Cancel checks run between attachment files during download/upload.

### Sync screen UI
- Phase-specific titles (e.g. “Syncing observations”, “Downloading attachments”).
- **Attachments:** progress bar + **N of M** only (no percent line, no filename).
- **Observation pull:** indeterminate bar + status text; UI maps “records” → **“observations”** (display layer only).
- **App bundle update:** progress bar only (no duplicate % / “Form bundle” lines).

### Other fixes
- Removed `Promise.race` **30-minute timeout** from `handleSync` so the UI does not claim failure while sync keeps running.
- Android foreground notifications use the same phase titles and simplified body text.

<img width="400" height="670" alt="image" src="https://github.com/user-attachments/assets/ccaad099-6ca2-4c21-b4b7-5adad6bc06f1" />

