### PR TITLE
feat: enable per-ABI APK splits for F-Droid

### DIFF
--- a/formulus/android/app/build.gradle
+++ b/formulus/android/app/build.gradle
@@ -1,3 +1,9 @@
+// F-Droid metadata uses gradleprops abiFilters=arm64-v8a; React Native builds native code from reactNativeArchitectures.
+def fdroidAbiFilter = findProperty("abiFilters")
+if (fdroidAbiFilter) {
+    project.ext.set("reactNativeArchitectures", fdroidAbiFilter.toString())
+}
+
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
@@ -81,6 +87,8 @@ def enableProguardInReleaseBuilds = false
  */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
+def abiVersionCodes = ['armeabi-v7a': 1, 'arm64-v8a': 2, 'x86': 3, 'x86_64': 4]
+
 android {
     ndkVersion = rootProject.ext.ndkVersion
     buildToolsVersion = rootProject.ext.buildToolsVersion
@@ -96,6 +104,23 @@ android {
         versionName = "1.0.1"
 
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", (findProperty("newArchEnabled") ?: "false").toString()
+
+        if (fdroidAbiFilter) {
+            ndk {
+                abiFilters fdroidAbiFilter.toString()
+            }
+        }
+    }
+
+    if (!fdroidAbiFilter) {
+        splits {
+            abi {
+                enable true
+                reset()
+                include "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+                universalApk false
+            }
+        }
     }
 
     signingConfigs {
@@ -127,15 +152,27 @@ android {
         }
     }
 
-    // Custom APK naming
+    // Per-ABI versionCode when building split APKs (F-Droid uses explicit versionCode per gradleprops build).
+    if (!fdroidAbiFilter) {
+        applicationVariants.configureEach { variant ->
+            variant.outputs.each { output ->
+                def abi = output.getFilter(com.android.build.OutputFile.ABI)
+                if (abi != null) {
+                    output.versionCodeOverride =
+                        (100 * defaultConfig.versionCode) + abiVersionCodes.get(abi, 0)
+                }
+            }
+        }
+    }
+
+    // Custom APK naming (local builds; F-Droid metadata strips this block in prebuild).
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
             def versionName = variant.versionName
             def versionCode = variant.versionCode
             def buildType = variant.buildType.name
             def date = new Date().format('yyyyMMdd')
-            
-            // Format: formulus-v1.0-1-release-20251006.apk
+
             outputFileName = "formulus-v${versionName}-${versionCode}-${buildType}-${date}.apk"
         }
     }


### PR DESCRIPTION
## Description:

Adds ABI splits to shrink release APKs (~35 MB arm64 vs ~85 MB universal). Supports F-Droid gradleprops abiFilters via reactNativeArchitectures. For F-Droid MR 