### PR TITLE
fix: unique APK filename per ABI split

### DIFF
--- a/formulus/android/app/build.gradle
+++ b/formulus/android/app/build.gradle
@@ -169,11 +169,13 @@ android {
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
             def versionName = variant.versionName
-            def versionCode = variant.versionCode
+            def versionCode = output.versionCode
             def buildType = variant.buildType.name
             def date = new Date().format('yyyyMMdd')
+            def abi = output.getFilter(com.android.build.OutputFile.ABI)
+            def abiSuffix = abi != null ? "-${abi}" : ""
 
-            outputFileName = "formulus-v${versionName}-${versionCode}-${buildType}-${date}.apk"
+            outputFileName = "formulus-v${versionName}-${versionCode}${abiSuffix}-${buildType}-${date}.apk"
         }
     }
 


### PR DESCRIPTION
## Description

Fixes the GitHub Actions **Build Formulus Android APK** failure after merging per-ABI release splits (#646).

`assembleRelease` was failing at `:app:packageRelease` because every ABI split used the same custom APK filename. Parallel packaging then tried to write `META-INF/com/android/build/gradle/app-metadata.properties` into the same zip twice.

The custom naming block now uses `output.versionCode` and includes the ABI in the filename (e.g. `formulus-v1.0.1-202-arm64-v8a-release-YYYYMMDD.apk`).

## Test plan

- [x] Local `./gradlew assembleRelease` produces four distinct release APKs (armeabi-v7a, arm64-v8a, x86, x86_64)
- [x] `:app:packageRelease` completes without the `app-metadata.properties` overwrite error
- [ ] GitHub Actions **Build Formulus Android APK** passes on this PR