### PR TITLE
fix(formplayer): prevent re-revealing of input fields

### DIFF
--- a/formulus-formplayer/src/hooks/useKeyboardScrollClamp.integration.test.tsx
+++ b/formulus-formplayer/src/hooks/useKeyboardScrollClamp.integration.test.tsx
@@ -1,11 +1,39 @@
 // @vitest-environment jsdom
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import FormLayout from '../components/FormLayout';
+import * as keyboardScroll from '../utils/keyboardScroll';
 
 afterEach(() => cleanup());
 
 describe('FormLayout keyboard scroll integration', () => {
+  it('does not re-reveal on input or layout resize while focused', async () => {
+    const revealSpy = vi.spyOn(keyboardScroll, 'revealFieldIfNeeded');
+
+    render(
+      <FormLayout showNavigation={false}>
+        <div style={{ height: 1200 }}>
+          <input data-testid="field" type="number" defaultValue="" />
+        </div>
+      </FormLayout>,
+    );
+
+    const scrollArea = screen.getByTestId('formplayer-scroll-area');
+    const input = screen.getByTestId('field');
+
+    fireEvent.focusIn(input, { bubbles: true });
+    await new Promise(resolve => setTimeout(resolve, 150));
+    revealSpy.mockClear();
+
+    fireEvent.input(input, { target: { value: '5' }, bubbles: true });
+    scrollArea.appendChild(document.createElement('div'));
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(revealSpy).not.toHaveBeenCalled();
+    revealSpy.mockRestore();
+  });
+
   it('clamps scrollTop after input without exceeding max scroll', async () => {
     const { container } = render(
       <FormLayout showNavigation={false}>

--- a/formulus-formplayer/src/hooks/useKeyboardScrollClamp.ts
+++ b/formulus-formplayer/src/hooks/useKeyboardScrollClamp.ts
@@ -130,20 +130,12 @@ export function useKeyboardScrollClamp<T extends HTMLElement>() {
       runClampChain();
     };
 
+    // Clamp only on content resize (e.g. value change re-render). Re-revealing here
+    // caused a scroll gap above the keyboard on first keystroke in number fields.
     const resizeObserver =
       typeof ResizeObserver !== 'undefined'
         ? new ResizeObserver(() => {
-            const active = document.activeElement;
-            if (
-              active &&
-              el.contains(active) &&
-              isFormFieldForScrollClamp(active)
-            ) {
-              focusedFieldRef.current = active;
-              tryRevealFocused();
-            } else {
-              runClampChain();
-            }
+            runClampChain();
           })
         : null;
 


### PR DESCRIPTION
# Pull Request Title

This PR aims to further improve the device on-screen keyboard vs. scroll-into-view + padding UX inconvenience that sometimes can still occur in certain scenarios (a number input field positioned at the end of a tall swipe layout on a narrow device).
