### PR TITLE
fix(formulus): Disable edge-to-edge appearance on newer android devices

### DIFF
--- a/formulus-formplayer/index.html
+++ b/formulus-formplayer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-visual" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Formulus Form Player" />
     <link rel="apple-touch-icon" href="/logo192.png" />

--- a/formulus-formplayer/src/App.tsx
+++ b/formulus-formplayer/src/App.tsx
@@ -1174,7 +1174,7 @@ function App() {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          height: '100dvh',
+          height: '100%',
         }}>
         <CircularProgress />
         <Typography variant="h6" sx={{ mt: 2 }}>
@@ -1198,7 +1198,7 @@ function App() {
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
-            height: '100dvh',
+            height: '100%',
             p: 3,
             backgroundColor: 'background.paper',
           }}>
@@ -1230,7 +1230,7 @@ function App() {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          height: '100dvh',
+          height: '100%',
         }}>
         <CircularProgress />
         <Typography variant="h6" sx={{ mt: 2 }}>
@@ -1256,7 +1256,7 @@ function App() {
           className="App"
           style={{
             display: 'flex',
-            height: '100dvh', // Use dynamic viewport height for mobile keyboard support
+            height: '100%', // Fill WebView; host resizes for keyboard (adjustResize)
             width: '100%',
             backgroundColor: currentTheme.palette.background.default, // Ensure dark background
             color: currentTheme.palette.text.primary,

--- a/formulus-formplayer/src/components/DraftSelector.tsx
+++ b/formulus-formplayer/src/components/DraftSelector.tsx
@@ -177,7 +177,7 @@ export const DraftSelector: React.FC<DraftSelectorProps> = ({
   const content = (
     <Box
       sx={{
-        minHeight: fullScreen ? '100dvh' : 'auto',
+        minHeight: fullScreen ? '100%' : 'auto',
         display: 'flex',
         flexDirection: 'column',
         bgcolor: 'background.default',

--- a/formulus-formplayer/src/components/FormLayout.tsx
+++ b/formulus-formplayer/src/components/FormLayout.tsx
@@ -75,8 +75,8 @@ interface FormLayoutProps {
  * - Keeps prev/next in normal flex flow at the bottom of the WebView so when the
  *   host app resizes the WebView for the keyboard (e.g. Android adjustResize), the
  *   bar stays at the bottom of the visible area without visualViewport math.
- * - Ensures all form fields are scrollable and accessible
- * - Uses dynamic viewport height (100dvh) for proper mobile support
+ * - Web content fills the WebView with height: 100% (not dvh) so keyboard inset
+ *   is not double-counted when the host also shrinks the WebView.
  *
  * Layout Structure:
  * - Header area (sticky at top, optional)
@@ -236,7 +236,7 @@ const FormLayout: React.FC<FormLayoutProps> = ({
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        height: '100dvh',
+        height: '100%',
         width: '100%',
         overflow: 'hidden',
         position: 'relative',

--- a/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
+++ b/formulus-formplayer/src/renderers/SwipeLayoutRenderer.tsx
@@ -674,7 +674,7 @@ const SwipeLayoutRenderer = ({
                   left: 0,
                   right: 0,
                   bottom: 0,
-                  minHeight: '100dvh',
+                  minHeight: '100%',
                   height: '100%',
                   zIndex: 99,
                   display: 'flex',

--- a/formulus/android/app/src/main/java/org/opendataensemble/formulus/MainActivity.kt
+++ b/formulus/android/app/src/main/java/org/opendataensemble/formulus/MainActivity.kt
@@ -1,6 +1,7 @@
 package org.opendataensemble.formulus
 
 import android.os.Bundle
+import androidx.core.view.WindowCompat
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -17,6 +18,8 @@ class MainActivity : ReactActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     supportFragmentManager.fragmentFactory = RNScreensFragmentFactory()
     super.onCreate(savedInstanceState)
+    // Restore classic window fitting so adjustResize works on Android 15+ (targetSdk 35+).
+    WindowCompat.setDecorFitsSystemWindows(window, true)
   }
 
   /**

--- a/formulus/custom_app_development.md
+++ b/formulus/custom_app_development.md
@@ -212,11 +212,11 @@ Use `openFormplayer(formType, params, savedData, options?)`. Reserved `params` k
 
 Common **options** (4th argument):
 
-| Option | Purpose |
-|--------|---------|
+| Option               | Purpose                                                                      |
+| -------------------- | ---------------------------------------------------------------------------- |
 | `subObservationMode` | Embedded child form; result JSON returns to parent without top-level persist |
-| `skipFinalize` | Auto-submit from last page (typical with sub-observations) |
-| `skipDraftSelection` | Skip draft picker when the app orchestrates a new root session |
+| `skipFinalize`       | Auto-submit from last page (typical with sub-observations)                   |
+| `skipDraftSelection` | Skip draft picker when the app orchestrates a new root session               |
 
 ```javascript
 await formulus.openFormplayer(

--- a/formulus/src/components/FormplayerModal.tsx
+++ b/formulus/src/components/FormplayerModal.tsx
@@ -14,7 +14,6 @@ import {
   Text,
   Platform,
   ActivityIndicator,
-  KeyboardAvoidingView,
 } from 'react-native';
 import CustomAppWebView, {
   CustomAppWebViewHandle,
@@ -663,9 +662,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
         onRequestClose={handleClose}
         presentationStyle="fullScreen"
         statusBarTranslucent={false}>
-        <KeyboardAvoidingView
-          style={shellStyle}
-          behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        <View style={shellStyle}>
           <View
             style={[
               styles.container,
@@ -732,7 +729,7 @@ const FormplayerModal = forwardRef<FormplayerModalHandle, FormplayerModalProps>(
               </View>
             )}
           </View>
-        </KeyboardAvoidingView>
+        </View>
       </Modal>
     );
   },


### PR DESCRIPTION
# Fixes UX issue with on-screen keyboard

This PR fixes the "white panel above the on-screen keyboard" (keyboard-height dead space, not in the DOM) in Formplayer forms.

>Root cause: Native WebView resize (adjustResize) and Formplayer height: 100dvh both shrank for the keyboard, leaving a gap filled by the WebView background.

Changes:

- Formulus (MainActivity.kt): WindowCompat.setDecorFitsSystemWindows(window, true) so adjustResize works again on Android 15+ (targetSdk 36) and content stays inside system bars.
- Formulus (FormplayerModal.tsx): Removed KeyboardAvoidingView around the Formplayer WebView — WebView is the sole keyboard-aware surface.
- Formplayer: Replaced root 100dvh with 100% in App.tsx, FormLayout.tsx, DraftSelector.tsx, SwipeLayoutRenderer.tsx so web layout fills the host-resized WebView without double-counting keyboard inset.
- Formplayer (index.html): Added interactive-widget=resizes-visual to keep layout viewport stable when the IME opens.