### PR TITLE
fix(formplayer): honor SHOW/HIDE visible prop on choice and media ren…

### DIFF
--- a/formulus-formplayer/src/jsonforms/visibleGuard.test.tsx
+++ b/formulus-formplayer/src/jsonforms/visibleGuard.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { isControlHidden, withVisibleGuard } from './visibleGuard';
+
+describe('visibleGuard', () => {
+  it('isControlHidden is true only when visible is false', () => {
+    expect(isControlHidden(false)).toBe(true);
+    expect(isControlHidden(undefined)).toBe(false);
+    expect(isControlHidden(true)).toBe(false);
+  });
+
+  it('withVisibleGuard hides wrapped component when visible is false', () => {
+    const Inner = ({ label }: { label: string; visible?: boolean }) => (
+      <span>{label}</span>
+    );
+    const Guarded = withVisibleGuard(Inner);
+    const { rerender } = render(<Guarded label="shown" visible={true} />);
+    expect(screen.getByText('shown')).toBeTruthy();
+    rerender(<Guarded label="shown" visible={false} />);
+    expect(screen.queryByText('shown')).toBeNull();
+  });
+});

--- a/formulus-formplayer/src/jsonforms/visibleGuard.tsx
+++ b/formulus-formplayer/src/jsonforms/visibleGuard.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+/** JsonForms passes `visible: false` when SHOW/HIDE rules hide a control. */
+export function isControlHidden(visible?: boolean): boolean {
+  return visible === false;
+}
+
+/**
+ * HOC: return null when JsonForms marks the control hidden (SHOW/HIDE rules).
+ */
+export function withVisibleGuard<P extends { visible?: boolean }>(
+  Component: React.ComponentType<P>,
+): React.FC<P> {
+  const Guarded = (props: P) => {
+    if (isControlHidden(props.visible)) return null;
+    return <Component {...props} />;
+  };
+  Guarded.displayName = `WithVisibleGuard(${
+    Component.displayName || Component.name || 'Component'
+  })`;
+  return Guarded;
+}

--- a/formulus-formplayer/src/renderers/AudioQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/AudioQuestionRenderer.tsx
@@ -106,6 +106,7 @@ const AudioQuestionRenderer: React.FC<ControlProps> = ({
   uischema,
   errors,
   enabled = true,
+  visible = true,
 }) => {
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
@@ -374,6 +375,8 @@ const AudioQuestionRenderer: React.FC<ControlProps> = ({
     !!displayBasename &&
     !!currentAudioData &&
     typeof meta?.duration === 'number';
+
+  if (visible === false) return null;
 
   return (
     <QuestionShell

--- a/formulus-formplayer/src/renderers/GPSQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/GPSQuestionRenderer.tsx
@@ -62,7 +62,15 @@ function parseLocationDisplayData(data: unknown): LocationDisplayData | null {
 }
 
 const GPSQuestionRenderer: React.FC<GPSQuestionRendererProps> = props => {
-  const { data, handleChange, path, errors, schema, enabled } = props;
+  const {
+    data,
+    handleChange,
+    path,
+    errors,
+    schema,
+    enabled,
+    visible = true,
+  } = props;
 
   const [isCapturing, setIsCapturing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -146,6 +154,8 @@ const GPSQuestionRenderer: React.FC<GPSQuestionRendererProps> = props => {
 
   const hasValidationErrors = errors && errors.length > 0;
   const isDisabled = !enabled || isCapturing;
+
+  if (visible === false) return null;
 
   return (
     <QuestionShell

--- a/formulus-formplayer/src/renderers/PhotoQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/PhotoQuestionRenderer.tsx
@@ -75,6 +75,7 @@ const PhotoQuestionRenderer: React.FC<PhotoQuestionProps> = ({
   schema,
   uischema,
   enabled = true,
+  visible = true,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
@@ -238,6 +239,8 @@ const PhotoQuestionRenderer: React.FC<PhotoQuestionProps> = ({
   const displayBasename = attachmentBasenameFromObservation(
     currentPhotoData as Record<string, unknown> | null,
   );
+
+  if (visible === false) return null;
 
   return (
     <QuestionShell

--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -441,15 +441,8 @@ const SwipeLayoutRenderer = ({
     const errorCount = core?.errors?.length ?? 0;
     if (isOnFinalizePage) {
       return {
-        onTrigger: () => {
-          if (errorCount > 0 || !formInitData) return;
-          window.dispatchEvent(
-            new CustomEvent('finalizeForm', {
-              detail: { formInitData, data },
-            }),
-          );
-        },
-        disabled: errorCount > 0 || !formInitData,
+        onTrigger: trySubmitForm,
+        disabled: errorCount > 0 || !formInitData || isNavigating,
       };
     }
     if (skipFinalize && isLastContentPage) {

--- a/formulus-formplayer/src/renderers/VideoQuestionRenderer.tsx
+++ b/formulus-formplayer/src/renderers/VideoQuestionRenderer.tsx
@@ -108,6 +108,7 @@ const VideoQuestionRenderer: React.FC<ControlProps> = ({
   schema,
   uischema,
   enabled = true,
+  visible = true,
 }) => {
   const [error, setError] = useState<string | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -329,6 +330,8 @@ const VideoQuestionRenderer: React.FC<ControlProps> = ({
     !!displayBasename &&
     !!currentVideoData &&
     typeof meta?.duration === 'number';
+
+  if (visible === false) return null;
 
   return (
     <QuestionShell

--- a/formulus-formplayer/src/theme/choiceControl.render.test.tsx
+++ b/formulus-formplayer/src/theme/choiceControl.render.test.tsx
@@ -68,6 +68,24 @@ describe('ChoiceControl (single-select)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'r' }));
     expect(handleChange).toHaveBeenCalledWith('color', undefined);
   });
+
+  it('returns null when visible is false (SHOW/HIDE rules)', () => {
+    renderWithTheme(
+      <ChoiceControl
+        {...({
+          data: undefined,
+          path: 'color',
+          handleChange: vi.fn(),
+          schema: enumSchema,
+          uischema: { type: 'Control', options: { display: 'buttons' } },
+          enabled: true,
+          visible: false,
+        } as unknown as ControlProps)}
+      />,
+    );
+    expect(screen.queryByText('r')).toBeNull();
+    expect(screen.queryByText('g')).toBeNull();
+  });
 });
 
 describe('MultiChoiceControl (multi-select)', () => {
@@ -121,5 +139,22 @@ describe('MultiChoiceControl (multi-select)', () => {
     renderWithTheme(<MultiChoiceControl {...(props as any)} />);
     fireEvent.click(screen.getByText('X'));
     expect(removeItem).toHaveBeenCalledWith('tags', 'x');
+  });
+
+  it('returns null when visible is false (SHOW/HIDE rules)', () => {
+    const props = {
+      data: [] as string[],
+      options,
+      addItem: vi.fn(),
+      removeItem: vi.fn(),
+      path: 'tags',
+      schema: arraySchema,
+      uischema: { type: 'Control', options: { display: 'checkboxes' } },
+      enabled: true,
+      visible: false,
+    };
+    renderWithTheme(<MultiChoiceControl {...(props as any)} />);
+    expect(screen.queryByText('X')).toBeNull();
+    expect(screen.queryByText('Y')).toBeNull();
   });
 });

--- a/formulus-formplayer/src/theme/material-wrappers.tsx
+++ b/formulus-formplayer/src/theme/material-wrappers.tsx
@@ -37,6 +37,7 @@ import {
   ToggleButtonGroup,
 } from '@mui/material';
 import QuestionShell from '../components/QuestionShell';
+import { isControlHidden } from '../jsonforms/visibleGuard';
 import { tokens } from './tokens-adapter';
 
 const parsePx = (value: string): number =>
@@ -56,7 +57,10 @@ const CardEnumControl = (props: AnyControlProps) => {
     uischema,
     errors,
     enabled = true,
+    visible,
   } = props;
+
+  if (isControlHidden(visible)) return null;
   const label = (uischema as any)?.label || schema.title;
   const description = schema.description;
   const required = Boolean(
@@ -194,7 +198,10 @@ const SelectOneOfEnumControl = (props: ControlProps & OwnPropsOfEnum) => {
     errors,
     enabled = true,
     options = [],
+    visible,
   } = props;
+
+  if (isControlHidden(visible)) return null;
   const label = (uischema as any)?.label || schema.title;
   const description = schema.description;
   const required = Boolean(
@@ -415,7 +422,10 @@ export const ChoiceControl = (props: AnyControlProps) => {
     uischema,
     errors,
     enabled = true,
+    visible,
   } = props;
+
+  if (isControlHidden(visible)) return null;
   const label = (uischema as any)?.label || schema.title;
   const description = schema.description;
   const required = Boolean(
@@ -503,7 +513,10 @@ export const MultiChoiceControl = (
     uischema,
     errors,
     enabled = true,
+    visible,
   } = props;
+
+  if (isControlHidden(visible)) return null;
   const label = (uischema as any)?.label || schema.title;
   const description = schema.description;
   const required = Boolean((uischema as any)?.options?.required);


### PR DESCRIPTION
Some controls didn't respect the visible=false flag (and hence the relevance-logic looked like it wasn't working) - this PR fixes that issue by wrapping our controls in a "withVisibleGuard" that handles visiblity.