### PR TITLE
feat(formplayer): mobile UX and bridge API pack.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ Do not assume custom app authors have local checkouts of **ODE** or internal exa
 
 - **Pipelines:** [.github/CICD.md](.github/CICD.md).
 - **Lint/format:** Run the relevant scripts in the **package you touch** (see root [README.md](README.md) and each package).
+- **Pre-flight before opening a PR:** each package `AGENTS.md` lists the local `lint` / `format:check` / `test` / `build` commands that match CI — run them in every package you changed (e.g. [formulus-formplayer/AGENTS.md](formulus-formplayer/AGENTS.md#pre-flight-before-a-pr)).
 - **Commits/PRs:** Conventional Commits and PR expectations are documented in [formulus-formplayer/AGENTS.md](formulus-formplayer/AGENTS.md) (project-wide convention).
 
 ---

--- a/formulus-formplayer/AGENTS.md
+++ b/formulus-formplayer/AGENTS.md
@@ -77,6 +77,23 @@ This file gives AI assistants and developers enough context to work effectively 
 - `pnpm start` — Vite dev server; uses `webview-mock` and (optionally) `DevTestbed` so you can test without the RN app.
 - Tests: `pnpm test` (Vitest). Lint/format: `pnpm run lint`, `pnpm run lint:fix`, `pnpm run format`, `pnpm run format:check`.
 
+## Pre-flight before a PR
+
+Run from **`formulus-formplayer/`** (CI runs the same steps):
+
+```bash
+pnpm run lint
+pnpm run format:check
+pnpm run test run
+pnpm run build
+```
+
+**React renderers:** never put `if (visible === false) return null` (or any early return) **before** hooks. Call all hooks unconditionally at the top of the component, then return `null` when hidden. ESLint `react-hooks/rules-of-hooks` fails CI; this pattern is easy to miss when adding `visible` guards to renderers.
+
+**Imports:** remove unused symbols (`@typescript-eslint/no-unused-vars` is an error).
+
+If the PR also touches **Formulus** (`../formulus/`), run `pnpm run lint` there too (errors block; warnings are capped with `--max-warnings 9999`).
+
 ## Commit and pull request workflow
 
 - **Commit messages** must follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(scope): add X`, `fix(scope): resolve Y`).

--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -36,6 +36,7 @@ import FormulusClient from './services/FormulusInterface';
 import { FormInitData } from './types/FormulusInterfaceDefinition';
 import {
   initialFormDataFromParams,
+  applySchemaDefaultTokens,
   dataMatchingSchemaRoot,
 } from './utils/formObservationData';
 
@@ -329,6 +330,12 @@ function App() {
   const [customValidatorErrors, setCustomValidatorErrors] = useState<
     ErrorObject[]
   >([]);
+  // Deferred validation: new forms start hidden (no red errors on first paint),
+  // then switch to ValidateAndShow on first forward navigation / finalize. Edits
+  // and draft resumes start shown. Host can override via params.validationMode.
+  const [validationMode, setValidationMode] = useState<
+    'ValidateAndShow' | 'ValidateAndHide' | 'NoValidation'
+  >('ValidateAndShow');
 
   // Reference to the FormulusClient instance and loading state
   const formulusClient = useRef<FormulusClient>(FormulusClient.getInstance());
@@ -526,13 +533,47 @@ function App() {
         }
 
         const formSchemaTyped = formSchema as FormSchema | null;
+        // Deferred-validation policy. Honor an explicit host override first;
+        // otherwise defer (hide) for brand-new observations and show for
+        // edits / draft resumes so existing data is validated immediately.
+        const paramValidationMode = (params as Record<string, unknown> | null)?.[
+          'validationMode'
+        ];
+        const hasSavedData = Boolean(
+          savedData && Object.keys(savedData).length > 0,
+        );
+        if (
+          paramValidationMode === 'ValidateAndShow' ||
+          paramValidationMode === 'ValidateAndHide' ||
+          paramValidationMode === 'NoValidation'
+        ) {
+          setValidationMode(paramValidationMode);
+        } else {
+          setValidationMode(hasSavedData ? 'ValidateAndShow' : 'ValidateAndHide');
+        }
+
+        // Reserved session-context channel: a custom app may pass
+        // `params.context` (device role, selected cluster, etc.). It is excluded
+        // from observation data (see FORMPARAMS_NON_DATA_KEYS) and exposed here
+        // read-only so extensions / custom question types can react to it.
+        const sessionContext = (params as Record<string, unknown> | null)?.[
+          'context'
+        ];
+        (window as unknown as Record<string, unknown>).formulusSessionContext =
+          sessionContext ?? null;
+
         if (savedData && Object.keys(savedData).length > 0) {
           console.log('Preloading saved data:', savedData);
           setData(
             dataMatchingSchemaRoot(savedData as FormData, formSchemaTyped),
           );
         } else {
-          const defaultData = initialFormDataFromParams(params);
+          // New observation: merge dynamic schema default tokens ($today/$now)
+          // for any field not already provided via params/defaultData.
+          const defaultData = applySchemaDefaultTokens(
+            initialFormDataFromParams(params),
+            formSchemaTyped,
+          );
           console.log('Preloading initialization form values:', defaultData);
           setData(dataMatchingSchemaRoot(defaultData, formSchemaTyped));
         }
@@ -807,7 +848,16 @@ function App() {
       }
     };
 
+    const handleShowValidation = () => {
+      // Idempotent: once shown, stays shown for the session.
+      setValidationMode(prev =>
+        prev === 'ValidateAndHide' ? 'ValidateAndShow' : prev,
+      );
+    };
+
     const handleFinalizeForm = (event: Event) => {
+      // Reaching finalize is a meaningful checkpoint: ensure validation is shown.
+      handleShowValidation();
       // Prefer the payload from the FinalizeRenderer if available
       const customEvent = event as CustomEvent<{
         formInitData?: FormInitData;
@@ -859,6 +909,10 @@ function App() {
       'finalizeForm',
       handleFinalizeForm as EventListener,
     );
+    window.addEventListener(
+      'formShowValidation',
+      handleShowValidation as EventListener,
+    );
 
     return () => {
       window.removeEventListener(
@@ -868,6 +922,10 @@ function App() {
       window.removeEventListener(
         'finalizeForm',
         handleFinalizeForm as EventListener,
+      );
+      window.removeEventListener(
+        'formShowValidation',
+        handleShowValidation as EventListener,
       );
     };
   }, [data, formInitData, draftSessionKey, uischema, schema]); // Include all dependencies
@@ -1192,7 +1250,7 @@ function App() {
                       ]}
                       cells={materialCells}
                       onChange={handleDataChange}
-                      validationMode="ValidateAndShow"
+                      validationMode={validationMode}
                       ajv={ajv}
                       additionalErrors={customValidatorErrors}
                     />

--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -39,6 +39,12 @@ import {
   applySchemaDefaultTokens,
   dataMatchingSchemaRoot,
 } from './utils/formObservationData';
+import {
+  collectStickyFieldPaths,
+  extractStickyValues,
+  applyStickyDefaults,
+} from './utils/stickyFieldHelpers';
+import { stickyService } from './services/StickyService';
 
 import SwipeLayoutRenderer, {
   swipeLayoutTester,
@@ -78,9 +84,9 @@ import SubObservationQuestionRenderer, {
 import { shellMaterialRenderers } from './theme/material-wrappers';
 import { numberStepperRenderer } from './renderers/NumberStepperRenderer';
 import DynamicEnumControl, { dynamicEnumTester } from './DynamicEnumControl';
-import MaterialTextControlWithImeHint, {
-  materialTextControlWithImeHintTester,
-} from './jsonforms/MaterialTextControlWithImeHint';
+import ShellInputControl, {
+  shellInputControlTester,
+} from './jsonforms/ShellInputControl';
 import type { KeyboardPrimaryEnterKeyHint } from './utils/keyboardEnterKeyHint';
 
 import ErrorBoundary from './components/ErrorBoundary';
@@ -180,6 +186,7 @@ const ensureSwipeLayoutRoot = (uiSchema: FormUISchema | null): FormUISchema => {
 // Function to process UI schema and ensure Finalize element is present
 const processUISchemaWithFinalize = (
   uiSchema: FormUISchema | null,
+  skipFinalize?: boolean,
 ): FormUISchema => {
   if (!uiSchema || !uiSchema.elements) {
     // If no UI schema or no elements, create a basic one with just Finalize
@@ -215,10 +222,12 @@ const processUISchemaWithFinalize = (
     });
   }
 
-  // Always add our Finalize element as the last element
-  elements.push({
-    type: 'Finalize',
-  });
+  // Append Finalize page unless skipFinalize (sub-observation fast path).
+  if (!skipFinalize) {
+    elements.push({
+      type: 'Finalize',
+    });
+  }
 
   processedUISchema.elements = elements;
   return processedUISchema;
@@ -252,8 +261,8 @@ export const useFormContext = () => useContext(FormContext);
 
 export const customRenderers = [
   {
-    tester: materialTextControlWithImeHintTester,
-    renderer: MaterialTextControlWithImeHint,
+    tester: shellInputControlTester,
+    renderer: ShellInputControl,
   },
   { tester: swipeLayoutTester, renderer: SwipeLayoutRenderer },
   { tester: groupAsSwipeLayoutTester, renderer: SwipeLayoutRenderer },
@@ -369,6 +378,9 @@ function App() {
           uiSchema,
           extensions,
         } = initData;
+        const skipFinalize = Boolean(
+          (initData as FormInitData & { skipFinalize?: boolean }).skipFinalize,
+        );
 
         setFormInitData(initData);
 
@@ -518,17 +530,20 @@ function App() {
           setSchema({} as FormSchema); // Set to empty schema or handle as per requirements
           // First ensure SwipeLayout root, then process to ensure Finalize element is present
           const swipeLayoutUISchema = ensureSwipeLayoutRoot(null);
-          const processedUISchema =
-            processUISchemaWithFinalize(swipeLayoutUISchema);
+          const processedUISchema = processUISchemaWithFinalize(
+            swipeLayoutUISchema,
+            skipFinalize,
+          );
           setUISchema(processedUISchema);
         } else {
           setSchema(formSchema as FormSchema);
-          // First ensure SwipeLayout root, then process to ensure Finalize element is present
           const swipeLayoutUISchema = ensureSwipeLayoutRoot(
             uiSchema as FormUISchema,
           );
-          const processedUISchema =
-            processUISchemaWithFinalize(swipeLayoutUISchema);
+          const processedUISchema = processUISchemaWithFinalize(
+            swipeLayoutUISchema,
+            skipFinalize,
+          );
           setUISchema(processedUISchema);
         }
 
@@ -567,9 +582,27 @@ function App() {
           setData(
             dataMatchingSchemaRoot(savedData as FormData, formSchemaTyped),
           );
+        } else if (!isSubObservationSession(initData)) {
+          const formVersion = (formSchemaTyped as { version?: string })
+            ?.version;
+          const layoutRoot = ensureSwipeLayoutRoot(uiSchema as FormUISchema);
+          const stickyPaths = collectStickyFieldPaths(layoutRoot);
+          const stored = stickyService.getStickyValues(
+            receivedFormType,
+            formVersion,
+          );
+          const relevantSticky: Record<string, unknown> = {};
+          for (const p of stickyPaths) {
+            if (stored[p] !== undefined) relevantSticky[p] = stored[p];
+          }
+          const withTokens = applySchemaDefaultTokens(
+            initialFormDataFromParams(params),
+            formSchemaTyped,
+          );
+          const withSticky = applyStickyDefaults(withTokens, relevantSticky);
+          console.log('Preloading initialization form values:', withSticky);
+          setData(dataMatchingSchemaRoot(withSticky, formSchemaTyped));
         } else {
-          // New observation: merge dynamic schema default tokens ($today/$now)
-          // for any field not already provided via params/defaultData.
           const defaultData = applySchemaDefaultTokens(
             initialFormDataFromParams(params),
             formSchemaTyped,
@@ -891,6 +924,19 @@ function App() {
               payloadFormInit.formType,
               draftSessionKey,
             );
+          }
+          // Persist sticky field values for next new observation of this form.
+          if (!isSubObservationSession(payloadFormInit) && uischema) {
+            const formVersion = (schema as { version?: string } | null)?.version;
+            const stickyPaths = collectStickyFieldPaths(uischema);
+            const stickyValues = extractStickyValues(payloadData, stickyPaths);
+            if (Object.keys(stickyValues).length > 0) {
+              stickyService.saveStickyValues(
+                payloadFormInit.formType,
+                formVersion,
+                stickyValues,
+              );
+            }
           }
           setSubmitError(null);
           setShowFinalizeMessage(true);

--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -551,9 +551,9 @@ function App() {
         // Deferred-validation policy. Honor an explicit host override first;
         // otherwise defer (hide) for brand-new observations and show for
         // edits / draft resumes so existing data is validated immediately.
-        const paramValidationMode = (params as Record<string, unknown> | null)?.[
-          'validationMode'
-        ];
+        const paramValidationMode = (
+          params as Record<string, unknown> | null
+        )?.['validationMode'];
         const hasSavedData = Boolean(
           savedData && Object.keys(savedData).length > 0,
         );
@@ -564,7 +564,9 @@ function App() {
         ) {
           setValidationMode(paramValidationMode);
         } else {
-          setValidationMode(hasSavedData ? 'ValidateAndShow' : 'ValidateAndHide');
+          setValidationMode(
+            hasSavedData ? 'ValidateAndShow' : 'ValidateAndHide',
+          );
         }
 
         // Reserved session-context channel: a custom app may pass
@@ -927,7 +929,8 @@ function App() {
           }
           // Persist sticky field values for next new observation of this form.
           if (!isSubObservationSession(payloadFormInit) && uischema) {
-            const formVersion = (schema as { version?: string } | null)?.version;
+            const formVersion = (schema as { version?: string } | null)
+              ?.version;
             const stickyPaths = collectStickyFieldPaths(uischema);
             const stickyValues = extractStickyValues(payloadData, stickyPaths);
             if (Object.keys(stickyValues).length > 0) {

--- a/formulus-formplayer/src/components/FormLayout.tsx
+++ b/formulus-formplayer/src/components/FormLayout.tsx
@@ -90,6 +90,7 @@ const FormLayout: React.FC<FormLayoutProps> = ({
   header,
   showNavigation = true,
   keyboardSubmitAction,
+  contentBottomPadding = 0,
 }) => {
   const handleFormSubmit = useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
@@ -110,7 +111,9 @@ const FormLayout: React.FC<FormLayoutProps> = ({
         overflowY: 'auto',
         overflowX: 'hidden',
         WebkitOverflowScrolling: 'touch',
-        paddingBottom: theme.spacing(2),
+        // Base breathing room + caller-provided extra so the last fields can
+        // scroll clear of the nav bar / on-screen keyboard.
+        paddingBottom: `calc(${theme.spacing(2)} + ${contentBottomPadding}px)`,
         overscrollBehavior: 'contain',
         position: 'relative',
       })}>

--- a/formulus-formplayer/src/components/QuestionShell.tsx
+++ b/formulus-formplayer/src/components/QuestionShell.tsx
@@ -1,5 +1,13 @@
 import React, { ReactNode } from 'react';
-import { Box, Typography, Alert, Stack, Divider, useTheme } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Alert,
+  Stack,
+  Divider,
+  useTheme,
+  alpha,
+} from '@mui/material';
 import ErrorOutline from '@mui/icons-material/ErrorOutline';
 import { useFormDensity } from '../context/FormDensityContext';
 import { tokens } from '../theme/tokens-adapter';
@@ -67,6 +75,35 @@ const normalizeError = (error?: string | string[] | null): string | null => {
   return error;
 };
 
+/** Shared typography for inline label + plain value text (computed read-only, etc.). */
+const INLINE_TEXT_SX = {
+  fontSize: '1rem',
+  lineHeight: 1.375,
+  m: 0,
+  p: 0,
+} as const;
+
+/** Vertical padding inside each inline row — keeps content clear of row dividers. */
+const INLINE_ROW_PY = 1.5;
+
+/** Label column band — CSS Grid `minmax(min, max)` on the first track. */
+const INLINE_LABEL_MIN_WIDTH = '28%';
+const INLINE_LABEL_MAX_WIDTH = '48%';
+
+/** Reset theme field margins inside inline value cells. */
+const inlineValueCellSx = {
+  minWidth: 0,
+  py: INLINE_ROW_PY,
+  '& .MuiFormControl-root, & .MuiTextField-root': {
+    marginTop: 0,
+    marginBottom: 0,
+  },
+  '& .MuiToggleButtonGroup-root': {
+    marginTop: 0,
+    marginBottom: 0,
+  },
+} as const;
+
 const QuestionShell: React.FC<QuestionShellProps> = ({
   title,
   description,
@@ -88,15 +125,20 @@ const QuestionShell: React.FC<QuestionShellProps> = ({
     : tokens.color.neutral[600];
 
   const effectiveLayout = labelLayout ?? contextLayout;
-  const useInline =
-    !block && effectiveLayout === 'inline' && Boolean(title);
+  const useInline = !block && effectiveLayout === 'inline' && Boolean(title);
+  const labelVerticalAlign = description ? 'top' : 'middle';
+
+  const rowDividerColor = isDark
+    ? tokens.color.neutral[600]
+    : tokens.color.neutral[300];
 
   const titleBlock = (title || description) && (
     <Stack spacing={0.5}>
       {title && (
         <Typography
+          component="div"
           variant="subtitle1"
-          sx={{ fontWeight: 700, lineHeight: 1.3, fontSize: '1rem' }}>
+          sx={{ ...INLINE_TEXT_SX, fontWeight: 700 }}>
           {renderHtmlContent(title)}
           {required && (
             <Box component="span" sx={{ color: 'error.main', ml: 0.5 }}>
@@ -107,15 +149,16 @@ const QuestionShell: React.FC<QuestionShellProps> = ({
       )}
       {description && (
         <Typography
+          component="div"
           variant="body2"
-          sx={{ color: subtitleColor, lineHeight: 1.4 }}>
+          sx={{ color: subtitleColor, lineHeight: 1.4, m: 0 }}>
           {renderHtmlContent(description)}
         </Typography>
       )}
     </Stack>
   );
 
-  const inputBlock = (
+  const stackedInputBlock = (
     <Box
       sx={{
         width: '100%',
@@ -135,23 +178,44 @@ const QuestionShell: React.FC<QuestionShellProps> = ({
         display: 'flex',
         flexDirection: 'column',
         gap: 1,
+        ...(useInline && {
+          position: 'relative',
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            bottom: 0,
+            height: '1px',
+            background: `linear-gradient(90deg, transparent 0%, ${alpha(rowDividerColor, isDark ? 0.45 : 0.65)} 18%, ${alpha(rowDividerColor, isDark ? 0.45 : 0.65)} 82%, transparent 100%)`,
+            pointerEvents: 'none',
+          },
+        }),
       }}>
       {useInline ? (
         <Box
           sx={{
-            display: 'grid',
-            gridTemplateColumns: { xs: '1fr', sm: 'minmax(0, 38%) 1fr' },
-            alignItems: 'start',
-            columnGap: 2,
-            rowGap: 1,
+            display: { xs: 'flex', sm: 'grid' },
+            flexDirection: { xs: 'column', sm: 'unset' },
+            width: '100%',
+            gridTemplateColumns: {
+              sm: `minmax(${INLINE_LABEL_MIN_WIDTH}, ${INLINE_LABEL_MAX_WIDTH}) minmax(0, 1fr)`,
+            },
+            columnGap: { sm: 2 },
+            rowGap: { xs: 1 },
+            alignItems: {
+              sm: labelVerticalAlign === 'top' ? 'start' : 'center',
+            },
           }}>
-          <Box sx={{ minWidth: 0 }}>{titleBlock}</Box>
-          {inputBlock}
+          <Box sx={{ minWidth: 0, py: INLINE_ROW_PY, pr: { sm: 2 } }}>
+            {titleBlock}
+          </Box>
+          <Box sx={inlineValueCellSx}>{children}</Box>
         </Box>
       ) : (
         <>
           {titleBlock}
-          {inputBlock}
+          {stackedInputBlock}
         </>
       )}
 
@@ -194,3 +258,4 @@ const QuestionShell: React.FC<QuestionShellProps> = ({
 };
 
 export default QuestionShell;
+export { INLINE_TEXT_SX };

--- a/formulus-formplayer/src/components/QuestionShell.tsx
+++ b/formulus-formplayer/src/components/QuestionShell.tsx
@@ -93,7 +93,7 @@ const QuestionShell: React.FC<QuestionShellProps> = ({
         width: '100%',
         display: 'flex',
         flexDirection: 'column',
-        gap: 1.5,
+        gap: 1,
       }}>
       {(title || description) && (
         <Stack spacing={0.5}>

--- a/formulus-formplayer/src/components/QuestionShell.tsx
+++ b/formulus-formplayer/src/components/QuestionShell.tsx
@@ -1,43 +1,33 @@
 import React, { ReactNode } from 'react';
-import { Box, Typography, Alert, Stack, Divider } from '@mui/material';
+import { Box, Typography, Alert, Stack, Divider, useTheme } from '@mui/material';
 import ErrorOutline from '@mui/icons-material/ErrorOutline';
+import { useFormDensity } from '../context/FormDensityContext';
+import { tokens } from '../theme/tokens-adapter';
 
 /**
  * Simple HTML sanitizer that removes dangerous tags and attributes.
- * This is a lightweight alternative that doesn't require external dependencies.
  */
 const sanitizeHtml = (html: string): string => {
-  // Remove script tags and their content
   let sanitized = html.replace(
     /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
     '',
   );
-  // Remove style tags and their content
   sanitized = sanitized.replace(
     /<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi,
     '',
   );
-  // Remove event handlers (onclick, onerror, etc.)
   sanitized = sanitized.replace(/\s*on\w+\s*=\s*["'][^"']*["']/gi, '');
   sanitized = sanitized.replace(/\s*on\w+\s*=\s*[^\s>]+/gi, '');
-  // Remove javascript: URLs
   sanitized = sanitized.replace(/javascript:/gi, '');
-  // Remove data: URLs in href/src (potential XSS vector)
   sanitized = sanitized.replace(/\s*href\s*=\s*["']?\s*data:/gi, ' href="');
   sanitized = sanitized.replace(/\s*src\s*=\s*["']?\s*data:/gi, ' src="');
 
   return sanitized;
 };
 
-/**
- * Renders content with basic HTML support.
- * Detects HTML tags and renders them safely using dangerouslySetInnerHTML.
- * Falls back to plain text for non-HTML content.
- */
 const renderHtmlContent = (content: string | undefined): React.ReactNode => {
   if (!content) return null;
 
-  // Check for HTML tags - looks for < followed by a letter (tag start)
   const htmlTagPattern = /<[a-z][a-z0-9]*(\s+[^>]*)?>/i;
   const hasHtmlTags = htmlTagPattern.test(content);
 
@@ -46,13 +36,11 @@ const renderHtmlContent = (content: string | undefined): React.ReactNode => {
       const sanitized = sanitizeHtml(content);
       return <span dangerouslySetInnerHTML={{ __html: sanitized }} />;
     } catch (error) {
-      // If sanitization fails, strip all HTML tags
       console.error('Error rendering HTML content:', error);
       return content.replace(/<[^>]*>/g, '');
     }
   }
 
-  // No HTML tags detected, render as plain text
   return content;
 };
 
@@ -64,6 +52,10 @@ export interface QuestionShellProps {
   helperText?: ReactNode;
   actions?: ReactNode;
   metadata?: ReactNode;
+  /** Full-width layout (colspan 2) for large/media controls. */
+  block?: boolean;
+  /** Per-instance layout override from control `options.labelLayout`. */
+  labelLayout?: 'inline' | 'stacked';
   children: ReactNode;
 }
 
@@ -83,9 +75,58 @@ const QuestionShell: React.FC<QuestionShellProps> = ({
   helperText,
   actions,
   metadata,
+  block = false,
+  labelLayout,
   children,
 }) => {
+  const theme = useTheme();
+  const { labelLayout: contextLayout } = useFormDensity();
   const normalizedError = normalizeError(error);
+  const isDark = theme.palette.mode === 'dark';
+  const subtitleColor = isDark
+    ? tokens.color.neutral[400]
+    : tokens.color.neutral[600];
+
+  const effectiveLayout = labelLayout ?? contextLayout;
+  const useInline =
+    !block && effectiveLayout === 'inline' && Boolean(title);
+
+  const titleBlock = (title || description) && (
+    <Stack spacing={0.5}>
+      {title && (
+        <Typography
+          variant="subtitle1"
+          sx={{ fontWeight: 700, lineHeight: 1.3, fontSize: '1rem' }}>
+          {renderHtmlContent(title)}
+          {required && (
+            <Box component="span" sx={{ color: 'error.main', ml: 0.5 }}>
+              *
+            </Box>
+          )}
+        </Typography>
+      )}
+      {description && (
+        <Typography
+          variant="body2"
+          sx={{ color: subtitleColor, lineHeight: 1.4 }}>
+          {renderHtmlContent(description)}
+        </Typography>
+      )}
+    </Stack>
+  );
+
+  const inputBlock = (
+    <Box
+      sx={{
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1,
+        minWidth: 0,
+      }}>
+      {children}
+    </Box>
+  );
 
   return (
     <Box
@@ -95,24 +136,23 @@ const QuestionShell: React.FC<QuestionShellProps> = ({
         flexDirection: 'column',
         gap: 1,
       }}>
-      {(title || description) && (
-        <Stack spacing={0.5}>
-          {title && (
-            <Typography variant="h6" sx={{ fontWeight: 700, lineHeight: 1.3 }}>
-              {renderHtmlContent(title)}
-              {required && (
-                <Box component="span" sx={{ color: 'error.main', ml: 0.5 }}>
-                  *
-                </Box>
-              )}
-            </Typography>
-          )}
-          {description && (
-            <Typography variant="body1" color="text.secondary">
-              {renderHtmlContent(description)}
-            </Typography>
-          )}
-        </Stack>
+      {useInline ? (
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', sm: 'minmax(0, 38%) 1fr' },
+            alignItems: 'start',
+            columnGap: 2,
+            rowGap: 1,
+          }}>
+          <Box sx={{ minWidth: 0 }}>{titleBlock}</Box>
+          {inputBlock}
+        </Box>
+      ) : (
+        <>
+          {titleBlock}
+          {inputBlock}
+        </>
       )}
 
       {normalizedError && (
@@ -130,20 +170,10 @@ const QuestionShell: React.FC<QuestionShellProps> = ({
         </Alert>
       )}
 
-      <Box
-        sx={{
-          width: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 1,
-        }}>
-        {children}
-      </Box>
-
       {(helperText || actions) && (
         <Stack spacing={1}>
           {helperText && (
-            <Typography variant="body2" color="text.secondary">
+            <Typography variant="body2" sx={{ color: subtitleColor }}>
               {typeof helperText === 'string'
                 ? renderHtmlContent(helperText)
                 : helperText}

--- a/formulus-formplayer/src/context/FormDensityContext.tsx
+++ b/formulus-formplayer/src/context/FormDensityContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+export type LabelLayout = 'inline' | 'stacked';
+
+export interface FormDensityContextValue {
+  labelLayout: LabelLayout;
+}
+
+export const FormDensityContext = createContext<FormDensityContextValue>({
+  labelLayout: 'stacked',
+});
+
+export const useFormDensity = () => useContext(FormDensityContext);

--- a/formulus-formplayer/src/jsonforms/ShellInputControl.tsx
+++ b/formulus-formplayer/src/jsonforms/ShellInputControl.tsx
@@ -21,11 +21,12 @@ const ShellInputControl = (props: ControlProps) => {
 
   if (visible === false) return null;
 
-  const title = (uischema as { label?: string })?.label || schema?.title || label;
+  const title =
+    (uischema as { label?: string })?.label || schema?.title || label;
   const description = schema?.description;
   const isRequired = Boolean(
     (uischema as { options?: { required?: boolean } })?.options?.required ??
-      required,
+    required,
   );
   const errorStr = Array.isArray(errors)
     ? errors.filter(Boolean).join(', ')

--- a/formulus-formplayer/src/jsonforms/ShellInputControl.tsx
+++ b/formulus-formplayer/src/jsonforms/ShellInputControl.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {
+  ControlProps,
+  isStringControl,
+  RankedTester,
+  rankWith,
+} from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import { MuiInputText } from '@jsonforms/material-renderers';
+import QuestionShell from '../components/QuestionShell';
+import { useFormContext } from '../App';
+
+/**
+ * String control that renders the stock MuiInputText cell inside QuestionShell
+ * (two-column layout + unified typography) instead of MaterialInputControl's
+ * floating InputLabel.
+ */
+const ShellInputControl = (props: ControlProps) => {
+  const { keyboardEnterKeyHint } = useFormContext();
+  const { uischema, schema, errors, label, visible, required } = props;
+
+  if (visible === false) return null;
+
+  const title = (uischema as { label?: string })?.label || schema?.title || label;
+  const description = schema?.description;
+  const isRequired = Boolean(
+    (uischema as { options?: { required?: boolean } })?.options?.required ??
+      required,
+  );
+  const errorStr = Array.isArray(errors)
+    ? errors.filter(Boolean).join(', ')
+    : errors || null;
+  const isValid = !errorStr;
+
+  return (
+    <QuestionShell
+      title={title}
+      description={description}
+      required={isRequired}
+      error={errorStr}>
+      <MuiInputText
+        {...(props as React.ComponentProps<typeof MuiInputText>)}
+        label={undefined}
+        isValid={isValid}
+        muiInputProps={
+          keyboardEnterKeyHint
+            ? { enterKeyHint: keyboardEnterKeyHint }
+            : undefined
+        }
+      />
+    </QuestionShell>
+  );
+};
+
+export const shellInputControlTester: RankedTester = rankWith(
+  2,
+  isStringControl,
+);
+
+export default withJsonFormsControlProps(ShellInputControl);

--- a/formulus-formplayer/src/renderers/AudioQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/AudioQuestionRenderer.tsx
@@ -376,7 +376,8 @@ const AudioQuestionRenderer: React.FC<ControlProps> = ({
     typeof meta?.duration === 'number';
 
   return (
-    <QuestionShell block
+    <QuestionShell
+      block
       title={label}
       description={description}
       required={isRequired}

--- a/formulus-formplayer/src/renderers/AudioQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/AudioQuestionRenderer.tsx
@@ -376,7 +376,7 @@ const AudioQuestionRenderer: React.FC<ControlProps> = ({
     typeof meta?.duration === 'number';
 
   return (
-    <QuestionShell
+    <QuestionShell block
       title={label}
       description={description}
       required={isRequired}

--- a/formulus-formplayer/src/renderers/CustomQuestionTypeAdapter.tsx
+++ b/formulus-formplayer/src/renderers/CustomQuestionTypeAdapter.tsx
@@ -124,6 +124,7 @@ export function createCustomQuestionTypeRenderer(
     label,
     description,
     required,
+    visible,
   }) => {
     // Build the simplified props for the custom component
     const hasErrors =
@@ -211,11 +212,21 @@ export function createCustomQuestionTypeRenderer(
         message: errorMessage,
       },
       enabled: enabled ?? true,
+      visible: visible ?? true,
       fieldPath: path,
       label: label ?? '',
       description: description,
       jsonFormsContext,
     };
+
+    // Honor JSON Forms visibility rules (SHOW/HIDE). The dispatcher renders a
+    // matched control regardless of its rule outcome, so each renderer must
+    // hide itself when `visible === false`; otherwise custom question types
+    // would always render and ignore relevance rules (matches the built-in
+    // renderers, e.g. QrcodeQuestionRenderer/AdateQuestionRenderer).
+    if (visible === false) {
+      return null;
+    }
 
     return (
       <QuestionShell

--- a/formulus-formplayer/src/renderers/FileQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/FileQuestionRenderer.tsx
@@ -192,7 +192,8 @@ const FileQuestionRenderer: React.FC<ControlProps> = ({
   );
 
   return (
-    <QuestionShell block
+    <QuestionShell
+      block
       title={label}
       description={description}
       required={isRequired}

--- a/formulus-formplayer/src/renderers/FileQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/FileQuestionRenderer.tsx
@@ -192,7 +192,7 @@ const FileQuestionRenderer: React.FC<ControlProps> = ({
   );
 
   return (
-    <QuestionShell
+    <QuestionShell block
       title={label}
       description={description}
       required={isRequired}

--- a/formulus-formplayer/src/renderers/GPSQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/GPSQuestionRenderer.tsx
@@ -148,7 +148,7 @@ const GPSQuestionRenderer: React.FC<GPSQuestionRendererProps> = props => {
   const isDisabled = !enabled || isCapturing;
 
   return (
-    <QuestionShell
+    <QuestionShell block
       title={schema.title || 'GPS Location'}
       description={schema.description}
       required={Boolean(

--- a/formulus-formplayer/src/renderers/GPSQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/GPSQuestionRenderer.tsx
@@ -148,7 +148,8 @@ const GPSQuestionRenderer: React.FC<GPSQuestionRendererProps> = props => {
   const isDisabled = !enabled || isCapturing;
 
   return (
-    <QuestionShell block
+    <QuestionShell
+      block
       title={schema.title || 'GPS Location'}
       description={schema.description}
       required={Boolean(

--- a/formulus-formplayer/src/renderers/NumberStepperRenderer.tsx
+++ b/formulus-formplayer/src/renderers/NumberStepperRenderer.tsx
@@ -38,6 +38,8 @@ const NumberStepperRenderer = ({
   visible,
   required,
 }: ControlProps) => {
+  const [isFocused, setIsFocused] = useState(false);
+
   if (visible === false) return null;
 
   const numericValue =
@@ -86,8 +88,6 @@ const NumberStepperRenderer = ({
   const currentValue = numericValue || 0;
   const addDisabled = max !== undefined && currentValue >= max;
   const subtractDisabled = min !== undefined && currentValue <= min;
-
-  const [isFocused, setIsFocused] = useState(false);
 
   const errorStr = Array.isArray(errors)
     ? errors.filter(Boolean).join(', ')

--- a/formulus-formplayer/src/renderers/NumberStepperRenderer.tsx
+++ b/formulus-formplayer/src/renderers/NumberStepperRenderer.tsx
@@ -51,7 +51,7 @@ const NumberStepperRenderer = ({
   const description = schema.description;
   const isRequired = Boolean(
     (uischema as { options?: { required?: boolean } })?.options?.required ??
-      required,
+    required,
   );
 
   const handleAdd = () => {

--- a/formulus-formplayer/src/renderers/NumberStepperRenderer.tsx
+++ b/formulus-formplayer/src/renderers/NumberStepperRenderer.tsx
@@ -2,7 +2,7 @@
  * NumberStepperRenderer
  *
  * Custom renderer for number/integer fields that adds simple +/- buttons
- * via Material-UI's InputAdornment. Preserves all default Material-UI behavior.
+ * via Material-UI's InputAdornment. Uses QuestionShell for unified layout.
  */
 
 import React, { useState } from 'react';
@@ -16,9 +16,10 @@ import {
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { TextField, InputAdornment, IconButton } from '@mui/material';
 import { Add, Remove } from '@mui/icons-material';
+import QuestionShell from '../components/QuestionShell';
 
 const isNumberControl: RankedTester = rankWith(
-  5, // Higher priority to override default Material-UI number renderer (rank 2)
+  5,
   schemaMatches(schema => {
     const type = schema.type;
     return type === 'number' || type === 'integer';
@@ -30,16 +31,28 @@ const NumberStepperRenderer = ({
   handleChange,
   path,
   schema,
-  uischema: _uischema,
+  uischema,
   errors,
   enabled = true,
-  label, // ControlProps includes label automatically resolved by JSON Forms
+  label,
+  visible,
+  required,
 }: ControlProps) => {
+  if (visible === false) return null;
+
   const numericValue =
     data !== undefined && data !== null && data !== '' ? Number(data) : 0;
-  const min = schema.minimum ?? (schema as any).minimum;
-  const max = schema.maximum ?? (schema as any).maximum;
-  const step = schema.multipleOf ?? (schema as any).step ?? 1;
+  const min = schema.minimum ?? (schema as { minimum?: number }).minimum;
+  const max = schema.maximum ?? (schema as { maximum?: number }).maximum;
+  const step = schema.multipleOf ?? (schema as { step?: number }).step ?? 1;
+
+  const title =
+    (uischema as { label?: string })?.label || schema.title || label;
+  const description = schema.description;
+  const isRequired = Boolean(
+    (uischema as { options?: { required?: boolean } })?.options?.required ??
+      required,
+  );
 
   const handleAdd = () => {
     const currentValue = numericValue || 0;
@@ -65,15 +78,8 @@ const NumberStepperRenderer = ({
     }
     const numValue = Number(value);
     if (!isNaN(numValue)) {
-      // Apply min/max constraints
-      let constrainedValue = numValue;
-      if (min !== undefined && constrainedValue < min) {
-        constrainedValue = min;
-      }
-      if (max !== undefined && constrainedValue > max) {
-        constrainedValue = max;
-      }
-      handleChange(path, constrainedValue);
+      // Do not clamp while typing — validation surfaces out-of-range values.
+      handleChange(path, numValue);
     }
   };
 
@@ -81,75 +87,68 @@ const NumberStepperRenderer = ({
   const addDisabled = max !== undefined && currentValue >= max;
   const subtractDisabled = min !== undefined && currentValue <= min;
 
-  // Track focus state to show helper text only when focused
   const [isFocused, setIsFocused] = useState(false);
 
-  // Use schema.description for helper text (like "Please enter your age", "Height in centimeters")
-  // Show errors if present, otherwise show description only when focused
-  const helperText = errors
-    ? Array.isArray(errors)
-      ? errors.join(', ')
-      : String(errors)
-    : isFocused
-      ? schema.description
-      : undefined;
+  const errorStr = Array.isArray(errors)
+    ? errors.filter(Boolean).join(', ')
+    : errors || null;
 
   return (
-    <TextField
-      label={label}
-      type="number"
-      value={numericValue === 0 && data === undefined ? '' : numericValue}
-      onChange={handleInputChange}
-      onFocus={() => setIsFocused(true)}
-      onBlur={() => setIsFocused(false)}
-      disabled={!enabled}
-      error={Boolean(errors)}
-      helperText={helperText}
-      inputProps={{
-        min,
-        max,
-        step,
-      }}
-      InputProps={{
-        endAdornment: isFocused ? (
-          <InputAdornment position="end">
-            <IconButton
-              size="small"
-              onClick={handleSubtract}
-              onMouseDown={e => e.preventDefault()}
-              disabled={subtractDisabled || !enabled}
-              edge="end"
-              aria-label={`Decrease ${label || 'value'}`}>
-              <Remove fontSize="small" />
-            </IconButton>
-            <IconButton
-              size="small"
-              onClick={handleAdd}
-              onMouseDown={e => e.preventDefault()}
-              disabled={addDisabled || !enabled}
-              edge="end"
-              aria-label={`Increase ${label || 'value'}`}>
-              <Add fontSize="small" />
-            </IconButton>
-          </InputAdornment>
-        ) : null,
-      }}
-      sx={{
-        width: '100%',
-        // Hide native number input spinners
-        '& input[type="number"]': {
-          '-moz-appearance': 'textfield',
-          '&::-webkit-outer-spin-button': {
-            '-webkit-appearance': 'none',
-            margin: 0,
+    <QuestionShell
+      title={title}
+      description={description}
+      required={isRequired}
+      error={errorStr}>
+      <TextField
+        type="number"
+        value={numericValue === 0 && data === undefined ? '' : numericValue}
+        onChange={handleInputChange}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        disabled={!enabled}
+        error={Boolean(errorStr)}
+        fullWidth
+        inputProps={{ step }}
+        InputProps={{
+          endAdornment: isFocused ? (
+            <InputAdornment position="end">
+              <IconButton
+                size="small"
+                onClick={handleSubtract}
+                onMouseDown={e => e.preventDefault()}
+                disabled={subtractDisabled || !enabled}
+                edge="end"
+                aria-label={`Decrease ${title || 'value'}`}>
+                <Remove fontSize="small" />
+              </IconButton>
+              <IconButton
+                size="small"
+                onClick={handleAdd}
+                onMouseDown={e => e.preventDefault()}
+                disabled={addDisabled || !enabled}
+                edge="end"
+                aria-label={`Increase ${title || 'value'}`}>
+                <Add fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ) : null,
+        }}
+        sx={{
+          width: '100%',
+          '& input[type="number"]': {
+            MozAppearance: 'textfield',
+            '&::-webkit-outer-spin-button': {
+              WebkitAppearance: 'none',
+              margin: 0,
+            },
+            '&::-webkit-inner-spin-button': {
+              WebkitAppearance: 'none',
+              margin: 0,
+            },
           },
-          '&::-webkit-inner-spin-button': {
-            '-webkit-appearance': 'none',
-            margin: 0,
-          },
-        },
-      }}
-    />
+        }}
+      />
+    </QuestionShell>
   );
 };
 

--- a/formulus-formplayer/src/renderers/PhotoQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/PhotoQuestionRenderer.tsx
@@ -240,7 +240,7 @@ const PhotoQuestionRenderer: React.FC<PhotoQuestionProps> = ({
   );
 
   return (
-    <QuestionShell
+    <QuestionShell block
       title={label}
       description={description}
       required={isRequired}

--- a/formulus-formplayer/src/renderers/PhotoQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/PhotoQuestionRenderer.tsx
@@ -240,7 +240,8 @@ const PhotoQuestionRenderer: React.FC<PhotoQuestionProps> = ({
   );
 
   return (
-    <QuestionShell block
+    <QuestionShell
+      block
       title={label}
       description={description}
       required={isRequired}

--- a/formulus-formplayer/src/renderers/QrcodeQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/QrcodeQuestionRenderer.tsx
@@ -141,7 +141,8 @@ const QrcodeQuestionRenderer: React.FC<ControlProps> = ({
   const validationError = errors && errors.length > 0 ? String(errors) : null;
 
   return (
-    <QuestionShell block
+    <QuestionShell
+      block
       title={label}
       description={description}
       required={isRequired}

--- a/formulus-formplayer/src/renderers/QrcodeQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/QrcodeQuestionRenderer.tsx
@@ -141,7 +141,7 @@ const QrcodeQuestionRenderer: React.FC<ControlProps> = ({
   const validationError = errors && errors.length > 0 ? String(errors) : null;
 
   return (
-    <QuestionShell
+    <QuestionShell block
       title={label}
       description={description}
       required={isRequired}

--- a/formulus-formplayer/src/renderers/SignatureQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SignatureQuestionRenderer.tsx
@@ -221,7 +221,7 @@ const SignatureQuestionRenderer: React.FC<ControlProps> = ({
     errors && (Array.isArray(errors) ? errors.join(', ') : errors);
 
   return (
-    <QuestionShell
+    <QuestionShell block
       title={schema.title}
       description={schema.description}
       required={Boolean(

--- a/formulus-formplayer/src/renderers/SignatureQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SignatureQuestionRenderer.tsx
@@ -221,7 +221,8 @@ const SignatureQuestionRenderer: React.FC<ControlProps> = ({
     errors && (Array.isArray(errors) ? errors.join(', ') : errors);
 
   return (
-    <QuestionShell block
+    <QuestionShell
+      block
       title={schema.title}
       description={schema.description}
       required={Boolean(

--- a/formulus-formplayer/src/renderers/SubObservationQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SubObservationQuestionRenderer.tsx
@@ -351,7 +351,8 @@ const SubObservationQuestionRendererInner: React.FC<ControlProps> = ({
       : String(errors));
 
   return (
-    <QuestionShell block
+    <QuestionShell
+      block
       title={label ?? ''}
       description={description}
       required={required}

--- a/formulus-formplayer/src/renderers/SubObservationQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SubObservationQuestionRenderer.tsx
@@ -225,7 +225,10 @@ const SubObservationQuestionRendererInner: React.FC<ControlProps> = ({
         childFormType,
         baseValues,
         {},
-        { subObservationMode: true },
+        {
+          subObservationMode: true,
+          skipFinalize: Boolean(config.skipFinalize),
+        },
       );
       if (result?.status === 'form_submitted' && result.formData) {
         const row = result.formData as Record<string, unknown>;
@@ -273,7 +276,10 @@ const SubObservationQuestionRendererInner: React.FC<ControlProps> = ({
           childFormType,
           {},
           savedData,
-          { subObservationMode: true },
+          {
+            subObservationMode: true,
+            skipFinalize: Boolean(config.skipFinalize),
+          },
         );
         if (
           result &&
@@ -345,7 +351,7 @@ const SubObservationQuestionRendererInner: React.FC<ControlProps> = ({
       : String(errors));
 
   return (
-    <QuestionShell
+    <QuestionShell block
       title={label ?? ''}
       description={description}
       required={required}

--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -348,6 +348,13 @@ const SwipeLayoutRenderer = ({
       const isNavigatingForward = newPage > currentPage;
       const isOnFinalize = layouts[currentPage]?.type === 'Finalize';
 
+      // Deferred validation: once the enumerator moves forward, surface
+      // validation so empty/invalid required fields they are leaving behind are
+      // highlighted. App.tsx listens and switches JsonForms to ValidateAndShow.
+      if (isNavigatingForward) {
+        window.dispatchEvent(new CustomEvent('formShowValidation'));
+      }
+
       if (isNavigatingForward && !isOnFinalize) {
         const missingFields = getMissingRequiredFieldsOnPage();
 

--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -28,6 +28,10 @@ import { draftService } from '../services/DraftService';
 import FormProgressBar from '../components/FormProgressBar';
 import FormLayout from '../components/FormLayout';
 import {
+  FormDensityContext,
+  type LabelLayout,
+} from '../context/FormDensityContext';
+import {
   collectVisibleControlsInSubtree,
   pageIsVisibleInSwipe,
   visiblePageIndicesFromLayouts,
@@ -88,9 +92,13 @@ const SwipeLayoutRenderer = ({
   renderers,
   cells,
   enabled,
+  visible,
   currentPage,
   onPageChange,
 }: SwipeLayoutProps) => {
+  if (visible === false) {
+    return null;
+  }
   const theme = useTheme();
   const [isNavigating, setIsNavigating] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
@@ -133,6 +141,12 @@ const SwipeLayoutRenderer = ({
     }, [uischema]);
 
   const autoFocusFirstInput = swipeOptions.autoFocusFirstInput !== false;
+  const labelLayout: LabelLayout =
+    swipeOptions.labelLayout === 'stacked' ? 'stacked' : 'inline';
+  const showInnerTitle = swipeOptions.showInnerTitle === true;
+  const skipFinalize = Boolean(
+    (formInitData as { skipFinalize?: boolean } | null)?.skipFinalize,
+  );
 
   const swipeScreenRef = useRef<HTMLDivElement>(null);
 
@@ -412,6 +426,23 @@ const SwipeLayoutRenderer = ({
     return layouts[currentPage]?.type === 'Finalize';
   }, [layouts, currentPage]);
 
+  const isLastContentPage =
+    nextVisiblePage === null && !isOnFinalizePage;
+
+  const trySubmitForm = useCallback(() => {
+    if (!formInitData) return;
+    window.dispatchEvent(
+      new CustomEvent('formShowValidation'),
+    );
+    const errorCount = core?.errors?.length ?? 0;
+    if (errorCount > 0) return;
+    window.dispatchEvent(
+      new CustomEvent('finalizeForm', {
+        detail: { formInitData, data },
+      }),
+    );
+  }, [formInitData, data, core?.errors]);
+
   const keyboardSubmitAction = useMemo(() => {
     const errorCount = core?.errors?.length ?? 0;
     if (isOnFinalizePage) {
@@ -425,6 +456,12 @@ const SwipeLayoutRenderer = ({
           );
         },
         disabled: errorCount > 0 || !formInitData,
+      };
+    }
+    if (skipFinalize && isLastContentPage) {
+      return {
+        onTrigger: trySubmitForm,
+        disabled: errorCount > 0 || !formInitData || isNavigating,
       };
     }
     if (nextVisiblePage !== null) {
@@ -441,7 +478,9 @@ const SwipeLayoutRenderer = ({
     isNavigating,
     core?.errors,
     formInitData,
-    data,
+    trySubmitForm,
+    skipFinalize,
+    isLastContentPage,
   ]);
 
   const keyboardEnterKeyHint = useMemo(
@@ -498,18 +537,24 @@ const SwipeLayoutRenderer = ({
     swipeOptions.headerTitle || (schema as any)?.title || undefined;
   const headerFields: string[] = (swipeOptions.headerFields || []).slice(0, 2);
 
+  const densityContextValue = useMemo(
+    () => ({ labelLayout }),
+    [labelLayout],
+  );
+
   // ----- Render -----
 
   return (
+    <FormDensityContext.Provider value={densityContextValue}>
     <FormContext.Provider value={formContextForSwipe}>
       <FormLayout
         keyboardSubmitAction={keyboardSubmitAction}
         header={
           <>
             {/* Author-configured form title and sticky fields */}
-            {(headerTitle || headerFields.length > 0) && (
+            {((showInnerTitle && headerTitle) || headerFields.length > 0) && (
               <Box sx={{ pb: headerFields.length > 0 ? 0 : 0.25 }}>
-                {headerTitle && (
+                {showInnerTitle && headerTitle && (
                   <Typography
                     variant="subtitle2"
                     sx={{
@@ -595,7 +640,16 @@ const SwipeLayoutRenderer = ({
             : undefined
         }
         nextButton={
-          nextVisiblePage !== null
+          skipFinalize && isLastContentPage
+            ? {
+                onClick: trySubmitForm,
+                disabled:
+                  isNavigating ||
+                  !formInitData ||
+                  (core?.errors?.length ?? 0) > 0,
+                label: finalizeButtonLabelOption ?? 'Done',
+              }
+            : nextVisiblePage !== null
             ? {
                 onClick: () => navigateToPage(nextVisiblePage),
                 disabled: isNavigating,
@@ -688,6 +742,7 @@ const SwipeLayoutRenderer = ({
           )}
       </FormLayout>
     </FormContext.Provider>
+    </FormDensityContext.Provider>
   );
 };
 

--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -96,9 +96,6 @@ const SwipeLayoutRenderer = ({
   currentPage,
   onPageChange,
 }: SwipeLayoutProps) => {
-  if (visible === false) {
-    return null;
-  }
   const theme = useTheme();
   const [isNavigating, setIsNavigating] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
@@ -535,6 +532,10 @@ const SwipeLayoutRenderer = ({
   const headerFields: string[] = (swipeOptions.headerFields || []).slice(0, 2);
 
   const densityContextValue = useMemo(() => ({ labelLayout }), [labelLayout]);
+
+  if (visible === false) {
+    return null;
+  }
 
   // ----- Render -----
 

--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -426,14 +426,11 @@ const SwipeLayoutRenderer = ({
     return layouts[currentPage]?.type === 'Finalize';
   }, [layouts, currentPage]);
 
-  const isLastContentPage =
-    nextVisiblePage === null && !isOnFinalizePage;
+  const isLastContentPage = nextVisiblePage === null && !isOnFinalizePage;
 
   const trySubmitForm = useCallback(() => {
     if (!formInitData) return;
-    window.dispatchEvent(
-      new CustomEvent('formShowValidation'),
-    );
+    window.dispatchEvent(new CustomEvent('formShowValidation'));
     const errorCount = core?.errors?.length ?? 0;
     if (errorCount > 0) return;
     window.dispatchEvent(
@@ -537,211 +534,211 @@ const SwipeLayoutRenderer = ({
     swipeOptions.headerTitle || (schema as any)?.title || undefined;
   const headerFields: string[] = (swipeOptions.headerFields || []).slice(0, 2);
 
-  const densityContextValue = useMemo(
-    () => ({ labelLayout }),
-    [labelLayout],
-  );
+  const densityContextValue = useMemo(() => ({ labelLayout }), [labelLayout]);
 
   // ----- Render -----
 
   return (
     <FormDensityContext.Provider value={densityContextValue}>
-    <FormContext.Provider value={formContextForSwipe}>
-      <FormLayout
-        keyboardSubmitAction={keyboardSubmitAction}
-        header={
-          <>
-            {/* Author-configured form title and sticky fields */}
-            {((showInnerTitle && headerTitle) || headerFields.length > 0) && (
-              <Box sx={{ pb: headerFields.length > 0 ? 0 : 0.25 }}>
-                {showInnerTitle && headerTitle && (
-                  <Typography
-                    variant="subtitle2"
-                    sx={{
-                      fontWeight: 700,
-                      fontSize: '1.125rem',
-                      lineHeight: 1.3,
-                      color: 'text.primary',
-                      mb: headerFields.length > 0 ? 0.5 : 0,
-                      textAlign: 'left',
-                    }}>
-                    {headerTitle}
-                  </Typography>
-                )}
-                {headerFields.length > 0 && (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexWrap: 'wrap',
-                      gap: 0.5,
-                      pb: 0.5,
-                    }}>
-                    {headerFields.map((fieldKey: string) => {
-                      const fieldSchema = (schema as any)?.properties?.[
-                        fieldKey
-                      ];
-                      const label = fieldSchema?.title || fieldKey;
-                      const value = data?.[fieldKey];
-                      const displayValue =
-                        value != null && value !== '' ? String(value) : '—';
-                      return (
-                        <Typography
-                          key={fieldKey}
-                          variant="caption"
-                          sx={{
-                            px: 1,
-                            py: 0.25,
-                            borderRadius: 1,
-                            backgroundColor: 'action.hover',
-                            fontSize: '0.75rem',
-                            color:
-                              displayValue === '—'
-                                ? 'text.disabled'
-                                : 'text.primary',
-                            fontWeight: displayValue === '—' ? 400 : 600,
-                            textAlign: 'left',
-                          }}>
-                          {label}: {displayValue}
-                        </Typography>
-                      );
-                    })}
-                  </Box>
-                )}
-              </Box>
+      <FormContext.Provider value={formContextForSwipe}>
+        <FormLayout
+          keyboardSubmitAction={keyboardSubmitAction}
+          header={
+            <>
+              {/* Author-configured form title and sticky fields */}
+              {((showInnerTitle && headerTitle) || headerFields.length > 0) && (
+                <Box sx={{ pb: headerFields.length > 0 ? 0 : 0.25 }}>
+                  {showInnerTitle && headerTitle && (
+                    <Typography
+                      variant="subtitle2"
+                      sx={{
+                        fontWeight: 700,
+                        fontSize: '1.125rem',
+                        lineHeight: 1.3,
+                        color: 'text.primary',
+                        mb: headerFields.length > 0 ? 0.5 : 0,
+                        textAlign: 'left',
+                      }}>
+                      {headerTitle}
+                    </Typography>
+                  )}
+                  {headerFields.length > 0 && (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        gap: 0.5,
+                        pb: 0.5,
+                      }}>
+                      {headerFields.map((fieldKey: string) => {
+                        const fieldSchema = (schema as any)?.properties?.[
+                          fieldKey
+                        ];
+                        const label = fieldSchema?.title || fieldKey;
+                        const value = data?.[fieldKey];
+                        const displayValue =
+                          value != null && value !== '' ? String(value) : '—';
+                        return (
+                          <Typography
+                            key={fieldKey}
+                            variant="caption"
+                            sx={{
+                              px: 1,
+                              py: 0.25,
+                              borderRadius: 1,
+                              backgroundColor: 'action.hover',
+                              fontSize: '0.75rem',
+                              color:
+                                displayValue === '—'
+                                  ? 'text.disabled'
+                                  : 'text.primary',
+                              fontWeight: displayValue === '—' ? 400 : 600,
+                              textAlign: 'left',
+                            }}>
+                            {label}: {displayValue}
+                          </Typography>
+                        );
+                      })}
+                    </Box>
+                  )}
+                </Box>
+              )}
+              <FormProgressBar
+                currentPage={visiblePosition}
+                totalScreens={totalVisibleScreens}
+                data={data}
+                schema={schema}
+                uischema={uischema}
+                mode="screens"
+                isOnFinalizePage={isOnFinalizePage}
+                onNavigatePrevious={
+                  prevVisiblePage !== null
+                    ? () => navigateToPage(prevVisiblePage)
+                    : undefined
+                }
+                onNavigateNext={
+                  nextVisiblePage !== null
+                    ? () => navigateToPage(nextVisiblePage)
+                    : undefined
+                }
+                navigationDisabled={isNavigating}
+              />
+            </>
+          }
+          previousButton={
+            prevVisiblePage !== null
+              ? {
+                  onClick: () => navigateToPage(prevVisiblePage),
+                  disabled: isNavigating,
+                }
+              : undefined
+          }
+          nextButton={
+            skipFinalize && isLastContentPage
+              ? {
+                  onClick: trySubmitForm,
+                  disabled:
+                    isNavigating ||
+                    !formInitData ||
+                    (core?.errors?.length ?? 0) > 0,
+                  label: finalizeButtonLabelOption ?? 'Done',
+                }
+              : nextVisiblePage !== null
+                ? {
+                    onClick: () => navigateToPage(nextVisiblePage),
+                    disabled: isNavigating,
+                    label: nextButtonLabelOption,
+                  }
+                : undefined
+          }
+          contentBottomPadding={80}
+          showNavigation={true}>
+          <div
+            ref={mergedSwipeScreenRef}
+            {...swipeHandlers}
+            className="swipelayout_screen">
+            {(uischema as any)?.label && <h1>{(uischema as any).label}</h1>}
+            {layouts.length > 0 && layouts[currentPage] && (
+              <JsonFormsDispatch
+                schema={schema}
+                uischema={layouts[currentPage]}
+                path={path}
+                enabled={enabled}
+                renderers={renderers}
+                cells={cells}
+              />
             )}
-            <FormProgressBar
-              currentPage={visiblePosition}
-              totalScreens={totalVisibleScreens}
-              data={data}
-              schema={schema}
-              uischema={uischema}
-              mode="screens"
-              isOnFinalizePage={isOnFinalizePage}
-              onNavigatePrevious={
-                prevVisiblePage !== null
-                  ? () => navigateToPage(prevVisiblePage)
-                  : undefined
-              }
-              onNavigateNext={
-                nextVisiblePage !== null
-                  ? () => navigateToPage(nextVisiblePage)
-                  : undefined
-              }
-              navigationDisabled={isNavigating}
-            />
-          </>
-        }
-        previousButton={
-          prevVisiblePage !== null
-            ? {
-                onClick: () => navigateToPage(prevVisiblePage),
-                disabled: isNavigating,
-              }
-            : undefined
-        }
-        nextButton={
-          skipFinalize && isLastContentPage
-            ? {
-                onClick: trySubmitForm,
-                disabled:
-                  isNavigating ||
-                  !formInitData ||
-                  (core?.errors?.length ?? 0) > 0,
-                label: finalizeButtonLabelOption ?? 'Done',
-              }
-            : nextVisiblePage !== null
-            ? {
-                onClick: () => navigateToPage(nextVisiblePage),
-                disabled: isNavigating,
-                label: nextButtonLabelOption,
-              }
-            : undefined
-        }
-        contentBottomPadding={80}
-        showNavigation={true}>
-        <div
-          ref={mergedSwipeScreenRef}
-          {...swipeHandlers}
-          className="swipelayout_screen">
-          {(uischema as any)?.label && <h1>{(uischema as any).label}</h1>}
-          {layouts.length > 0 && layouts[currentPage] && (
-            <JsonFormsDispatch
-              schema={schema}
-              uischema={layouts[currentPage]}
-              path={path}
-              enabled={enabled}
-              renderers={renderers}
-              cells={cells}
-            />
-          )}
-        </div>
+          </div>
 
-        {snackbarOpen &&
-          typeof document !== 'undefined' &&
-          createPortal(
-            <Box
-              sx={{
-                position: 'fixed',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                minHeight: '100dvh',
-                height: '100%',
-                zIndex: 99,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                padding: 4,
-                backgroundColor: 'transparent',
-              }}>
+          {snackbarOpen &&
+            typeof document !== 'undefined' &&
+            createPortal(
               <Box
                 sx={{
-                  width: '100%',
-                  maxWidth: 340,
-                  borderRadius: CONFIRM_CARD_RADIUS,
-                  border: `${CONFIRM_BORDER_WIDTH}px solid`,
-                  borderColor: 'divider',
-                  padding: `${CONFIRM_CARD_PADDING}px`,
-                  backgroundColor: theme.palette.background.paper,
-                  overflow: 'hidden',
+                  position: 'fixed',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  minHeight: '100dvh',
+                  height: '100%',
+                  zIndex: 99,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: 4,
+                  backgroundColor: 'transparent',
                 }}>
-                <Typography
-                  variant="h6"
-                  sx={{ fontWeight: 600, textAlign: 'center', mb: 1.5 }}>
-                  Missing required fields
-                </Typography>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ textAlign: 'center', mb: 3 }}>
-                  {snackbarMessage ||
-                    'Some required fields are missing. Any unsaved changes will be available as a draft when you return.'}
-                </Typography>
                 <Box
                   sx={{
-                    flexDirection: 'row',
-                    display: 'flex',
-                    justifyContent: 'center',
-                    gap: 2,
-                    flexWrap: 'wrap',
+                    width: '100%',
+                    maxWidth: 340,
+                    borderRadius: CONFIRM_CARD_RADIUS,
+                    border: `${CONFIRM_BORDER_WIDTH}px solid`,
+                    borderColor: 'divider',
+                    padding: `${CONFIRM_CARD_PADDING}px`,
+                    backgroundColor: theme.palette.background.paper,
+                    overflow: 'hidden',
                   }}>
-                  <Button
-                    variant="neutral"
-                    size="medium"
-                    onPress={handleSnackbarClose}>
-                    Stay here
-                  </Button>
-                  <Button variant="danger" size="medium" onPress={handleGoBack}>
-                    Go back
-                  </Button>
+                  <Typography
+                    variant="h6"
+                    sx={{ fontWeight: 600, textAlign: 'center', mb: 1.5 }}>
+                    Missing required fields
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ textAlign: 'center', mb: 3 }}>
+                    {snackbarMessage ||
+                      'Some required fields are missing. Any unsaved changes will be available as a draft when you return.'}
+                  </Typography>
+                  <Box
+                    sx={{
+                      flexDirection: 'row',
+                      display: 'flex',
+                      justifyContent: 'center',
+                      gap: 2,
+                      flexWrap: 'wrap',
+                    }}>
+                    <Button
+                      variant="neutral"
+                      size="medium"
+                      onPress={handleSnackbarClose}>
+                      Stay here
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="medium"
+                      onPress={handleGoBack}>
+                      Go back
+                    </Button>
+                  </Box>
                 </Box>
-              </Box>
-            </Box>,
-            document.body,
-          )}
-      </FormLayout>
-    </FormContext.Provider>
+              </Box>,
+              document.body,
+            )}
+        </FormLayout>
+      </FormContext.Provider>
     </FormDensityContext.Provider>
   );
 };

--- a/formulus-formplayer/src/renderers/VideoQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/VideoQuestionRenderer.tsx
@@ -331,7 +331,7 @@ const VideoQuestionRenderer: React.FC<ControlProps> = ({
     typeof meta?.duration === 'number';
 
   return (
-    <QuestionShell
+    <QuestionShell block
       title={label}
       description={description}
       required={isRequired}

--- a/formulus-formplayer/src/renderers/VideoQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/VideoQuestionRenderer.tsx
@@ -331,7 +331,8 @@ const VideoQuestionRenderer: React.FC<ControlProps> = ({
     typeof meta?.duration === 'number';
 
   return (
-    <QuestionShell block
+    <QuestionShell
+      block
       title={label}
       description={description}
       required={isRequired}

--- a/formulus-formplayer/src/renderers/subObservationHelpers.test.ts
+++ b/formulus-formplayer/src/renderers/subObservationHelpers.test.ts
@@ -28,6 +28,17 @@ describe('subObservationHelpers', () => {
     expect(resolveTemplateValue('{{p_id}}', { p_id: 'x' }, null)).toBe('x');
   });
 
+  it('resolveTemplateValue preserves JSON type for a whole-string single token', () => {
+    // Numbers stay numbers (so AJV type:"integer" passes on copied sub-obs data)
+    expect(resolveTemplateValue('{{age}}', { age: 5 }, null)).toBe(5);
+    expect(resolveTemplateValue('{{n}}', { n: 0 }, null)).toBe(0);
+    expect(resolveTemplateValue('{{flag}}', { flag: false }, null)).toBe(false);
+    // Missing -> empty string (unchanged behavior)
+    expect(resolveTemplateValue('{{missing}}', {}, null)).toBe('');
+    // Mixed templates still interpolate as text
+    expect(resolveTemplateValue('AF-{{num}}', { num: 7 }, null)).toBe('AF-7');
+  });
+
   it('resolveInitialValues maps object values', () => {
     expect(
       resolveInitialValues(

--- a/formulus-formplayer/src/renderers/subObservationHelpers.ts
+++ b/formulus-formplayer/src/renderers/subObservationHelpers.ts
@@ -38,12 +38,34 @@ export function readDataPath(data: unknown, dotPath: string): unknown {
   return cur;
 }
 
+/** Matches a string that is exactly one `{{ token }}` with no surrounding text. */
+const SINGLE_TOKEN_RE = /^\s*\{\{\s*([^}]+?)\s*\}\}\s*$/;
+
 export function resolveTemplateValue(
   value: unknown,
   formData: Record<string, unknown>,
   parentValue: string | null,
 ): unknown {
   if (typeof value !== 'string') return value;
+
+  // When the whole value is a single token (e.g. "{{age}}"), preserve the
+  // source value's JSON type so numbers/booleans copied into a sub-observation
+  // stay numbers/booleans (otherwise AJV `type: "integer"` rejects "5"). Mixed
+  // templates (e.g. "AF-{{num}}") still interpolate as text below.
+  const single = value.match(SINGLE_TOKEN_RE);
+  if (single) {
+    const t = single[1].trim();
+    if (t === 'parentValue') {
+      return parentValue == null ? '' : String(parentValue);
+    }
+    if (t === 'currentInstanceId') {
+      const id = formData.observationId;
+      return id == null ? '' : String(id);
+    }
+    const fromData = readDataPath(formData, t);
+    return fromData == null ? '' : fromData;
+  }
+
   return value.replace(/\{\{\s*([^}]+)\s*\}\}/g, (_m, token: string) => {
     const t = String(token || '').trim();
     if (t === 'parentValue')

--- a/formulus-formplayer/src/services/FormulusInterface.ts
+++ b/formulus-formplayer/src/services/FormulusInterface.ts
@@ -367,7 +367,7 @@ class FormulusClient {
     formType: string,
     params: Record<string, unknown>,
     savedData: Record<string, unknown>,
-    options?: { subObservationMode?: boolean },
+    options?: { subObservationMode?: boolean; skipFinalize?: boolean },
   ): Promise<FormCompletionResult> {
     await this.tryEnsureFormulus();
     if (this.formulus) {

--- a/formulus-formplayer/src/services/StickyService.ts
+++ b/formulus-formplayer/src/services/StickyService.ts
@@ -1,0 +1,64 @@
+/**
+ * Persists last-submitted scalar field values for opt-in "sticky" controls.
+ * Keyed by formType + formVersion + field path (JSON pointer segment).
+ */
+
+export interface StickyStore {
+  [fieldPath: string]: unknown;
+}
+
+export class StickyService {
+  private static instance: StickyService;
+  private readonly STORAGE_KEY = 'formulus_sticky_fields';
+
+  private constructor() {}
+
+  static getInstance(): StickyService {
+    if (!StickyService.instance) {
+      StickyService.instance = new StickyService();
+    }
+    return StickyService.instance;
+  }
+
+  private storageKey(formType: string, formVersion?: string): string {
+    return `${formType}::${formVersion ?? '0'}`;
+  }
+
+  private readAll(): Record<string, StickyStore> {
+    try {
+      const raw = localStorage.getItem(this.STORAGE_KEY);
+      if (!raw) return {};
+      const parsed = JSON.parse(raw);
+      return typeof parsed === 'object' && parsed !== null ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  private writeAll(data: Record<string, StickyStore>): void {
+    try {
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(data));
+    } catch (e) {
+      console.warn('[StickyService] Failed to persist sticky values', e);
+    }
+  }
+
+  getStickyValues(formType: string, formVersion?: string): StickyStore {
+    const all = this.readAll();
+    return all[this.storageKey(formType, formVersion)] ?? {};
+  }
+
+  saveStickyValues(
+    formType: string,
+    formVersion: string | undefined,
+    values: StickyStore,
+  ): void {
+    if (!formType || Object.keys(values).length === 0) return;
+    const all = this.readAll();
+    const key = this.storageKey(formType, formVersion);
+    all[key] = { ...(all[key] ?? {}), ...values };
+    this.writeAll(all);
+  }
+}
+
+export const stickyService = StickyService.getInstance();

--- a/formulus-formplayer/src/theme/choiceControl.render.test.tsx
+++ b/formulus-formplayer/src/theme/choiceControl.render.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import type { ControlProps } from '@jsonforms/core';
+import { ChoiceControl, MultiChoiceControl } from './material-wrappers';
+
+const theme = createTheme();
+
+afterEach(() => cleanup());
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+
+const enumSchema = { type: 'string', title: 'Color', enum: ['r', 'g'] };
+
+describe('ChoiceControl (single-select)', () => {
+  it('radio: selecting an option calls handleChange with the value', () => {
+    const handleChange = vi.fn();
+    renderWithTheme(
+      <ChoiceControl
+        {...({
+          data: undefined,
+          path: 'color',
+          handleChange,
+          schema: enumSchema,
+          uischema: { type: 'Control', options: { display: 'radio' } },
+          enabled: true,
+        } as unknown as ControlProps)}
+      />,
+    );
+    fireEvent.click(screen.getByText('g'));
+    expect(handleChange).toHaveBeenCalledWith('color', 'g');
+  });
+
+  it('radio: tapping the selected option clears it (undefined)', () => {
+    const handleChange = vi.fn();
+    renderWithTheme(
+      <ChoiceControl
+        {...({
+          data: 'r',
+          path: 'color',
+          handleChange,
+          schema: enumSchema,
+          uischema: { type: 'Control', options: { display: 'radio' } },
+          enabled: true,
+        } as unknown as ControlProps)}
+      />,
+    );
+    fireEvent.click(screen.getByText('r'));
+    expect(handleChange).toHaveBeenCalledWith('color', undefined);
+  });
+
+  it('buttons: tapping the selected button clears it (undefined)', () => {
+    const handleChange = vi.fn();
+    renderWithTheme(
+      <ChoiceControl
+        {...({
+          data: 'r',
+          path: 'color',
+          handleChange,
+          schema: enumSchema,
+          uischema: { type: 'Control', options: { display: 'buttons' } },
+          enabled: true,
+        } as unknown as ControlProps)}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'r' }));
+    expect(handleChange).toHaveBeenCalledWith('color', undefined);
+  });
+});
+
+describe('MultiChoiceControl (multi-select)', () => {
+  const arraySchema = {
+    type: 'array',
+    title: 'Tags',
+    items: {
+      oneOf: [
+        { const: 'x', title: 'X' },
+        { const: 'y', title: 'Y' },
+      ],
+    },
+  };
+  const options = [
+    { label: 'X', value: 'x' },
+    { label: 'Y', value: 'y' },
+  ];
+
+  it('checkboxes: toggling an unselected option adds it', () => {
+    const addItem = vi.fn();
+    const removeItem = vi.fn();
+    const props = {
+      data: [] as string[],
+      options,
+      addItem,
+      removeItem,
+      path: 'tags',
+      schema: arraySchema,
+      uischema: { type: 'Control', options: { display: 'checkboxes' } },
+      enabled: true,
+    };
+    renderWithTheme(<MultiChoiceControl {...(props as any)} />);
+    fireEvent.click(screen.getByText('X'));
+    expect(addItem).toHaveBeenCalledWith('tags', 'x');
+    expect(removeItem).not.toHaveBeenCalled();
+  });
+
+  it('checkboxes: toggling a selected option removes it', () => {
+    const addItem = vi.fn();
+    const removeItem = vi.fn();
+    const props = {
+      data: ['x'],
+      options,
+      addItem,
+      removeItem,
+      path: 'tags',
+      schema: arraySchema,
+      uischema: { type: 'Control', options: { display: 'checkboxes' } },
+      enabled: true,
+    };
+    renderWithTheme(<MultiChoiceControl {...(props as any)} />);
+    fireEvent.click(screen.getByText('X'));
+    expect(removeItem).toHaveBeenCalledWith('tags', 'x');
+  });
+});

--- a/formulus-formplayer/src/theme/choiceControlTesters.test.ts
+++ b/formulus-formplayer/src/theme/choiceControlTesters.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
 import {
   choiceControlTester,
+  enumArrayShellControlTester,
   multiChoiceControlTester,
 } from './material-wrappers';
 
@@ -23,7 +24,13 @@ const rootSchema: JsonSchema = {
     } as JsonSchema,
     tags: {
       type: 'array',
-      items: { oneOf: [{ const: 'x', title: 'X' }] },
+      uniqueItems: true,
+      items: {
+        oneOf: [
+          { const: 'x', title: 'X' },
+          { const: 'y', title: 'Y' },
+        ],
+      },
     } as JsonSchema,
   },
 };
@@ -64,6 +71,23 @@ describe('choiceControlTester (single-select)', () => {
   it('does not claim array (multi-select) controls', () => {
     const ui = control('#/properties/tags', { display: 'radio' });
     expect(choiceControlTester(ui, rootSchema, ctx)).toBe(-1);
+  });
+});
+
+describe('enumArrayShellControlTester (default multi-select)', () => {
+  it('claims array-of-enum when options.display is not set', () => {
+    const ui = control('#/properties/tags');
+    expect(enumArrayShellControlTester(ui, rootSchema, ctx)).toBe(6);
+  });
+
+  it('defers when options.display=checkboxes (MultiChoiceControl wins)', () => {
+    const ui = control('#/properties/tags', { display: 'checkboxes' });
+    expect(enumArrayShellControlTester(ui, rootSchema, ctx)).toBe(-1);
+  });
+
+  it('defers when options.display=buttons', () => {
+    const ui = control('#/properties/tags', { display: 'buttons' });
+    expect(enumArrayShellControlTester(ui, rootSchema, ctx)).toBe(-1);
   });
 });
 

--- a/formulus-formplayer/src/theme/choiceControlTesters.test.ts
+++ b/formulus-formplayer/src/theme/choiceControlTesters.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
+import {
+  choiceControlTester,
+  multiChoiceControlTester,
+} from './material-wrappers';
+
+const rootSchema: JsonSchema = {
+  type: 'object',
+  properties: {
+    color: { type: 'string', enum: ['r', 'g', 'b'] },
+    ref: {
+      type: 'string',
+      oneOf: [
+        { const: 'a', title: 'A' },
+        { const: 'b', title: 'B' },
+      ],
+    },
+    native: {
+      type: 'string',
+      format: 'native_enum',
+      oneOf: [{ const: 'a', title: 'A' }],
+    } as JsonSchema,
+    tags: {
+      type: 'array',
+      items: { oneOf: [{ const: 'x', title: 'X' }] },
+    } as JsonSchema,
+  },
+};
+
+const ctx = { rootSchema, config: {} };
+
+const control = (
+  scope: string,
+  options?: Record<string, unknown>,
+): UISchemaElement =>
+  ({
+    type: 'Control',
+    scope,
+    ...(options ? { options } : {}),
+  }) as unknown as UISchemaElement;
+
+describe('choiceControlTester (single-select)', () => {
+  it('claims an enum control with options.display=radio', () => {
+    const ui = control('#/properties/color', { display: 'radio' });
+    expect(choiceControlTester(ui, rootSchema, ctx)).toBe(7);
+  });
+
+  it('claims a oneOf ($ref) control with options.display=buttons', () => {
+    const ui = control('#/properties/ref', { display: 'buttons' });
+    expect(choiceControlTester(ui, rootSchema, ctx)).toBe(7);
+  });
+
+  it('defers when no options.display is set (keeps current default)', () => {
+    const ui = control('#/properties/color');
+    expect(choiceControlTester(ui, rootSchema, ctx)).toBe(-1);
+  });
+
+  it('defers when the schema has a format (custom question types win)', () => {
+    const ui = control('#/properties/native', { display: 'radio' });
+    expect(choiceControlTester(ui, rootSchema, ctx)).toBe(-1);
+  });
+
+  it('does not claim array (multi-select) controls', () => {
+    const ui = control('#/properties/tags', { display: 'radio' });
+    expect(choiceControlTester(ui, rootSchema, ctx)).toBe(-1);
+  });
+});
+
+describe('multiChoiceControlTester (multi-select)', () => {
+  it('claims an array-of-enum control with options.display=checkboxes', () => {
+    const ui = control('#/properties/tags', { display: 'checkboxes' });
+    expect(multiChoiceControlTester(ui, rootSchema, ctx)).toBe(7);
+  });
+
+  it('claims an array-of-enum control with options.display=buttons', () => {
+    const ui = control('#/properties/tags', { display: 'buttons' });
+    expect(multiChoiceControlTester(ui, rootSchema, ctx)).toBe(7);
+  });
+
+  it('defers when no options.display is set', () => {
+    const ui = control('#/properties/tags');
+    expect(multiChoiceControlTester(ui, rootSchema, ctx)).toBe(-1);
+  });
+
+  it('does not claim scalar controls', () => {
+    const ui = control('#/properties/color', { display: 'checkboxes' });
+    expect(multiChoiceControlTester(ui, rootSchema, ctx)).toBe(-1);
+  });
+});

--- a/formulus-formplayer/src/theme/material-wrappers.tsx
+++ b/formulus-formplayer/src/theme/material-wrappers.tsx
@@ -1,11 +1,24 @@
 import {
   isEnumControl,
+  isOneOfEnumControl,
   RankedTester,
   rankWith,
   ControlProps,
+  OwnPropsOfEnum,
 } from '@jsonforms/core';
-import { withJsonFormsControlProps } from '@jsonforms/react';
-import { Typography, Box, useTheme } from '@mui/material';
+import {
+  withJsonFormsControlProps,
+  withJsonFormsOneOfEnumProps,
+} from '@jsonforms/react';
+import {
+  Typography,
+  Box,
+  useTheme,
+  FormControl,
+  Select,
+  MenuItem,
+  FormHelperText,
+} from '@mui/material';
 import QuestionShell from '../components/QuestionShell';
 import { tokens } from './tokens-adapter';
 
@@ -122,6 +135,90 @@ const CardEnumControl = (props: AnyControlProps) => {
   );
 };
 
+/**
+ * Keyboard-free dropdown for `oneOf` enums (the shape produced by shared
+ * `$ref` choice lists). The stock `MaterialOneOfEnumControl` defaults to an
+ * Autocomplete, which opens the on-screen keyboard on tablets/phones. This
+ * override renders a plain MUI `Select` (menu picker) instead. The theme sets
+ * `MuiSelect` `inputProps.readOnly`/`inputMode: 'none'`, so no keyboard appears.
+ *
+ * Opt back into the searchable Autocomplete per field with
+ * `ui.json` `"options": { "autocomplete": true }` (then the tester below
+ * defers to the stock rank-5 control).
+ */
+const selectOneOfEnumControlTester: RankedTester = rankWith(
+  6,
+  (uischema, schema, context) => {
+    if (!isOneOfEnumControl(uischema, schema, context)) {
+      return false;
+    }
+    // Defer to format-based renderers (custom question types share rank 6 and
+    // are registered later in the array, so on a tie the first match would win
+    // here). A field that declares a `format` wants that specialized renderer
+    // (e.g. GBMIS `native_enum`), so this Select only claims plain $ref/oneOf.
+    if ((schema as any)?.format) {
+      return false;
+    }
+    // Explicit opt-in to the searchable Autocomplete -> let the stock control win.
+    const autocomplete = (uischema as any)?.options?.autocomplete;
+    return autocomplete !== true;
+  },
+);
+
+const SelectOneOfEnumControl = (props: ControlProps & OwnPropsOfEnum) => {
+  const {
+    data,
+    handleChange,
+    path,
+    schema,
+    uischema,
+    errors,
+    enabled = true,
+    options = [],
+  } = props;
+  const label = (uischema as any)?.label || schema.title;
+  const description = schema.description;
+  const required = Boolean(
+    (uischema as any)?.options?.required ?? (schema as any)?.options?.required,
+  );
+  const hasError = Boolean(errors && errors.length > 0);
+
+  return (
+    <QuestionShell
+      title={label}
+      description={description}
+      required={required}
+      error={errors}>
+      <FormControl fullWidth error={hasError} disabled={!enabled}>
+        <Select
+          value={data ?? ''}
+          displayEmpty
+          onChange={event => {
+            const value = event.target.value;
+            handleChange(path, value === '' ? undefined : value);
+          }}
+          renderValue={(selected: unknown) => {
+            if (selected === undefined || selected === null || selected === '') {
+              return <em>—</em>;
+            }
+            const match = options.find(o => o.value === selected);
+            return match ? match.label : String(selected);
+          }}>
+          <MenuItem value="">
+            <em>—</em>
+          </MenuItem>
+          {options.map(option => (
+            <MenuItem key={String(option.value)} value={option.value as any}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+        {hasError ? <FormHelperText>{errors}</FormHelperText> : null}
+      </FormControl>
+    </QuestionShell>
+  );
+};
+
 // NOTE: We removed the shell wrappers for text/number/integer/date controls because
 // they interfere with JSONForms' internal cell rendering mechanism.
 // The default materialRenderers handle these controls properly.
@@ -131,5 +228,10 @@ export const shellMaterialRenderers = [
   {
     tester: cardEnumControlTester,
     renderer: withJsonFormsControlProps(CardEnumControl),
+  },
+  // Keyboard-free Select for oneOf enums (shared $ref choice lists)
+  {
+    tester: selectOneOfEnumControlTester,
+    renderer: withJsonFormsOneOfEnumProps(SelectOneOfEnumControl),
   },
 ];

--- a/formulus-formplayer/src/theme/material-wrappers.tsx
+++ b/formulus-formplayer/src/theme/material-wrappers.tsx
@@ -1,16 +1,21 @@
 import {
   and,
   or,
+  not,
+  hasType,
   isEnumControl,
   isOneOfEnumControl,
   optionIs,
   schemaMatches,
+  schemaSubPathMatches,
+  resolveSchema,
   uiTypeIs,
   RankedTester,
   rankWith,
   ControlProps,
   OwnPropsOfEnum,
   DispatchPropsOfMultiEnumControl,
+  JsonSchema,
 } from '@jsonforms/core';
 import {
   withJsonFormsControlProps,
@@ -23,7 +28,6 @@ import {
   useTheme,
   FormControl,
   Select,
-  MenuItem,
   FormHelperText,
   Radio,
   Checkbox,
@@ -151,9 +155,11 @@ const CardEnumControl = (props: AnyControlProps) => {
 /**
  * Keyboard-free dropdown for `oneOf` enums (the shape produced by shared
  * `$ref` choice lists). The stock `MaterialOneOfEnumControl` defaults to an
- * Autocomplete, which opens the on-screen keyboard on tablets/phones. This
- * override renders a plain MUI `Select` (menu picker) instead. The theme sets
- * `MuiSelect` `inputProps.readOnly`/`inputMode: 'none'`, so no keyboard appears.
+ * Autocomplete, which opens the on-screen keyboard on tablets/phones.
+ *
+ * Uses a **native** `<select>` so the
+ * picker works inside Formulus / ODE Desktop WebViews — MUI Menu portals and
+ * `readOnly` on the faux input both break menu open on mobile WebViews.
  *
  * Opt back into the searchable Autocomplete per field with
  * `ui.json` `"options": { "autocomplete": true }` (then the tester below
@@ -168,7 +174,7 @@ const selectOneOfEnumControlTester: RankedTester = rankWith(
     // Defer to format-based renderers (custom question types share rank 6 and
     // are registered later in the array, so on a tie the first match would win
     // here). A field that declares a `format` wants that specialized renderer
-    // (e.g. GBMIS `native_enum`), so this Select only claims plain $ref/oneOf.
+    // (e.g. a custom `format` renderer), so this Select only claims plain $ref/oneOf.
     if ((schema as any)?.format) {
       return false;
     }
@@ -206,32 +212,130 @@ const SelectOneOfEnumControl = (props: ControlProps & OwnPropsOfEnum) => {
       description={description}
       required={required}
       error={errors}>
-      <FormControl fullWidth error={hasError} disabled={!enabled}>
+      <FormControl
+        fullWidth
+        variant="outlined"
+        error={hasError}
+        disabled={!enabled}>
         <Select
+          native
           value={data ?? ''}
           displayEmpty
           onChange={event => {
             const value = event.target.value;
             handleChange(path, value === '' ? undefined : value);
           }}
-          renderValue={(selected: unknown) => {
-            if (selected === undefined || selected === null || selected === '') {
-              return <em>{placeholder}</em>;
-            }
-            const match = options.find(o => o.value === selected);
-            return match ? match.label : String(selected);
+          inputProps={{
+            'aria-label':
+              typeof label === 'string' ? label : (schema.title ?? undefined),
           }}>
-          <MenuItem value="">
-            <em>{placeholder}</em>
-          </MenuItem>
+          <option value="">{placeholder}</option>
           {options.map(option => (
-            <MenuItem key={String(option.value)} value={option.value as any}>
+            <option key={String(option.value)} value={String(option.value)}>
               {option.label}
-            </MenuItem>
+            </option>
           ))}
         </Select>
         {hasError ? <FormHelperText>{errors}</FormHelperText> : null}
       </FormControl>
+    </QuestionShell>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Default multi-select (array enum) — QuestionShell + vertical checkboxes
+// Replaces stock MaterialEnumArrayRenderer (legend above row of boxes) in
+// SwipeLayout inline mode. Opt-in display modes stay on MultiChoiceControl (7).
+// ---------------------------------------------------------------------------
+
+const hasOneOfItems = (schema: JsonSchema): boolean =>
+  schema.oneOf !== undefined &&
+  schema.oneOf.length > 0 &&
+  (schema.oneOf as JsonSchema[]).every(entry => entry.const !== undefined);
+
+const hasEnumItems = (schema: JsonSchema): boolean =>
+  schema.type === 'string' && schema.enum !== undefined;
+
+const isMultiEnumControl = and(
+  uiTypeIs('Control'),
+  and(
+    schemaMatches(
+      schema =>
+        hasType(schema, 'array') &&
+        !Array.isArray(schema.items) &&
+        schema.uniqueItems === true,
+    ),
+    schemaSubPathMatches('items', (schema, rootSchema) => {
+      if (!schema) return false;
+      const resolvedSchema =
+        schema.$ref && rootSchema
+          ? resolveSchema(rootSchema, schema.$ref, rootSchema)
+          : schema;
+      if (!resolvedSchema) return false;
+      return hasOneOfItems(resolvedSchema) || hasEnumItems(resolvedSchema);
+    }),
+  ),
+);
+
+export const enumArrayShellControlTester: RankedTester = rankWith(
+  6,
+  and(
+    isMultiEnumControl,
+    not(or(optionIs('display', 'checkboxes'), optionIs('display', 'buttons'))),
+  ),
+);
+
+const EnumArrayShellControl = (
+  props: ControlProps & OwnPropsOfEnum & DispatchPropsOfMultiEnumControl,
+) => {
+  const {
+    data,
+    options = [],
+    addItem,
+    removeItem,
+    path,
+    schema,
+    uischema,
+    errors,
+    enabled = true,
+    visible,
+    label,
+  } = props;
+
+  if (visible === false) return null;
+
+  const title = (uischema as any)?.label || schema.title || label;
+  const description = schema.description;
+  const required = Boolean((uischema as any)?.options?.required);
+  const selected: unknown[] = Array.isArray(data) ? data : [];
+  const isSelected = (v: unknown) => selected.includes(v);
+  const toggle = (v: unknown) => {
+    if (!enabled) return;
+    if (isSelected(v)) removeItem?.(path, v);
+    else addItem?.(path, v);
+  };
+
+  return (
+    <QuestionShell
+      title={title}
+      description={description}
+      required={required}
+      error={errors}>
+      <FormGroup sx={choiceListSx('vertical')}>
+        {options.map(opt => (
+          <FormControlLabel
+            key={String(opt.value)}
+            disabled={!enabled}
+            control={
+              <Checkbox
+                checked={isSelected(opt.value)}
+                onChange={() => toggle(opt.value)}
+              />
+            }
+            label={opt.label}
+          />
+        ))}
+      </FormGroup>
     </QuestionShell>
   );
 };
@@ -257,8 +361,7 @@ const deriveChoiceOptions = (schema: any): ChoiceOption[] =>
   schema.oneOf?.map((o: any) => ({
     value: o.const ?? o.enum?.[0] ?? o,
     label: o.title ?? String(o.const ?? o),
-  })) ||
-  (schema.enum || []).map((v: any) => ({ value: v, label: String(v) }));
+  })) || (schema.enum || []).map((v: any) => ({ value: v, label: String(v) }));
 
 type ChoiceOrientation = 'vertical' | 'horizontal' | 'flow';
 
@@ -373,7 +476,7 @@ export const ChoiceControl = (props: AnyControlProps) => {
       description={description}
       required={required}
       error={errors}
-      block={display === 'buttons' || orientation !== 'vertical'}>
+      block={orientation === 'flow'}>
       {body}
     </QuestionShell>
   );
@@ -382,14 +485,7 @@ export const ChoiceControl = (props: AnyControlProps) => {
 export const multiChoiceControlTester: RankedTester = rankWith(
   7,
   and(
-    uiTypeIs('Control'),
-    schemaMatches(
-      schema =>
-        (schema as any)?.type === 'array' &&
-        !!(schema as any)?.items &&
-        (Array.isArray((schema as any).items.oneOf) ||
-          Array.isArray((schema as any).items.enum)),
-    ),
+    isMultiEnumControl,
     or(optionIs('display', 'checkboxes'), optionIs('display', 'buttons')),
   ),
 );
@@ -467,7 +563,7 @@ export const MultiChoiceControl = (
       description={description}
       required={required}
       error={errors}
-      block={display === 'buttons' || orientation !== 'vertical'}>
+      block={orientation === 'flow'}>
       {body}
     </QuestionShell>
   );
@@ -487,6 +583,11 @@ export const shellMaterialRenderers = [
   {
     tester: selectOneOfEnumControlTester,
     renderer: withJsonFormsOneOfEnumProps(SelectOneOfEnumControl),
+  },
+  // Default multi-select checkboxes in two-column QuestionShell
+  {
+    tester: enumArrayShellControlTester,
+    renderer: withJsonFormsMultiEnumProps(EnumArrayShellControl),
   },
   // Opt-in radio / button single-select (ui.json options.display)
   {

--- a/formulus-formplayer/src/theme/material-wrappers.tsx
+++ b/formulus-formplayer/src/theme/material-wrappers.tsx
@@ -1,14 +1,21 @@
 import {
+  and,
+  or,
   isEnumControl,
   isOneOfEnumControl,
+  optionIs,
+  schemaMatches,
+  uiTypeIs,
   RankedTester,
   rankWith,
   ControlProps,
   OwnPropsOfEnum,
+  DispatchPropsOfMultiEnumControl,
 } from '@jsonforms/core';
 import {
   withJsonFormsControlProps,
   withJsonFormsOneOfEnumProps,
+  withJsonFormsMultiEnumProps,
 } from '@jsonforms/react';
 import {
   Typography,
@@ -18,6 +25,12 @@ import {
   Select,
   MenuItem,
   FormHelperText,
+  Radio,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import QuestionShell from '../components/QuestionShell';
 import { tokens } from './tokens-adapter';
@@ -182,6 +195,10 @@ const SelectOneOfEnumControl = (props: ControlProps & OwnPropsOfEnum) => {
     (uischema as any)?.options?.required ?? (schema as any)?.options?.required,
   );
   const hasError = Boolean(errors && errors.length > 0);
+  const placeholder =
+    typeof (uischema as any)?.options?.placeholder === 'string'
+      ? (uischema as any).options.placeholder
+      : '—';
 
   return (
     <QuestionShell
@@ -199,13 +216,13 @@ const SelectOneOfEnumControl = (props: ControlProps & OwnPropsOfEnum) => {
           }}
           renderValue={(selected: unknown) => {
             if (selected === undefined || selected === null || selected === '') {
-              return <em>—</em>;
+              return <em>{placeholder}</em>;
             }
             const match = options.find(o => o.value === selected);
             return match ? match.label : String(selected);
           }}>
           <MenuItem value="">
-            <em>—</em>
+            <em>{placeholder}</em>
           </MenuItem>
           {options.map(option => (
             <MenuItem key={String(option.value)} value={option.value as any}>
@@ -215,6 +232,243 @@ const SelectOneOfEnumControl = (props: ControlProps & OwnPropsOfEnum) => {
         </Select>
         {hasError ? <FormHelperText>{errors}</FormHelperText> : null}
       </FormControl>
+    </QuestionShell>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Choice display options (opt-in via `ui.json` control `options`)
+//
+//   options.display:
+//     single-select (enum / oneOf): "radio" | "buttons"
+//     multi-select  (array enum):   "checkboxes" | "buttons"
+//   options.orientation: "vertical" (default) | "horizontal" | "flow" (wrap)
+//   options.buttonGroup: "segmented" (default) | "separated"
+//
+// Single-select radio/buttons support tap-the-selected-option-to-clear.
+// These claim rank 7 so they win over the rank-6 enum controls, but only when
+// `options.display` is set and the field has no `schema.format` (so custom
+// question types like `native_enum` still win).
+// ---------------------------------------------------------------------------
+
+type ChoiceOption = { value: unknown; label: string };
+
+const deriveChoiceOptions = (schema: any): ChoiceOption[] =>
+  schema.oneOf?.map((o: any) => ({
+    value: o.const ?? o.enum?.[0] ?? o,
+    label: o.title ?? String(o.const ?? o),
+  })) ||
+  (schema.enum || []).map((v: any) => ({ value: v, label: String(v) }));
+
+type ChoiceOrientation = 'vertical' | 'horizontal' | 'flow';
+
+const readChoiceLayout = (uischema: any) => {
+  const o = uischema?.options ?? {};
+  const orientation: ChoiceOrientation =
+    o.orientation === 'horizontal' || o.orientation === 'flow'
+      ? o.orientation
+      : 'vertical';
+  const separated = o.buttonGroup === 'separated';
+  return { orientation, separated };
+};
+
+const choiceListSx = (orientation: ChoiceOrientation) => ({
+  display: 'flex',
+  flexDirection: orientation === 'vertical' ? 'column' : 'row',
+  flexWrap: orientation === 'flow' ? 'wrap' : 'nowrap',
+  gap: orientation === 'vertical' ? 0 : 0.5,
+});
+
+const toggleGroupSx = (orientation: ChoiceOrientation, separated: boolean) => ({
+  flexWrap: orientation === 'flow' ? 'wrap' : 'nowrap',
+  ...(separated
+    ? {
+        gap: 1,
+        '& .MuiToggleButtonGroup-grouped': {
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          '&:not(:first-of-type)': { marginLeft: 0 },
+        },
+      }
+    : {}),
+});
+
+export const choiceControlTester: RankedTester = rankWith(
+  7,
+  and(
+    or(isEnumControl, isOneOfEnumControl),
+    schemaMatches(schema => !(schema as any)?.format),
+    or(optionIs('display', 'radio'), optionIs('display', 'buttons')),
+  ),
+);
+
+export const ChoiceControl = (props: AnyControlProps) => {
+  const {
+    data,
+    handleChange,
+    path,
+    schema,
+    uischema,
+    errors,
+    enabled = true,
+  } = props;
+  const label = (uischema as any)?.label || schema.title;
+  const description = schema.description;
+  const required = Boolean(
+    (uischema as any)?.options?.required ?? (schema as any)?.options?.required,
+  );
+  const display = (uischema as any)?.options?.display;
+  const { orientation, separated } = readChoiceLayout(uischema);
+  const options = deriveChoiceOptions(schema);
+
+  const body =
+    display === 'buttons' ? (
+      <ToggleButtonGroup
+        exclusive
+        disabled={!enabled}
+        orientation={orientation === 'vertical' ? 'vertical' : 'horizontal'}
+        value={data ?? null}
+        onChange={(_e, val) => {
+          if (!enabled) return;
+          // Exclusive group returns null when re-clicking the active option,
+          // which gives tap-to-clear for free.
+          handleChange(path, val == null ? undefined : val);
+        }}
+        sx={toggleGroupSx(orientation, separated)}>
+        {options.map(opt => (
+          <ToggleButton key={String(opt.value)} value={opt.value as any}>
+            {opt.label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+    ) : (
+      <Box role="radiogroup" sx={choiceListSx(orientation)}>
+        {options.map(opt => {
+          const selected = data === opt.value;
+          return (
+            <FormControlLabel
+              key={String(opt.value)}
+              disabled={!enabled}
+              control={
+                <Radio
+                  checked={selected}
+                  onClick={() => {
+                    if (!enabled) return;
+                    // Tap the selected option again to clear it.
+                    handleChange(path, selected ? undefined : opt.value);
+                  }}
+                />
+              }
+              label={opt.label}
+            />
+          );
+        })}
+      </Box>
+    );
+
+  return (
+    <QuestionShell
+      title={label}
+      description={description}
+      required={required}
+      error={errors}
+      block={display === 'buttons' || orientation !== 'vertical'}>
+      {body}
+    </QuestionShell>
+  );
+};
+
+export const multiChoiceControlTester: RankedTester = rankWith(
+  7,
+  and(
+    uiTypeIs('Control'),
+    schemaMatches(
+      schema =>
+        (schema as any)?.type === 'array' &&
+        !!(schema as any)?.items &&
+        (Array.isArray((schema as any).items.oneOf) ||
+          Array.isArray((schema as any).items.enum)),
+    ),
+    or(optionIs('display', 'checkboxes'), optionIs('display', 'buttons')),
+  ),
+);
+
+export const MultiChoiceControl = (
+  props: ControlProps & OwnPropsOfEnum & DispatchPropsOfMultiEnumControl,
+) => {
+  const {
+    data,
+    options = [],
+    addItem,
+    removeItem,
+    path,
+    schema,
+    uischema,
+    errors,
+    enabled = true,
+  } = props;
+  const label = (uischema as any)?.label || schema.title;
+  const description = schema.description;
+  const required = Boolean((uischema as any)?.options?.required);
+  const display = (uischema as any)?.options?.display;
+  const { orientation, separated } = readChoiceLayout(uischema);
+  const selected: unknown[] = Array.isArray(data) ? data : [];
+  const isSelected = (v: unknown) => selected.includes(v);
+  const toggle = (v: unknown) => {
+    if (!enabled) return;
+    if (isSelected(v)) removeItem?.(path, v);
+    else addItem?.(path, v);
+  };
+
+  const body =
+    display === 'buttons' ? (
+      <ToggleButtonGroup
+        disabled={!enabled}
+        orientation={orientation === 'vertical' ? 'vertical' : 'horizontal'}
+        value={selected as any}
+        onChange={(_e, newVals: unknown[]) => {
+          if (!enabled) return;
+          newVals
+            .filter(v => !selected.includes(v))
+            .forEach(v => addItem?.(path, v));
+          selected
+            .filter(v => !newVals.includes(v))
+            .forEach(v => removeItem?.(path, v));
+        }}
+        sx={toggleGroupSx(orientation, separated)}>
+        {options.map(opt => (
+          <ToggleButton key={String(opt.value)} value={opt.value as any}>
+            {opt.label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+    ) : (
+      <FormGroup sx={choiceListSx(orientation)}>
+        {options.map(opt => (
+          <FormControlLabel
+            key={String(opt.value)}
+            disabled={!enabled}
+            control={
+              <Checkbox
+                checked={isSelected(opt.value)}
+                onChange={() => toggle(opt.value)}
+              />
+            }
+            label={opt.label}
+          />
+        ))}
+      </FormGroup>
+    );
+
+  return (
+    <QuestionShell
+      title={label}
+      description={description}
+      required={required}
+      error={errors}
+      block={display === 'buttons' || orientation !== 'vertical'}>
+      {body}
     </QuestionShell>
   );
 };
@@ -233,5 +487,15 @@ export const shellMaterialRenderers = [
   {
     tester: selectOneOfEnumControlTester,
     renderer: withJsonFormsOneOfEnumProps(SelectOneOfEnumControl),
+  },
+  // Opt-in radio / button single-select (ui.json options.display)
+  {
+    tester: choiceControlTester,
+    renderer: withJsonFormsControlProps(ChoiceControl),
+  },
+  // Opt-in checkbox / button multi-select (ui.json options.display)
+  {
+    tester: multiChoiceControlTester,
+    renderer: withJsonFormsMultiEnumProps(MultiChoiceControl),
   },
 ];

--- a/formulus-formplayer/src/theme/theme.ts
+++ b/formulus-formplayer/src/theme/theme.ts
@@ -23,6 +23,20 @@ const parsePx = (value: string): number => {
   return parseInt(value.replace('px', ''), 10);
 };
 
+/**
+ * Compact field density (form-field height reduction).
+ *
+ * Inputs/selects previously used a 56px (`touchTarget.large`) minimum height
+ * with 16px vertical padding, which made long forms feel very tall on mobile.
+ * These constants shrink the vertical footprint while keeping an accessible
+ * tap target (>= 44px including border) and the same horizontal text inset.
+ */
+const FIELD_MIN_HEIGHT = 44; // px (was tokens.touchTarget.large = 56)
+const FIELD_PADDING_Y = parsePx(tokens.spacing[2]); // 8px (was tokens.spacing[4] = 16)
+const FIELD_PADDING_X = parsePx(tokens.spacing[4]); // 16px (unchanged horizontal inset)
+const FIELD_PADDING = `${FIELD_PADDING_Y}px ${FIELD_PADDING_X}px`;
+const FIELD_MARGIN_BOTTOM = parsePx(tokens.spacing[3]); // 12px (was tokens.spacing[4] = 16)
+
 // Token-based helpers (single source: @ode/tokens)
 const getDisabledOpacity = (): number =>
   parseFloat(
@@ -304,7 +318,7 @@ export const getThemeOptions = (
         styleOverrides: {
           root: {
             width: '100%',
-            marginBottom: parsePx(tokens.spacing[4]),
+            marginBottom: FIELD_MARGIN_BOTTOM,
             '& .MuiOutlinedInput-root': {
               borderRadius: parsePx(tokens.border.radius.md), // 8px - match button, not too rounded
               backgroundColor: 'transparent',
@@ -353,10 +367,10 @@ export const getThemeOptions = (
               },
             },
             '& .MuiInputBase-input': {
-              padding: `${parsePx(tokens.spacing[4])}px`,
+              padding: FIELD_PADDING,
               fontSize: parsePx(tokens.typography.fontSize.base),
               lineHeight: parseFloat(tokens.typography.lineHeight.normal),
-              minHeight: `${tokens.touchTarget.large}px`, // 56px - Minimum touch target
+              minHeight: `${FIELD_MIN_HEIGHT}px`, // compact field height
               '&::placeholder': {
                 color: isDark
                   ? tokens.color.neutral[500]
@@ -404,10 +418,10 @@ export const getThemeOptions = (
             },
           },
           input: {
-            padding: parsePx(tokens.spacing[4]),
+            padding: FIELD_PADDING,
             fontSize: parsePx(tokens.typography.fontSize.base),
             lineHeight: parseFloat(tokens.typography.lineHeight.normal),
-            minHeight: `${tokens.touchTarget.large}px`,
+            minHeight: `${FIELD_MIN_HEIGHT}px`,
           },
         },
       },
@@ -550,7 +564,7 @@ export const getThemeOptions = (
         styleOverrides: {
           root: {
             borderRadius: parsePx(tokens.border.radius.md), // Same as text fields (8px, match button)
-            minHeight: `${tokens.touchTarget.large}px`,
+            minHeight: `${FIELD_MIN_HEIGHT}px`,
             '&.Mui-focused': {
               '& .MuiOutlinedInput-notchedOutline': {
                 borderColor: primaryMain,

--- a/formulus-formplayer/src/theme/theme.ts
+++ b/formulus-formplayer/src/theme/theme.ts
@@ -1,6 +1,7 @@
 import {
   createTheme as muiCreateTheme,
   ThemeOptions,
+  alpha,
 } from '@mui/material/styles';
 import { tokens } from './tokens-adapter';
 
@@ -454,7 +455,7 @@ export const getThemeOptions = (
             marginRight: 0,
           },
           label: {
-            fontSize: parsePx(tokens.typography.fontSize.base),
+            fontSize: parsePx(tokens.typography.fontSize.sm),
             '&.Mui-disabled': {
               color: isDark
                 ? tokens.color.neutral[600]
@@ -512,6 +513,45 @@ export const getThemeOptions = (
         styleOverrides: {
           root: {
             flexDirection: 'column',
+          },
+        },
+      },
+      // Toggle buttons (opt-in `options.display: "buttons"` choice controls)
+      MuiToggleButton: {
+        styleOverrides: {
+          root: {
+            minHeight: FIELD_MIN_HEIGHT,
+            padding: `${FIELD_PADDING_Y}px ${FIELD_PADDING_X}px`,
+            textTransform: 'none',
+            fontSize: parsePx(tokens.typography.fontSize.base),
+            lineHeight: parseFloat(tokens.typography.lineHeight.normal),
+            color: isDark
+              ? tokens.color.neutral[200]
+              : tokens.color.neutral[800],
+            borderColor: isDark
+              ? tokens.color.neutral[700]
+              : tokens.color.neutral[300],
+            '&.Mui-selected': {
+              color: primaryMain,
+              backgroundColor: alpha(primaryMain, isDark ? 0.24 : 0.12),
+              borderColor: primaryMain,
+              fontWeight: 600,
+              '&:hover': {
+                backgroundColor: alpha(primaryMain, isDark ? 0.32 : 0.18),
+              },
+            },
+            '&.Mui-disabled': {
+              color: isDark
+                ? tokens.color.neutral[700]
+                : tokens.color.neutral[400],
+            },
+          },
+        },
+      },
+      MuiToggleButtonGroup: {
+        styleOverrides: {
+          root: {
+            flexWrap: 'wrap',
           },
         },
       },

--- a/formulus-formplayer/src/theme/theme.ts
+++ b/formulus-formplayer/src/theme/theme.ts
@@ -614,13 +614,17 @@ export const getThemeOptions = (
           },
         },
         defaultProps: {
-          inputProps: {
-            readOnly: true,
-            inputMode: 'none',
-          },
+          // Native selects (see SelectOneOfEnumControl) need no readOnly hack.
+          // For any remaining MUI Menu-based selects, keep the menu inside the
+          // WebView scroll tree — portaled menus are often clipped/invisible.
           MenuProps: {
+            disablePortal: true,
             disableAutoFocus: true,
             disableEnforceFocus: true,
+            disableScrollLock: true,
+            PaperProps: {
+              sx: { zIndex: 10000 },
+            },
           },
         },
       },

--- a/formulus-formplayer/src/types/CustomQuestionTypeContract.ts
+++ b/formulus-formplayer/src/types/CustomQuestionTypeContract.ts
@@ -40,6 +40,13 @@ export interface CustomQuestionTypeProps {
   /** Whether the field is currently enabled/editable */
   enabled: boolean;
 
+  /**
+   * Whether the field is currently visible according to JSON Forms relevance
+   * rules (SHOW/HIDE). The adapter already hides the component when this is
+   * false, but the value is exposed so renderers can react (e.g. clear state).
+   */
+  visible: boolean;
+
   /** The field's unique path in the form data (e.g., "satisfaction") */
   fieldPath: string;
 

--- a/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
+++ b/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
@@ -58,6 +58,8 @@ export interface FormInitData {
   operationId?: string;
   /** Sub-observation session: embedded child form returns JSON to parent; do not persist as a top-level observation. */
   subObservationMode?: boolean;
+  /** Skip the Finalize page and submit from the last content page (sub-observation fast path). */
+  skipFinalize?: boolean;
   extensions?: ExtensionMetadata;
   customQuestionTypes?: {
     custom_types: Record<string, { source: string }>;
@@ -395,7 +397,7 @@ export interface FormulusInterface {
     formType: string,
     params: Record<string, unknown>,
     savedData: Record<string, unknown>,
-    options?: { subObservationMode?: boolean },
+    options?: { subObservationMode?: boolean; skipFinalize?: boolean },
   ): Promise<FormCompletionResult>;
 
   /**
@@ -656,6 +658,17 @@ export interface FormulusInterface {
    * @returns {Promise<ConnectivityStatus>} The current connectivity status
    */
   getConnectivityStatus(): Promise<ConnectivityStatus>;
+
+  /**
+   * Read the device's last-known Synkronus data revision (`current_version`
+   * from the most recent successful sync). Reflects server-stream alignment
+   * only — not unsynced local edits. Use with periodic polling or after
+   * {@link sync} to detect when another device has pushed changes.
+   *
+   * @since 1.4.0
+   * @returns {Promise<number>} Non-negative revision count (0 if never synced)
+   */
+  getCurrentDataRevisionCount(): Promise<number>;
 }
 
 /**
@@ -674,7 +687,7 @@ export interface FormulusCallbacks {
 /**
  * Current version of the interface
  */
-export const FORMULUS_INTERFACE_VERSION = '1.3.0';
+export const FORMULUS_INTERFACE_VERSION = '1.4.0';
 
 /** Parses major.minor.patch from the start of a version string (ignores prerelease after `-`). */
 function semverSegments(version: string): [number, number, number] {

--- a/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
+++ b/formulus-formplayer/src/types/FormulusInterfaceDefinition.ts
@@ -320,13 +320,56 @@ export interface FormCompletionResult {
 }
 
 /**
+ * Input for {@link FormulusInterface.persistObservation}.
+ * @property formType - Form type id the observation belongs to
+ * @property finalData - Observation JSON to store (must match the form schema)
+ * @property observationId - Provide to update an existing observation; omit/null to create
+ */
+export interface PersistObservationInput {
+  formType: string;
+  finalData: Record<string, unknown>;
+  observationId?: string | null;
+}
+
+/**
+ * Result of {@link FormulusInterface.persistObservation}.
+ * @property observationId - The id of the created/updated observation
+ * @property formData - The stored data (attachment paths normalized to committed locations)
+ */
+export interface PersistObservationResult {
+  observationId: string;
+  formData: Record<string, unknown>;
+}
+
+/**
+ * Result of {@link FormulusInterface.sync}.
+ * @property version - Final repository/data version reported by the server after sync
+ */
+export interface SyncResult {
+  version: number;
+}
+
+/**
+ * Result of {@link FormulusInterface.getConnectivityStatus}.
+ * @property online - Whether the configured Synkronus server answered a `/health` probe
+ * @property serverUrl - The configured server URL, or null if none is set
+ * @property checkedAt - Epoch milliseconds when the probe completed
+ */
+export interface ConnectivityStatus {
+  online: boolean;
+  serverUrl: string | null;
+  checkedAt: number;
+}
+
+/**
  * Interface for the Formulus app methods that will be injected into the WebViews for custom_app and FormPlayer
  * @namespace formulus
  */
 export interface FormulusInterface {
   /**
-   * Get the current version of the Formulus API
-   * @returns {Promise<string>} The API version
+   * Get the current version of the Formulus bridge API (the interface contract
+   * version, e.g. for {@link isCompatibleVersion} checks).
+   * @returns {Promise<string>} The API version (semver)
    */
   getVersion(): Promise<string>;
 
@@ -339,7 +382,12 @@ export interface FormulusInterface {
   /**
    * Open Formplayer with the specified form
    * @param {string} formType - The identifier of the formtype to open
-   * @param {Object} params - Additional parameters for form initialization
+   * @param {Object} params - Additional parameters for form initialization.
+   *   Reserved keys are not treated as observation data:
+   *   `defaultData` (prefill), `theme`/`darkMode`/`themeColors` (theming), and
+   *   `context` — a read-only **session context** object (device role, selected
+   *   cluster, ...) that Formplayer never persists and exposes to extensions as
+   *   `window.formulusSessionContext`.
    * @param {Object} savedData - Previously saved form data (for editing)
    * @returns {Promise<FormCompletionResult>} Promise that resolves when the form is completed/closed with result details
    */
@@ -568,6 +616,46 @@ export interface FormulusInterface {
    * @returns Forms directory URL
    */
   getFormSpecsUri(): Promise<string>;
+
+  /**
+   * Persist an observation **without opening Formplayer** (headless write).
+   *
+   * Intended for custom apps that create or update records programmatically.
+   * Uses the same persistence path as a Formplayer submit, including promotion
+   * of any referenced draft attachments. Provide `observationId` to update an
+   * existing row; omit it to create a new one.
+   *
+   * @since 1.3.0
+   * @param {PersistObservationInput} input - The observation to persist
+   * @returns {Promise<PersistObservationResult>} The stored observation id and data
+   */
+  persistObservation(
+    input: PersistObservationInput,
+  ): Promise<PersistObservationResult>;
+
+  /**
+   * Trigger a synchronization with Synkronus (pull + push).
+   *
+   * Resolves when the sync completes; rejects if a sync is already in progress
+   * or the sync fails. Attachments are excluded by default for speed.
+   *
+   * @since 1.3.0
+   * @param {{ includeAttachments?: boolean }} [options] - Sync options
+   * @returns {Promise<SyncResult>} The final data version after sync
+   */
+  sync(options?: { includeAttachments?: boolean }): Promise<SyncResult>;
+
+  /**
+   * Probe connectivity to the configured Synkronus server (`GET /health`).
+   *
+   * Never rejects for an offline device — returns `{ online: false }` so callers
+   * can branch on connectivity without try/catch. Suitable for the
+   * "verify subject details when online, fall back when offline" pattern.
+   *
+   * @since 1.3.0
+   * @returns {Promise<ConnectivityStatus>} The current connectivity status
+   */
+  getConnectivityStatus(): Promise<ConnectivityStatus>;
 }
 
 /**
@@ -586,7 +674,7 @@ export interface FormulusCallbacks {
 /**
  * Current version of the interface
  */
-export const FORMULUS_INTERFACE_VERSION = '1.2.1';
+export const FORMULUS_INTERFACE_VERSION = '1.3.0';
 
 /** Parses major.minor.patch from the start of a version string (ignores prerelease after `-`). */
 function semverSegments(version: string): [number, number, number] {

--- a/formulus-formplayer/src/utils/formObservationData.test.ts
+++ b/formulus-formplayer/src/utils/formObservationData.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applySchemaDefaultTokens,
   dataMatchingSchemaRoot,
   initialFormDataFromParams,
+  resolveDefaultToken,
 } from './formObservationData';
 
 /**
@@ -60,6 +62,82 @@ describe('dataMatchingSchemaRoot', () => {
   it('passes data through when properties is empty', () => {
     const data = { a: 1, theme: 'x' };
     expect(dataMatchingSchemaRoot(data, { properties: {} })).toEqual(data);
+  });
+});
+
+describe('resolveDefaultToken', () => {
+  it('resolves $today to a local YYYY-MM-DD date', () => {
+    const result = resolveDefaultToken('$today');
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const d = new Date();
+    const expected = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(
+      2,
+      '0',
+    )}-${String(d.getDate()).padStart(2, '0')}`;
+    expect(result).toBe(expected);
+  });
+
+  it('resolves $now to an ISO date-time', () => {
+    const result = resolveDefaultToken('$now');
+    expect(typeof result).toBe('string');
+    expect(() => new Date(result as string).toISOString()).not.toThrow();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('returns undefined for static or unknown defaults', () => {
+    expect(resolveDefaultToken('2026-01-01')).toBeUndefined();
+    expect(resolveDefaultToken('hello')).toBeUndefined();
+    expect(resolveDefaultToken(5)).toBeUndefined();
+    expect(resolveDefaultToken(undefined)).toBeUndefined();
+  });
+});
+
+describe('applySchemaDefaultTokens', () => {
+  it('injects $today only for missing fields with a token default', () => {
+    const schema = {
+      properties: {
+        obsdate: { type: 'string', format: 'date', default: '$today' },
+        name: { type: 'string' },
+      },
+    };
+    const out = applySchemaDefaultTokens({ name: 'x' }, schema);
+    expect(out.name).toBe('x');
+    expect(out.obsdate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('does not override values already provided via params/defaultData', () => {
+    const schema = {
+      properties: {
+        obsdate: { type: 'string', format: 'date', default: '$today' },
+      },
+    };
+    expect(
+      applySchemaDefaultTokens({ obsdate: '2020-05-05' }, schema).obsdate,
+    ).toBe('2020-05-05');
+  });
+
+  it('fills empty-string values (treated as missing)', () => {
+    const schema = {
+      properties: {
+        obsdate: { type: 'string', format: 'date', default: '$today' },
+      },
+    };
+    expect(applySchemaDefaultTokens({ obsdate: '' }, schema).obsdate).toMatch(
+      /^\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+
+  it('leaves static defaults untouched (no auto-merge of plain defaults)', () => {
+    const schema = {
+      properties: {
+        color: { type: 'string', default: 'red' },
+      },
+    };
+    expect(applySchemaDefaultTokens({}, schema)).toEqual({});
+  });
+
+  it('is a no-op when schema has no properties', () => {
+    expect(applySchemaDefaultTokens({ a: 1 }, {})).toEqual({ a: 1 });
   });
 });
 

--- a/formulus-formplayer/src/utils/formObservationData.ts
+++ b/formulus-formplayer/src/utils/formObservationData.ts
@@ -9,6 +9,10 @@ export const FORMPARAMS_NON_DATA_KEYS = new Set([
   'theme',
   'darkMode',
   'themeColors',
+  // Reserved read-only session context channel (see App init): a custom app may
+  // pass `params.context` with session info (device role, selected cluster, ...)
+  // that must never be persisted as observation data.
+  'context',
 ]);
 
 export type FormObservationData = Record<string, unknown>;
@@ -31,6 +35,73 @@ export function initialFormDataFromParams(
   for (const [key, value] of Object.entries(p)) {
     if (!FORMPARAMS_NON_DATA_KEYS.has(key)) {
       out[key] = value;
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve a dynamic default token used in a schema property `default`.
+ *
+ * Only a small, documented set of tokens is supported so that existing static
+ * `default` values are never altered:
+ *   - `$today` -> local calendar date as `YYYY-MM-DD` (matches `format: "date"`)
+ *   - `$now`   -> ISO 8601 date-time (matches `format: "date-time"`)
+ *
+ * Returns `undefined` for anything that is not a recognized token, signalling
+ * "do not inject a value".
+ */
+export function resolveDefaultToken(token: unknown): unknown {
+  if (typeof token !== 'string') {
+    return undefined;
+  }
+  switch (token) {
+    case '$today': {
+      const d = new Date();
+      const yyyy = d.getFullYear();
+      const mm = String(d.getMonth() + 1).padStart(2, '0');
+      const dd = String(d.getDate()).padStart(2, '0');
+      return `${yyyy}-${mm}-${dd}`;
+    }
+    case '$now':
+      return new Date().toISOString();
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Merge resolved dynamic-default tokens (`$today` / `$now`) from the schema into
+ * initial data for a NEW observation.
+ *
+ * Rules:
+ *   - Only acts on properties whose `default` is a recognized token (see
+ *     `resolveDefaultToken`); plain/static `default` values are left untouched
+ *     so existing forms keep their current behaviour.
+ *   - Never overrides a value already provided via `params` / `defaultData`
+ *     (only fills keys that are missing/empty).
+ *
+ * Callers must only use this on the new-observation path (no saved draft), so
+ * resumed/edited observations keep their stored values.
+ */
+export function applySchemaDefaultTokens(
+  data: FormObservationData,
+  formSchema: unknown,
+): FormObservationData {
+  const props = (formSchema as { properties?: unknown } | null)?.properties;
+  if (!props || typeof props !== 'object' || Array.isArray(props)) {
+    return { ...data };
+  }
+  const out: FormObservationData = { ...data };
+  for (const [key, prop] of Object.entries(props as Record<string, unknown>)) {
+    const existing = out[key];
+    if (existing !== undefined && existing !== null && existing !== '') {
+      continue;
+    }
+    const def = (prop as { default?: unknown } | null)?.default;
+    const resolved = resolveDefaultToken(def);
+    if (resolved !== undefined) {
+      out[key] = resolved;
     }
   }
   return out;

--- a/formulus-formplayer/src/utils/stickyFieldHelpers.ts
+++ b/formulus-formplayer/src/utils/stickyFieldHelpers.ts
@@ -1,0 +1,68 @@
+import type { UISchemaElement } from '@jsonforms/core';
+import type { FormObservationData } from './formObservationData';
+
+/** Walk uischema and collect data paths for controls with `options.sticky: true`. */
+export function collectStickyFieldPaths(
+  uischema: unknown,
+  paths: string[] = [],
+): string[] {
+  if (!uischema || typeof uischema !== 'object') return paths;
+  const el = uischema as Record<string, unknown>;
+
+  if (el.type === 'Control' && typeof el.scope === 'string') {
+    const opts = el.options as Record<string, unknown> | undefined;
+    if (opts?.sticky === true) {
+      const field = el.scope.replace(/^#\/properties\//, '').split('/')[0];
+      if (field) paths.push(field);
+    }
+  }
+
+  const children = el.elements;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      collectStickyFieldPaths(child, paths);
+    }
+  }
+
+  return paths;
+}
+
+function isScalarStickyValue(value: unknown): boolean {
+  if (value === undefined || value === null || value === '') return false;
+  const t = typeof value;
+  return t === 'string' || t === 'number' || t === 'boolean';
+}
+
+/** Extract scalar sticky values from submitted form data for the given field paths. */
+export function extractStickyValues(
+  data: FormObservationData,
+  fieldPaths: string[],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of fieldPaths) {
+    const v = data[key];
+    if (isScalarStickyValue(v)) {
+      out[key] = v;
+    }
+  }
+  return out;
+}
+
+/** Lowest-precedence fill: only keys still missing after params / schema defaults. */
+export function applyStickyDefaults(
+  data: FormObservationData,
+  stickyValues: Record<string, unknown>,
+): FormObservationData {
+  if (!stickyValues || Object.keys(stickyValues).length === 0) {
+    return { ...data };
+  }
+  const out: FormObservationData = { ...data };
+  for (const [key, value] of Object.entries(stickyValues)) {
+    const existing = out[key];
+    if (existing !== undefined && existing !== null && existing !== '') {
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}

--- a/formulus-formplayer/src/utils/stickyFieldHelpers.ts
+++ b/formulus-formplayer/src/utils/stickyFieldHelpers.ts
@@ -1,4 +1,3 @@
-import type { UISchemaElement } from '@jsonforms/core';
 import type { FormObservationData } from './formObservationData';
 
 /** Walk uischema and collect data paths for controls with `options.sticky: true`. */

--- a/formulus/AGENTS.md
+++ b/formulus/AGENTS.md
@@ -44,3 +44,14 @@
 ## Build and run
 
 See [README.md](README.md): Metro, `pnpm run android` / `ios`, Android **Notifee** vendor step, iOS **Pods**. For CI and formatting, see root [README.md](../README.md) and [.github/CICD.md](../.github/CICD.md).
+
+## Pre-flight before a PR
+
+From **`formulus/`**:
+
+```bash
+pnpm run lint
+pnpm run test --ci --watchAll=false
+```
+
+Lint allows warnings (`--max-warnings 9999`) but **errors** fail CI — e.g. unused imports (`@typescript-eslint/no-unused-vars`). If the PR touches formplayer too, run its pre-flight in [formulus-formplayer/AGENTS.md](../formulus-formplayer/AGENTS.md#pre-flight-before-a-pr).

--- a/formulus/App.tsx
+++ b/formulus/App.tsx
@@ -70,7 +70,8 @@ function AppInner(): React.JSX.Element {
     observationId: string | null;
     savedData: Record<string, unknown> | null;
     operationId: string | null;
-    subObservationMode?: boolean; // Embedded sub-observation (e.g. sub-observation custom type)
+    subObservationMode?: boolean;
+    skipFinalize?: boolean;
   };
 
   const [formplayerStack, setFormplayerStack] = useState<
@@ -102,6 +103,7 @@ function AppInner(): React.JSX.Element {
             entry.savedData,
             entry.operationId,
             entry.subObservationMode,
+            entry.skipFinalize,
           );
         }, 200);
       };
@@ -159,10 +161,12 @@ function AppInner(): React.JSX.Element {
         savedData,
         operationId,
         subObservationMode: subObservationModeField,
+        skipFinalize: skipFinalizeField,
       } = config;
       const legacy = config as FormInitData & { returnOnly?: boolean };
       const subObservationMode =
         Boolean(subObservationModeField) || Boolean(legacy.returnOnly);
+      const skipFinalize = Boolean(skipFinalizeField);
 
       try {
         const formService = await FormService.getInstance();
@@ -196,6 +200,7 @@ function AppInner(): React.JSX.Element {
           savedData: savedData || null,
           operationId: operationId || null,
           subObservationMode,
+          skipFinalize,
         };
 
         setFormplayerStack(current => [...current, entry]);

--- a/formulus/assets/webview/FormulusInjectionScript.js
+++ b/formulus/assets/webview/FormulusInjectionScript.js
@@ -1637,6 +1637,176 @@
         );
       });
     },
+
+    // persistObservation: input: PersistObservationInput => Promise<PersistObservationResult>
+    persistObservation: function (input) {
+      return new Promise((resolve, reject) => {
+        const messageId =
+          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+
+        const callback = event => {
+          try {
+            let data;
+            if (typeof event.data === 'string') {
+              data = JSON.parse(event.data);
+            } else if (typeof event.data === 'object' && event.data !== null) {
+              data = event.data; // Already an object
+            } else {
+              window.removeEventListener('message', callback); // Clean up listener
+              reject(
+                new Error(
+                  'persistObservation callback: Received response with unexpected data type. Raw: ' +
+                    String(event.data),
+                ),
+              );
+              return;
+            }
+            if (
+              data.type === 'persistObservation_response' &&
+              data.messageId === messageId
+            ) {
+              window.removeEventListener('message', callback);
+              if (data.error) {
+                reject(new Error(data.error));
+              } else {
+                resolve(data.result);
+              }
+            }
+          } catch (e) {
+            console.error(
+              "'persistObservation' callback: Error processing response:",
+              e,
+              'Raw event.data:',
+              event.data,
+            );
+            window.removeEventListener('message', callback); // Ensure listener is removed on error too
+            reject(e);
+          }
+        };
+        window.addEventListener('message', callback);
+
+        // Send the message to React Native
+        globalThis.ReactNativeWebView.postMessage(
+          JSON.stringify({
+            type: 'persistObservation',
+            messageId,
+            input: input,
+          }),
+        );
+      });
+    },
+
+    // sync: options: { includeAttachments?: boolean } => Promise<SyncResult>
+    sync: function (options) {
+      return new Promise((resolve, reject) => {
+        const messageId =
+          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+
+        const callback = event => {
+          try {
+            let data;
+            if (typeof event.data === 'string') {
+              data = JSON.parse(event.data);
+            } else if (typeof event.data === 'object' && event.data !== null) {
+              data = event.data; // Already an object
+            } else {
+              window.removeEventListener('message', callback); // Clean up listener
+              reject(
+                new Error(
+                  'sync callback: Received response with unexpected data type. Raw: ' +
+                    String(event.data),
+                ),
+              );
+              return;
+            }
+            if (data.type === 'sync_response' && data.messageId === messageId) {
+              window.removeEventListener('message', callback);
+              if (data.error) {
+                reject(new Error(data.error));
+              } else {
+                resolve(data.result);
+              }
+            }
+          } catch (e) {
+            console.error(
+              "'sync' callback: Error processing response:",
+              e,
+              'Raw event.data:',
+              event.data,
+            );
+            window.removeEventListener('message', callback); // Ensure listener is removed on error too
+            reject(e);
+          }
+        };
+        window.addEventListener('message', callback);
+
+        // Send the message to React Native
+        globalThis.ReactNativeWebView.postMessage(
+          JSON.stringify({
+            type: 'sync',
+            messageId,
+            options: options,
+          }),
+        );
+      });
+    },
+
+    // getConnectivityStatus:  => Promise<ConnectivityStatus>
+    getConnectivityStatus: function () {
+      return new Promise((resolve, reject) => {
+        const messageId =
+          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+
+        const callback = event => {
+          try {
+            let data;
+            if (typeof event.data === 'string') {
+              data = JSON.parse(event.data);
+            } else if (typeof event.data === 'object' && event.data !== null) {
+              data = event.data; // Already an object
+            } else {
+              window.removeEventListener('message', callback); // Clean up listener
+              reject(
+                new Error(
+                  'getConnectivityStatus callback: Received response with unexpected data type. Raw: ' +
+                    String(event.data),
+                ),
+              );
+              return;
+            }
+            if (
+              data.type === 'getConnectivityStatus_response' &&
+              data.messageId === messageId
+            ) {
+              window.removeEventListener('message', callback);
+              if (data.error) {
+                reject(new Error(data.error));
+              } else {
+                resolve(data.result);
+              }
+            }
+          } catch (e) {
+            console.error(
+              "'getConnectivityStatus' callback: Error processing response:",
+              e,
+              'Raw event.data:',
+              event.data,
+            );
+            window.removeEventListener('message', callback); // Ensure listener is removed on error too
+            reject(e);
+          }
+        };
+        window.addEventListener('message', callback);
+
+        // Send the message to React Native
+        globalThis.ReactNativeWebView.postMessage(
+          JSON.stringify({
+            type: 'getConnectivityStatus',
+            messageId,
+          }),
+        );
+      });
+    },
   };
 
   // Register the callback handler with the window object

--- a/formulus/assets/webview/FormulusInjectionScript.js
+++ b/formulus/assets/webview/FormulusInjectionScript.js
@@ -1807,6 +1807,62 @@
         );
       });
     },
+
+    // getCurrentDataRevisionCount:  => Promise<number>
+    getCurrentDataRevisionCount: function () {
+      return new Promise((resolve, reject) => {
+        const messageId =
+          'msg_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+
+        const callback = event => {
+          try {
+            let data;
+            if (typeof event.data === 'string') {
+              data = JSON.parse(event.data);
+            } else if (typeof event.data === 'object' && event.data !== null) {
+              data = event.data;
+            } else {
+              window.removeEventListener('message', callback);
+              reject(
+                new Error(
+                  'getCurrentDataRevisionCount callback: Received response with unexpected data type. Raw: ' +
+                    String(event.data),
+                ),
+              );
+              return;
+            }
+            if (
+              data.type === 'getCurrentDataRevisionCount_response' &&
+              data.messageId === messageId
+            ) {
+              window.removeEventListener('message', callback);
+              if (data.error) {
+                reject(new Error(data.error));
+              } else {
+                resolve(data.result);
+              }
+            }
+          } catch (e) {
+            console.error(
+              "'getCurrentDataRevisionCount' callback: Error processing response:",
+              e,
+              'Raw event.data:',
+              event.data,
+            );
+            window.removeEventListener('message', callback);
+            reject(e);
+          }
+        };
+        window.addEventListener('message', callback);
+
+        globalThis.ReactNativeWebView.postMessage(
+          JSON.stringify({
+            type: 'getCurrentDataRevisionCount',
+            messageId,
+          }),
+        );
+      });
+    },
   };
 
   // Register the callback handler with the window object

--- a/formulus/assets/webview/formulus-api.js
+++ b/formulus/assets/webview/formulus-api.js
@@ -244,6 +244,26 @@ const FormulusAPI = {
    * @returns {Promise<string>} Forms directory URL
    */
   getFormSpecsUri: function () {},
+
+  /**
+   * Persist an observation without opening Formplayer (headless write).
+   * @param {PersistObservationInput} input - The observation to persist
+   * @returns {Promise<PersistObservationResult>} The stored observation id and data
+   */
+  persistObservation: function (input) {},
+
+  /**
+   * Trigger a synchronization with Synkronus (pull + push).
+   * @param {{ includeAttachments?: boolean }} options - Sync options
+   * @returns {Promise<SyncResult>} The final data version after sync
+   */
+  sync: function (options) {},
+
+  /**
+   * Probe connectivity to the configured Synkronus server (GET /health).
+   * @returns {Promise<ConnectivityStatus>} The current connectivity status
+   */
+  getConnectivityStatus: function () {},
 };
 
 // Make the API available globally in browser environments

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -38,7 +38,6 @@ import {
   odeSpacing,
   odeTypography,
   odeBorderWidth,
-  odeScreenHeaderHeight,
   odeFormplayerHeaderHeight,
 } from '../theme/odeDesign';
 import { FormSpec } from '../services'; // FormService will be imported directly

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -39,6 +39,7 @@ import {
   odeTypography,
   odeBorderWidth,
   odeScreenHeaderHeight,
+  odeFormplayerHeaderHeight,
 } from '../theme/odeDesign';
 import { FormSpec } from '../services'; // FormService will be imported directly
 import { ExtensionService } from '../services/ExtensionService';
@@ -62,6 +63,7 @@ export interface FormplayerModalHandle {
     existingObservationData: Record<string, unknown> | null,
     operationId: string | null,
     subObservationMode?: boolean,
+    skipFinalize?: boolean,
   ) => void;
   handleSubmission: (data: {
     formType: string;
@@ -101,6 +103,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
     // Sub-observation (embedded child) forms: return JSON only; do not persist as top-level observations.
     // Ref updates synchronously in initializeForm so submit cannot run before flag is set.
     const subObservationModeRef = useRef(false);
+    const skipFinalizeRef = useRef(false);
 
     // Author-configurable display name shown in the native header bar
     const [currentFormDisplayName, setCurrentFormDisplayName] = useState<
@@ -216,6 +219,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       existingObservationData: Record<string, unknown> | null,
       operationId: string | null,
       subObservationMode: boolean = false,
+      skipFinalize: boolean = false,
     ) => {
       // Check if WebView is ready, if not log a warning (retry logic will handle it)
       if (!webViewReady) {
@@ -225,9 +229,12 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
       }
 
       subObservationModeRef.current = subObservationMode;
+      skipFinalizeRef.current = skipFinalize;
 
-      // GPS session: fresh fix + light watch while the user fills the form
-      geolocationService.beginObservationSession();
+      // GPS session: skip for sub-observations (data is not persisted with geo).
+      if (!subObservationMode) {
+        geolocationService.beginObservationSession();
+      }
 
       setCurrentFormType(formType.id);
       setCurrentObservationId(observationId);
@@ -459,6 +466,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         extensions,
         customQuestionTypes,
         subObservationMode,
+        skipFinalize,
       } as FormInitData;
 
       if (!webViewRef.current) {
@@ -543,13 +551,17 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
 
           if (currentOperationId) {
             resolveFormOperation(currentOperationId, completionResult);
-            // Clear the operation ID to prevent double resolution
             setCurrentOperationId(null);
           } else {
             resolveFormOperationByType(formType, completionResult);
           }
 
-          // Show success message and close modal
+          if (subObservationModeRef.current && skipFinalizeRef.current) {
+            setIsSubmitting(false);
+            onClose();
+            return resultObservationId;
+          }
+
           const successMessage = effectiveObservationId
             ? 'Observation updated successfully!'
             : 'Form submitted successfully!';
@@ -735,7 +747,8 @@ const styles = StyleSheet.create({
     width: '100%',
     padding: odeSpacing.md,
     borderBottomWidth: odeBorderWidth.hairline,
-    minHeight: odeScreenHeaderHeight,
+    minHeight: odeFormplayerHeaderHeight,
+    paddingVertical: odeSpacing.sm,
     borderTopWidth: 0,
     borderLeftWidth: 0,
     borderRightWidth: 0,

--- a/formulus/src/theme/odeDesign.ts
+++ b/formulus/src/theme/odeDesign.ts
@@ -77,3 +77,10 @@ export const odeScreenHeaderHeight = (() => {
     odeSpacing.md * 2 + titleLineHeight + odeSpacing.xs + subtitleLineHeight
   );
 })();
+
+/** Compact single-line header for the Formplayer modal (title + close only). */
+export const odeFormplayerHeaderHeight = (() => {
+  const lineHeightFactor = 1.25;
+  const titleLineHeight = odeTypography.screenTitle * lineHeightFactor;
+  return odeSpacing.sm * 2 + titleLineHeight;
+})();

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -58,6 +58,8 @@ export interface FormInitData {
   operationId?: string;
   /** Sub-observation session: embedded child form returns JSON to parent; do not persist as a top-level observation. */
   subObservationMode?: boolean;
+  /** Skip the Finalize page and submit from the last content page (sub-observation fast path). */
+  skipFinalize?: boolean;
   extensions?: ExtensionMetadata;
   customQuestionTypes?: {
     custom_types: Record<string, { source: string }>;
@@ -395,7 +397,7 @@ export interface FormulusInterface {
     formType: string,
     params: Record<string, unknown>,
     savedData: Record<string, unknown>,
-    options?: { subObservationMode?: boolean },
+    options?: { subObservationMode?: boolean; skipFinalize?: boolean },
   ): Promise<FormCompletionResult>;
 
   /**
@@ -656,6 +658,17 @@ export interface FormulusInterface {
    * @returns {Promise<ConnectivityStatus>} The current connectivity status
    */
   getConnectivityStatus(): Promise<ConnectivityStatus>;
+
+  /**
+   * Read the device's last-known Synkronus data revision (`current_version`
+   * from the most recent successful sync). Reflects server-stream alignment
+   * only — not unsynced local edits. Use with periodic polling or after
+   * {@link sync} to detect when another device has pushed changes.
+   *
+   * @since 1.4.0
+   * @returns {Promise<number>} Non-negative revision count (0 if never synced)
+   */
+  getCurrentDataRevisionCount(): Promise<number>;
 }
 
 /**
@@ -674,7 +687,7 @@ export interface FormulusCallbacks {
 /**
  * Current version of the interface
  */
-export const FORMULUS_INTERFACE_VERSION = '1.3.0';
+export const FORMULUS_INTERFACE_VERSION = '1.4.0';
 
 /** Parses major.minor.patch from the start of a version string (ignores prerelease after `-`). */
 function semverSegments(version: string): [number, number, number] {

--- a/formulus/src/webview/FormulusInterfaceDefinition.ts
+++ b/formulus/src/webview/FormulusInterfaceDefinition.ts
@@ -320,13 +320,56 @@ export interface FormCompletionResult {
 }
 
 /**
+ * Input for {@link FormulusInterface.persistObservation}.
+ * @property formType - Form type id the observation belongs to
+ * @property finalData - Observation JSON to store (must match the form schema)
+ * @property observationId - Provide to update an existing observation; omit/null to create
+ */
+export interface PersistObservationInput {
+  formType: string;
+  finalData: Record<string, unknown>;
+  observationId?: string | null;
+}
+
+/**
+ * Result of {@link FormulusInterface.persistObservation}.
+ * @property observationId - The id of the created/updated observation
+ * @property formData - The stored data (attachment paths normalized to committed locations)
+ */
+export interface PersistObservationResult {
+  observationId: string;
+  formData: Record<string, unknown>;
+}
+
+/**
+ * Result of {@link FormulusInterface.sync}.
+ * @property version - Final repository/data version reported by the server after sync
+ */
+export interface SyncResult {
+  version: number;
+}
+
+/**
+ * Result of {@link FormulusInterface.getConnectivityStatus}.
+ * @property online - Whether the configured Synkronus server answered a `/health` probe
+ * @property serverUrl - The configured server URL, or null if none is set
+ * @property checkedAt - Epoch milliseconds when the probe completed
+ */
+export interface ConnectivityStatus {
+  online: boolean;
+  serverUrl: string | null;
+  checkedAt: number;
+}
+
+/**
  * Interface for the Formulus app methods that will be injected into the WebViews for custom_app and FormPlayer
  * @namespace formulus
  */
 export interface FormulusInterface {
   /**
-   * Get the current version of the Formulus API
-   * @returns {Promise<string>} The API version
+   * Get the current version of the Formulus bridge API (the interface contract
+   * version, e.g. for {@link isCompatibleVersion} checks).
+   * @returns {Promise<string>} The API version (semver)
    */
   getVersion(): Promise<string>;
 
@@ -339,7 +382,12 @@ export interface FormulusInterface {
   /**
    * Open Formplayer with the specified form
    * @param {string} formType - The identifier of the formtype to open
-   * @param {Object} params - Additional parameters for form initialization
+   * @param {Object} params - Additional parameters for form initialization.
+   *   Reserved keys are not treated as observation data:
+   *   `defaultData` (prefill), `theme`/`darkMode`/`themeColors` (theming), and
+   *   `context` — a read-only **session context** object (device role, selected
+   *   cluster, ...) that Formplayer never persists and exposes to extensions as
+   *   `window.formulusSessionContext`.
    * @param {Object} savedData - Previously saved form data (for editing)
    * @returns {Promise<FormCompletionResult>} Promise that resolves when the form is completed/closed with result details
    */
@@ -568,6 +616,46 @@ export interface FormulusInterface {
    * @returns Forms directory URL
    */
   getFormSpecsUri(): Promise<string>;
+
+  /**
+   * Persist an observation **without opening Formplayer** (headless write).
+   *
+   * Intended for custom apps that create or update records programmatically.
+   * Uses the same persistence path as a Formplayer submit, including promotion
+   * of any referenced draft attachments. Provide `observationId` to update an
+   * existing row; omit it to create a new one.
+   *
+   * @since 1.3.0
+   * @param {PersistObservationInput} input - The observation to persist
+   * @returns {Promise<PersistObservationResult>} The stored observation id and data
+   */
+  persistObservation(
+    input: PersistObservationInput,
+  ): Promise<PersistObservationResult>;
+
+  /**
+   * Trigger a synchronization with Synkronus (pull + push).
+   *
+   * Resolves when the sync completes; rejects if a sync is already in progress
+   * or the sync fails. Attachments are excluded by default for speed.
+   *
+   * @since 1.3.0
+   * @param {{ includeAttachments?: boolean }} [options] - Sync options
+   * @returns {Promise<SyncResult>} The final data version after sync
+   */
+  sync(options?: { includeAttachments?: boolean }): Promise<SyncResult>;
+
+  /**
+   * Probe connectivity to the configured Synkronus server (`GET /health`).
+   *
+   * Never rejects for an offline device — returns `{ online: false }` so callers
+   * can branch on connectivity without try/catch. Suitable for the
+   * "verify subject details when online, fall back when offline" pattern.
+   *
+   * @since 1.3.0
+   * @returns {Promise<ConnectivityStatus>} The current connectivity status
+   */
+  getConnectivityStatus(): Promise<ConnectivityStatus>;
 }
 
 /**
@@ -586,7 +674,7 @@ export interface FormulusCallbacks {
 /**
  * Current version of the interface
  */
-export const FORMULUS_INTERFACE_VERSION = '1.2.1';
+export const FORMULUS_INTERFACE_VERSION = '1.3.0';
 
 /** Parses major.minor.patch from the start of a version string (ignores prerelease after `-`). */
 function semverSegments(version: string): [number, number, number] {

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -24,11 +24,20 @@ import {
 } from '@react-native-documents/picker';
 import {
   AttachmentDisplayDescriptor,
+  ConnectivityStatus,
   FormInitData,
   FormCompletionResult,
   FormInfo,
+  FORMULUS_INTERFACE_VERSION,
+  PersistObservationInput,
+  PersistObservationResult,
+  SyncResult,
 } from './FormulusInterfaceDefinition';
 import { FormulusMessageHandlers } from './FormulusMessageHandlers.types';
+import { persistObservationWithAttachments } from '../services/attachmentStorage';
+import { databaseService } from '../database/DatabaseService';
+import { SyncService } from '../services/SyncService';
+import { ServerConfigService } from '../services/ServerConfigService';
 
 // NitroSound is disabled for emulator in react-native.config.js - do not load the module
 // to avoid "Sound HybridObject not registered" console errors. Load lazily only when
@@ -241,9 +250,9 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
     },
     onGetVersion: async (): Promise<string> => {
       console.log('FormulusMessageHandlers: onGetVersion handler invoked.');
-      // Replace with your actual version retrieval logic.
-      const version = '0.1.0-native'; // Example version
-      return version;
+      // Return the bridge interface contract version so custom apps can do
+      // meaningful compatibility checks (see isCompatibleVersion).
+      return FORMULUS_INTERFACE_VERSION;
     },
     onSubmitObservation: async (data: {
       formType: string;
@@ -1016,6 +1025,69 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
     onRequestSyncStatus: () => {
       // TODO: implement sync status logic
       console.log('Request sync status handler called');
+    },
+    onPersistObservation: async (
+      data: {
+        input?: PersistObservationInput;
+      } & Partial<PersistObservationInput>,
+    ): Promise<PersistObservationResult> => {
+      // The bridge nests the single argument under `input`; tolerate both shapes.
+      const input = (data?.input ?? data) as PersistObservationInput;
+      if (!input || !input.formType) {
+        throw new Error('persistObservation: formType is required');
+      }
+      if (!input.finalData || typeof input.finalData !== 'object') {
+        throw new Error('persistObservation: finalData object is required');
+      }
+
+      const localRepo = databaseService.getLocalRepo();
+      if (!localRepo) {
+        throw new Error('persistObservation: database repository not available');
+      }
+
+      // Reuse the exact Formplayer submit persistence path (attachment promotion
+      // included). Headless writes are never sub-observations.
+      return persistObservationWithAttachments(
+        {
+          formType: input.formType,
+          finalData: input.finalData,
+          observationId: input.observationId ?? null,
+          subObservationMode: false,
+        },
+        {
+          saveObservation: args => localRepo.saveObservation(args),
+          updateObservation: args => localRepo.updateObservation(args),
+        },
+      );
+    },
+    onSync: async (data: {
+      options?: { includeAttachments?: boolean };
+      includeAttachments?: boolean;
+    }): Promise<SyncResult> => {
+      const includeAttachments = Boolean(
+        data?.options?.includeAttachments ?? data?.includeAttachments ?? false,
+      );
+      const version =
+        await SyncService.getInstance().syncObservations(includeAttachments);
+      return { version };
+    },
+    onGetConnectivityStatus: async (): Promise<ConnectivityStatus> => {
+      const checkedAt = Date.now();
+      try {
+        const serverUrl = await ServerConfigService.getInstance().getServerUrl();
+        if (!serverUrl) {
+          return { online: false, serverUrl: null, checkedAt: Date.now() };
+        }
+        const online =
+          await ServerConfigService.getInstance().isHealthEndpointOk(serverUrl);
+        return { online, serverUrl, checkedAt: Date.now() };
+      } catch (error) {
+        console.warn(
+          'FormulusMessageHandlers: getConnectivityStatus probe failed',
+          error,
+        );
+        return { online: false, serverUrl: null, checkedAt };
+      }
     },
     onRunLocalModel: (
       fieldId: string,

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -126,6 +126,7 @@ const startFormplayerOperation = (
   savedData: Record<string, unknown> = {},
   observationId: string | null = null,
   subObservationMode: boolean = false,
+  skipFinalize: boolean = false,
 ): Promise<FormCompletionResult> => {
   const operationId = `${formType}_${Date.now()}_${Math.random()
     .toString(36)
@@ -146,6 +147,7 @@ const startFormplayerOperation = (
       observationId,
       operationId,
       subObservationMode,
+      skipFinalize,
     });
 
     setTimeout(
@@ -1089,6 +1091,19 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
         return { online: false, serverUrl: null, checkedAt };
       }
     },
+    onGetCurrentDataRevisionCount: async (): Promise<number> => {
+      try {
+        const raw = await AsyncStorage.getItem('@last_seen_version');
+        const n = raw != null ? Number(raw) : 0;
+        return Number.isFinite(n) && n >= 0 ? n : 0;
+      } catch (error) {
+        console.warn(
+          'FormulusMessageHandlers: getCurrentDataRevisionCount failed',
+          error,
+        );
+        return 0;
+      }
+    },
     onRunLocalModel: (
       fieldId: string,
       modelId: string,
@@ -1306,7 +1321,11 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
     },
     onOpenFormplayer: async (
       data: FormInitData & {
-        options?: { subObservationMode?: boolean; returnOnly?: boolean };
+        options?: {
+          subObservationMode?: boolean;
+          skipFinalize?: boolean;
+          returnOnly?: boolean;
+        };
         /** @deprecated Legacy key; prefer subObservationMode */
         returnOnly?: boolean;
       },
@@ -1317,12 +1336,16 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
         data.options?.returnOnly ||
         data.returnOnly,
       );
+      const skipFinalize = Boolean(
+        data.options?.skipFinalize || data.skipFinalize,
+      );
       return startFormplayerOperation(
         data.formType,
         data.params,
         data.savedData,
         data.observationId ?? null,
         subObservationMode,
+        skipFinalize,
       );
     },
     onFormplayerInitialized: (_data: {

--- a/formulus/src/webview/FormulusMessageHandlers.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.ts
@@ -1044,7 +1044,9 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
 
       const localRepo = databaseService.getLocalRepo();
       if (!localRepo) {
-        throw new Error('persistObservation: database repository not available');
+        throw new Error(
+          'persistObservation: database repository not available',
+        );
       }
 
       // Reuse the exact Formplayer submit persistence path (attachment promotion
@@ -1076,7 +1078,8 @@ export function createFormulusMessageHandlers(): FormulusMessageHandlers {
     onGetConnectivityStatus: async (): Promise<ConnectivityStatus> => {
       const checkedAt = Date.now();
       try {
-        const serverUrl = await ServerConfigService.getInstance().getServerUrl();
+        const serverUrl =
+          await ServerConfigService.getInstance().getServerUrl();
         if (!serverUrl) {
           return { online: false, serverUrl: null, checkedAt: Date.now() };
         }

--- a/formulus/src/webview/FormulusMessageHandlers.types.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.types.ts
@@ -3,9 +3,13 @@
 import { Observation } from '../database/models/Observation';
 import {
   AttachmentDisplayDescriptor,
+  ConnectivityStatus,
   FormInitData,
   FormCompletionResult,
   FormInfo,
+  PersistObservationInput,
+  PersistObservationResult,
+  SyncResult,
 } from './FormulusInterfaceDefinition';
 
 export interface FormulusMessageHandlers {
@@ -76,6 +80,17 @@ export interface FormulusMessageHandlers {
   onGetAttachmentsUri?: () => Promise<string>;
   onGetCustomAppUri?: () => Promise<string>;
   onGetFormSpecsUri?: () => Promise<string>;
+  // Payload is the WebView message minus {type, messageId}; for single-object
+  // methods the argument is nested under its parameter name (e.g. `input`,
+  // `options`), so handlers accept either the wrapped or unwrapped shape.
+  onPersistObservation?: (
+    data: { input?: PersistObservationInput } & Partial<PersistObservationInput>,
+  ) => Promise<PersistObservationResult>;
+  onSync?: (data: {
+    options?: { includeAttachments?: boolean };
+    includeAttachments?: boolean;
+  }) => Promise<SyncResult>;
+  onGetConnectivityStatus?: () => Promise<ConnectivityStatus>;
   // Called when the Formplayer WebView signals that it has completed initialization
   // via a `formplayerInitialized` message. Primarily used for logging/diagnostics.
   onFormplayerInitialized?: (data: {

--- a/formulus/src/webview/FormulusMessageHandlers.types.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.types.ts
@@ -84,7 +84,9 @@ export interface FormulusMessageHandlers {
   // methods the argument is nested under its parameter name (e.g. `input`,
   // `options`), so handlers accept either the wrapped or unwrapped shape.
   onPersistObservation?: (
-    data: { input?: PersistObservationInput } & Partial<PersistObservationInput>,
+    data: {
+      input?: PersistObservationInput;
+    } & Partial<PersistObservationInput>,
   ) => Promise<PersistObservationResult>;
   onSync?: (data: {
     options?: { includeAttachments?: boolean };

--- a/formulus/src/webview/FormulusMessageHandlers.types.ts
+++ b/formulus/src/webview/FormulusMessageHandlers.types.ts
@@ -91,6 +91,7 @@ export interface FormulusMessageHandlers {
     includeAttachments?: boolean;
   }) => Promise<SyncResult>;
   onGetConnectivityStatus?: () => Promise<ConnectivityStatus>;
+  onGetCurrentDataRevisionCount?: () => Promise<number>;
   // Called when the Formplayer WebView signals that it has completed initialization
   // via a `formplayerInitialized` message. Primarily used for logging/diagnostics.
   onFormplayerInitialized?: (data: {

--- a/packages/components/src/react-native/Button.tsx
+++ b/packages/components/src/react-native/Button.tsx
@@ -96,13 +96,13 @@ const Button: React.FC<NativeButtonProps> = ({
   const pressedBorderColor = actualVariant === 'danger' ? dangerDefaultBorder : 'transparent';
 
   const textColor =
-    actualVariant === 'danger'
-      ? dangerDefaultText
-      : isActiveOrPressed
-        ? textOnFill
-        : borderColor;
+    actualVariant === 'danger' ? dangerDefaultText : isActiveOrPressed ? textOnFill : borderColor;
   const activeBorderColor =
-    actualVariant === 'danger' ? dangerDefaultBorder : isActiveOrPressed ? pressedBorderColor : borderColor;
+    actualVariant === 'danger'
+      ? dangerDefaultBorder
+      : isActiveOrPressed
+        ? pressedBorderColor
+        : borderColor;
   const backgroundColor =
     actualVariant === 'danger'
       ? isPressed

--- a/packages/components/src/react-web/Button.tsx
+++ b/packages/components/src/react-web/Button.tsx
@@ -65,7 +65,7 @@ const Button: React.FC<WebButtonProps> = ({
   // Listen for dark mode changes (both system preference and MUI theme)
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    
+
     // Check for MUI theme changes via MutationObserver
     const observer = new MutationObserver(() => {
       const muiThemeMode = document.documentElement.getAttribute('data-mui-color-scheme');
@@ -93,7 +93,7 @@ const Button: React.FC<WebButtonProps> = ({
         mediaQuery.removeEventListener('change', handleChange);
       };
     }
-    
+
     return () => observer.disconnect();
   }, []);
 
@@ -157,16 +157,12 @@ const Button: React.FC<WebButtonProps> = ({
   const hoverBg = actualVariant === 'danger' ? 'transparent' : borderColor;
   const activeBorderColor =
     actualVariant === 'danger'
-      ? dangerDefaultBorder 
+      ? dangerDefaultBorder
       : isActiveOrHovered
         ? 'transparent'
         : borderColor;
   const activeTextColor =
-    actualVariant === 'danger'
-      ? dangerDefaultText 
-      : isActiveOrHovered
-        ? textOnFill
-        : borderColor;
+    actualVariant === 'danger' ? dangerDefaultText : isActiveOrHovered ? textOnFill : borderColor;
   const activeBg =
     actualVariant === 'danger'
       ? isHovered

--- a/packages/components/src/react-web/index.ts
+++ b/packages/components/src/react-web/index.ts
@@ -11,6 +11,13 @@ export { default as Card } from './Card';
 export { default as Badge } from './Badge';
 
 // Export types for TypeScript inference
-export type { ButtonProps, ButtonVariant, ButtonSize, InputProps, CardProps, BadgeProps } from '../shared/types';
+export type {
+  ButtonProps,
+  ButtonVariant,
+  ButtonSize,
+  InputProps,
+  CardProps,
+  BadgeProps,
+} from '../shared/types';
 export type { WebButtonProps } from './Button';
 export type { ButtonGroupProps } from './ButtonGroup';


### PR DESCRIPTION
## Description

### Feature pack for v.1.1.0
Formplayer and Formulus bridge improvements for field data collection on tablets — a coordinated UX pack tested in production workflows.

**Formplayer / layout**
- SwipeLayout defaults to compact **inline** two-column rows (`labelLayout: "inline"`); per-control `"stacked"` override
- Optional `headerFields`, `showInnerTitle`, and slimmer Formulus modal chrome
- **Deferred validation** on new observations (errors shown after first forward navigation)

**Choice controls**
- Plain `oneOf` / `$ref` fields default to **native `<select>`** (keyboard-free, WebView-safe)
- Opt-in `display` (radio / buttons / checkboxes), `orientation`, `buttonGroup`, `autocomplete`, `placeholder`
- Tap-to-clear on single-select radio/button modes

**Author ergonomics**
- **`options.sticky`** — remember last submitted scalar per field (new observations only)
- Schema default tokens **`$today`** / **`$now`** for new observations
- **`params.context`** exposed read-only as `window.formulusSessionContext`
- Multi-select relevance via `contains.const`; root SwipeLayout and custom formats honor `visible` rules

**Sub-observations**
- **`skipFinalize`** — nested child forms skip Finalize and auto-submit from the last content page

**Bridge API (v1.4.0)**
- `getCurrentDataRevisionCount()` — last-known Synkronus data revision after sync
- `persistObservation()`, `getConnectivityStatus()`, typed `sync()` result
- `openFormplayer(..., { skipFinalize })`

Includes unit tests for choice testers, form observation init, and sub-observation helpers.

## Type of Change

- [ ] Bug Fix
- [x] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [x] **formulus** (React Native mobile app)
- [x] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [x] **Documentation** (follow-up in ode-docs)
- [ ] **DevOps / CI/CD**
- [x] **Other:** `@ode/components` Button exports

---

## Related Issue(s)

**Closes/Fixes/Resolves:** <!-- link issues if filed -->

---

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
- [x] Tested on multiple platforms (if applicable)
- [ ] Not applicable

---

## Breaking Changes

- [x] This PR introduces breaking changes
- [ ] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:**

SwipeLayout forms now default to `labelLayout: "inline"`. Forms that need the previous stacked appearance should set `"options": { "labelLayout": "stacked" }` on the root SwipeLayout (or per control).

---

## Documentation Updates

- [x] Documentation has been updated
- [ ] Documentation update is not required

---

## Checklist

- [x] Code follows project style guidelines
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**