### PR TITLE
feat(desktop): improved bundle handling, stability

### DIFF
--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -41,7 +41,9 @@ Persisted per profile via `upsertProfileRemote` / Rust `ServerProfile`.
 | Off  | `bundles/active/app/`             | `bundles/active/forms/`                                        |
 | On   | `bundles/dev-local/app/` (mirror) | `bundles/dev-local/forms/` (mirror if `<folder>/forms` exists) |
 
-Synk downloads and **Refresh from server** on the Bundles page only touch `bundles/active/`. The source folder on disk is **never** modified.
+Synk downloads and **Download & apply** on the Bundles page only touch `bundles/active/`. The source folder on disk is **never** modified.
+
+**Bundle download:** `download_and_apply_app_bundle` (TS: `tauriClient.downloadAndApplyAppBundle()`) — native Rust HTTP download; no zip bytes over IPC. Progress events: `bundle/apply-progress`, `bundle/index-rebuild`. Observation index rebuild runs in the background after apply.
 
 ### UI
 
@@ -64,13 +66,15 @@ On success, Zustand bumps `devMirrorGeneration` so embeds and form lists reload.
 - `src/hooks/useDeveloperMode.ts` — profile read/write, refresh, generation counter from store.
 - `src/components/DeveloperModePanel.tsx` — full vs banner UI; auto-mirror `useEffect` only on `variant="full"`.
 - `src/lib/bundleLayout.ts` — `bundleSegment()`, `bundleFormsRel()`.
-- `src/store/useCustodianStore.ts` — `devMirrorGeneration`, `devBusy`, `devError`, `refreshDevMirror`.
+- `src/store/useCustodianStore.ts` — `devMirrorGeneration`, `devBusy`, `devError`, `refreshDevMirror`, `bundleActivity`.
+- `src/lib/bundleTauriEvents.ts` — bundle apply progress listeners.
 
 ### Key Rust
 
 - `profile_developer_mode`, `bundle_segment`, `bundle_form_roots_for_ctx`
 - Dev-aware: `list_active_bundle_forms`, `read_bundle_form_spec`, `get_active_bundle_forms_file_base_url`, `scan_bundle_custom_question_types`, `bundle_app_config_path`
-- Tests: `validate_custom_app_dev_source_requires_index_html`, `mirror_custom_app_dev_folder_copies_tree`
+- `download_and_apply_app_bundle` — streamed Synkronus zip download + apply (never pass large binaries through WebView IPC as `number[]`)
+- Tests: `validate_custom_app_dev_source_requires_index_html`, `mirror_custom_app_dev_folder_copies_tree`, `apply_app_bundle_zip_at_workspace_writes_state_and_active`
 
 ### Errors
 

--- a/desktop/docs/UI_FEEDBACK.md
+++ b/desktop/docs/UI_FEEDBACK.md
@@ -4,11 +4,13 @@ Single source of truth for how the shell surfaces status, errors, and confirmati
 
 ## Progress banner (full-width)
 
-**Use for:** long-running sync and import jobs only.
+**Use for:** long-running sync, import, and **app bundle download/apply** jobs.
 
 - Renders below the mode switch / dev bar in `Shell`.
-- Shows spinner + status text; dismissible but reappears on next activity.
-- Do not use for quick actions (save, auth, bundle download).
+- Shows spinner + status text; optional determinate progress bar when `bundleActivity.total > 0`.
+- Dismissible but reappears on next activity.
+- Bundle apply: Rust emits `bundle/apply-progress` and `bundle/index-rebuild`; `bundleActivity` in `useCustodianStore` drives the banner.
+- Do not use for quick actions (save, auth, dev mirror refresh).
 
 ## Toasts (bottom-right stack)
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2603,6 +2603,7 @@ name = "odedesktop"
 version = "1.1.1"
 dependencies = [
  "chrono",
+ "futures-util",
  "keyring",
  "rayon",
  "reqwest 0.12.28",
@@ -3456,12 +3457,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -3496,7 +3499,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -5297,6 +5300,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -25,7 +25,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 rusqlite = { version = "0.32", features = ["bundled", "chrono", "serde_json"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "multipart"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "multipart", "stream"] }
+futures-util = "0.3"
 rayon = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 thiserror = "2"

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1362,8 +1362,7 @@ fn apply_app_bundle_zip_at_workspace(
     }
     fs::write(
         &state_path,
-        serde_json::to_string_pretty(&state)
-            .map_err(|e| CustodianError::Message(e.to_string()))?,
+        serde_json::to_string_pretty(&state).map_err(|e| CustodianError::Message(e.to_string()))?,
     )?;
     let legacy = bundles.join("app-bundle.zip");
     if legacy.exists() {
@@ -1386,15 +1385,7 @@ fn apply_app_bundle_zip_bytes(
     let state = with_workspace_fs_exclusive(ctx, |ctx| {
         let ws = get_workspace_path(ctx)?;
         emit_bundle_apply_progress(&app_c, &job, "archiving", 1, 1, "Saving archive…", None);
-        emit_bundle_apply_progress(
-            &app_c,
-            &job,
-            "extracting",
-            0,
-            0,
-            "Extracting bundle…",
-            None,
-        );
+        emit_bundle_apply_progress(&app_c, &job, "extracting", 0, 0, "Extracting bundle…", None);
         let mut extract_cb = |done: i64, total: i64, detail: Option<&str>| {
             emit_bundle_apply_progress(
                 &app_c,
@@ -1406,13 +1397,7 @@ fn apply_app_bundle_zip_bytes(
                 detail,
             );
         };
-        apply_app_bundle_zip_at_workspace(
-            &ws,
-            version,
-            hash,
-            zip_bytes,
-            Some(&mut extract_cb),
-        )
+        apply_app_bundle_zip_at_workspace(&ws, version, hash, zip_bytes, Some(&mut extract_cb))
     })?;
     Ok(state)
 }
@@ -1428,7 +1413,8 @@ async fn download_synkronus_app_bundle_zip(
         "{}/api/app-bundle/download-zip",
         base_url.trim().trim_end_matches('/')
     );
-    let parsed = Url::parse(&url).map_err(|e| CustodianError::Message(format!("invalid URL: {e}")))?;
+    let parsed =
+        Url::parse(&url).map_err(|e| CustodianError::Message(format!("invalid URL: {e}")))?;
     let client = reqwest::Client::new();
     let res = client
         .get(parsed)
@@ -1484,7 +1470,10 @@ async fn download_synkronus_app_bundle_zip(
         received,
         total_bytes.max(received),
         "Downloading bundle from server…",
-        Some(&format_byte_progress_mb(received, total_bytes.max(received))),
+        Some(&format_byte_progress_mb(
+            received,
+            total_bytes.max(received),
+        )),
     );
     if buf.is_empty() {
         return Err(CustodianError::Message("zip is empty".to_string()));
@@ -2554,9 +2543,8 @@ async fn rebuild_observation_indexes(
     tauri::async_runtime::spawn_blocking(move || {
         let defs = load_active_index_defs(&ctx);
         let conn = open_db(&ctx).map_err(|err| err.to_string())?;
-        let generation =
-            observation_index::rebuild_all_indexes(&conn, &defs, None)
-                .map_err(|err| err.to_string())?;
+        let generation = observation_index::rebuild_all_indexes(&conn, &defs, None)
+            .map_err(|err| err.to_string())?;
         let last_rebuild_at: Option<String> = conn
             .query_row(
                 "SELECT last_rebuild_at FROM observation_index_meta WHERE id = 1",
@@ -3822,30 +3810,23 @@ async fn download_and_apply_app_bundle(
         None,
     );
 
-    let zip_bytes = match download_synkronus_app_bundle_zip(
-        &app,
-        &job_id,
-        base,
-        token,
-        ode_ver,
-    )
-    .await
-    {
-        Ok(b) => b,
-        Err(e) => {
-            let msg = e.to_string();
-            emit_bundle_apply_progress(
-                &app,
-                &job_id,
-                "failed",
-                0,
-                0,
-                "Bundle download failed.",
-                Some(&msg),
-            );
-            return Err(msg);
-        }
-    };
+    let zip_bytes =
+        match download_synkronus_app_bundle_zip(&app, &job_id, base, token, ode_ver).await {
+            Ok(b) => b,
+            Err(e) => {
+                let msg = e.to_string();
+                emit_bundle_apply_progress(
+                    &app,
+                    &job_id,
+                    "failed",
+                    0,
+                    0,
+                    "Bundle download failed.",
+                    Some(&msg),
+                );
+                return Err(msg);
+            }
+        };
 
     let ctx_inner = ctx.inner().clone();
     let state = match apply_app_bundle_zip_bytes(&app, &job_id, &ctx_inner, ver, hash, &zip_bytes) {
@@ -3865,15 +3846,7 @@ async fn download_and_apply_app_bundle(
         }
     };
 
-    emit_bundle_apply_progress(
-        &app,
-        &job_id,
-        "completed",
-        1,
-        1,
-        "Bundle applied.",
-        None,
-    );
+    emit_bundle_apply_progress(&app, &job_id, "completed", 1, 1, "Bundle applied.", None);
 
     let needs_index = bundle_app_config_path(&ctx_inner)
         .ok()
@@ -4542,9 +4515,9 @@ mod tests {
     use std::path::Path;
 
     use super::{
-        apply_app_bundle_zip_at_workspace, bind_query_params, mirror_custom_app_dev_folder,
-        parse_time, resolve_attachment_path, should_mark_conflict,
-        validate_custom_app_dev_source_folder, CompressionMethod, SimpleFileOptions, ZipWriter,
+        CompressionMethod, SimpleFileOptions, ZipWriter, apply_app_bundle_zip_at_workspace,
+        bind_query_params, mirror_custom_app_dev_folder, parse_time, resolve_attachment_path,
+        should_mark_conflict, validate_custom_app_dev_source_folder,
     };
     use crate::observation_query::SqlParam;
     use rusqlite::Connection;
@@ -4667,10 +4640,8 @@ mod tests {
 
     fn minimal_bundle_zip_bytes() -> Vec<u8> {
         use std::io::Write;
-        let base = std::env::temp_dir().join(format!(
-            "ode_bundle_zip_fixture_{}",
-            std::process::id()
-        ));
+        let base =
+            std::env::temp_dir().join(format!("ode_bundle_zip_fixture_{}", std::process::id()));
         let zip_path = base.join("fixture.zip");
         let _ = fs::remove_dir_all(&base);
         fs::create_dir_all(&base).unwrap();
@@ -4690,10 +4661,8 @@ mod tests {
 
     #[test]
     fn apply_app_bundle_zip_at_workspace_writes_state_and_active() {
-        let base = std::env::temp_dir().join(format!(
-            "ode_bundle_apply_test_{}",
-            std::process::id()
-        ));
+        let base =
+            std::env::temp_dir().join(format!("ode_bundle_apply_test_{}", std::process::id()));
         let _ = fs::remove_dir_all(&base);
         fs::create_dir_all(&base).unwrap();
         let zip_bytes = minimal_bundle_zip_bytes();

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1258,6 +1258,8 @@ fn emit_bundle_index_rebuild_progress(
     );
 }
 
+type BundleExtractProgress<'a> = dyn FnMut(i64, i64, Option<&str>) + 'a;
+
 #[allow(dead_code)]
 fn extract_zip_to_dir(zip_bytes: &[u8], dest: &Path) -> Result<(), CustodianError> {
     extract_zip_to_dir_with_progress(zip_bytes, dest, None)
@@ -1266,7 +1268,7 @@ fn extract_zip_to_dir(zip_bytes: &[u8], dest: &Path) -> Result<(), CustodianErro
 fn extract_zip_to_dir_with_progress(
     zip_bytes: &[u8],
     dest: &Path,
-    mut on_progress: Option<&mut dyn FnMut(i64, i64, Option<&str>)>,
+    mut on_progress: Option<&mut BundleExtractProgress<'_>>,
 ) -> Result<(), CustodianError> {
     let reader = Cursor::new(zip_bytes);
     let mut archive = ZipArchive::new(reader)
@@ -1311,7 +1313,7 @@ fn apply_app_bundle_zip_at_workspace(
     version: &str,
     hash: &str,
     zip_bytes: &[u8],
-    on_extract_progress: Option<&mut dyn FnMut(i64, i64, Option<&str>)>,
+    on_extract_progress: Option<&mut BundleExtractProgress<'_>>,
 ) -> Result<AppBundleState, CustodianError> {
     let ver = version.trim();
     if ver.is_empty() {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -6,8 +6,10 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicUsize, Ordering},
     sync::{Arc, Mutex},
-    time::{Instant, UNIX_EPOCH},
+    time::{Duration, Instant, UNIX_EPOCH},
 };
+
+use futures_util::StreamExt;
 
 use chrono::{DateTime, Utc};
 use keyring::Entry;
@@ -65,6 +67,26 @@ pub struct AppBundleState {
     pub active_hash: String,
     pub downloaded_at: String,
     pub archived_versions: Vec<String>,
+}
+
+/// Emitted on `bundle/apply-progress` and `bundle/index-rebuild`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BundleApplyProgressEvent {
+    job_id: String,
+    phase: String,
+    done: i64,
+    total: i64,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DownloadAndApplyAppBundleResult {
+    state: AppBundleState,
+    index_rebuild_scheduled: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -1183,10 +1205,76 @@ fn sanitize_version_for_filename(version: &str) -> String {
     }
 }
 
+fn format_byte_progress_mb(done: i64, total: i64) -> String {
+    const MB: f64 = 1024.0 * 1024.0;
+    if total > 0 {
+        format!("{:.1} / {:.1} MB", done as f64 / MB, total as f64 / MB)
+    } else {
+        format!("{:.1} MB", done as f64 / MB)
+    }
+}
+
+fn emit_bundle_apply_progress(
+    app: &tauri::AppHandle,
+    job_id: &str,
+    phase: &str,
+    done: i64,
+    total: i64,
+    message: &str,
+    detail: Option<&str>,
+) {
+    let _ = app.emit(
+        "bundle/apply-progress",
+        BundleApplyProgressEvent {
+            job_id: job_id.to_string(),
+            phase: phase.to_string(),
+            done,
+            total,
+            message: message.to_string(),
+            detail: detail.map(|s| s.to_string()),
+        },
+    );
+}
+
+fn emit_bundle_index_rebuild_progress(
+    app: &tauri::AppHandle,
+    job_id: &str,
+    phase: &str,
+    done: i64,
+    total: i64,
+    message: &str,
+    detail: Option<&str>,
+) {
+    let _ = app.emit(
+        "bundle/index-rebuild",
+        BundleApplyProgressEvent {
+            job_id: job_id.to_string(),
+            phase: phase.to_string(),
+            done,
+            total,
+            message: message.to_string(),
+            detail: detail.map(|s| s.to_string()),
+        },
+    );
+}
+
+#[allow(dead_code)]
 fn extract_zip_to_dir(zip_bytes: &[u8], dest: &Path) -> Result<(), CustodianError> {
+    extract_zip_to_dir_with_progress(zip_bytes, dest, None)
+}
+
+fn extract_zip_to_dir_with_progress(
+    zip_bytes: &[u8],
+    dest: &Path,
+    mut on_progress: Option<&mut dyn FnMut(i64, i64, Option<&str>)>,
+) -> Result<(), CustodianError> {
     let reader = Cursor::new(zip_bytes);
     let mut archive = ZipArchive::new(reader)
         .map_err(|e| CustodianError::Message(format!("invalid zip: {}", e)))?;
+    let total = archive.len() as i64;
+    if let Some(ref mut cb) = on_progress {
+        cb(0, total, None);
+    }
     for i in 0..archive.len() {
         let mut file = archive
             .by_index(i)
@@ -1195,7 +1283,7 @@ fn extract_zip_to_dir(zip_bytes: &[u8], dest: &Path) -> Result<(), CustodianErro
             Some(p) => p.to_owned(),
             None => continue,
         };
-        let outpath = dest.join(rel);
+        let outpath = dest.join(&rel);
         if file.is_dir() || file.name().ends_with('/') {
             fs::create_dir_all(&outpath)?;
         } else {
@@ -1206,8 +1294,273 @@ fn extract_zip_to_dir(zip_bytes: &[u8], dest: &Path) -> Result<(), CustodianErro
             std::io::copy(&mut file, &mut outfile)
                 .map_err(|e| CustodianError::Message(e.to_string()))?;
         }
+        let done = (i + 1) as i64;
+        if let Some(ref mut cb) = on_progress {
+            let emit = done == total || done % 10 == 0;
+            if emit {
+                let detail = rel.to_string_lossy();
+                cb(done, total, Some(detail.as_ref()));
+            }
+        }
     }
     Ok(())
+}
+
+fn apply_app_bundle_zip_at_workspace(
+    ws: &Path,
+    version: &str,
+    hash: &str,
+    zip_bytes: &[u8],
+    on_extract_progress: Option<&mut dyn FnMut(i64, i64, Option<&str>)>,
+) -> Result<AppBundleState, CustodianError> {
+    let ver = version.trim();
+    if ver.is_empty() {
+        return Err(CustodianError::Message("version is required".to_string()));
+    }
+    let hash = hash.trim();
+    if hash.is_empty() {
+        return Err(CustodianError::Message("hash is required".to_string()));
+    }
+    if zip_bytes.is_empty() {
+        return Err(CustodianError::Message("zip is empty".to_string()));
+    }
+    let bundles = ws.join("bundles");
+    let archives_dir = bundles.join("archives");
+    let active_dir = bundles.join("active");
+    fs::create_dir_all(&archives_dir)?;
+    let prev = read_app_bundle_state_unlocked(&bundles)?;
+    let mut archived = prev
+        .as_ref()
+        .map(|s| s.archived_versions.clone())
+        .unwrap_or_default();
+    if !archived.iter().any(|v| v == ver) {
+        archived.push(ver.to_string());
+    }
+    archived.sort();
+    let sanit = sanitize_version_for_filename(ver);
+    let archive_zip = archives_dir.join(format!("{sanit}.zip"));
+    fs::write(&archive_zip, zip_bytes)?;
+    if active_dir.exists() {
+        fs::remove_dir_all(&active_dir)?;
+    }
+    fs::create_dir_all(&active_dir)?;
+    if let Some(cb) = on_extract_progress {
+        extract_zip_to_dir_with_progress(zip_bytes, &active_dir, Some(cb))?;
+    } else {
+        extract_zip_to_dir_with_progress(zip_bytes, &active_dir, None)?;
+    }
+    let state = AppBundleState {
+        schema_version: 1,
+        active_version: ver.to_string(),
+        active_hash: hash.to_string(),
+        downloaded_at: Utc::now().to_rfc3339(),
+        archived_versions: archived,
+    };
+    let state_path = bundles.join("state.json");
+    if let Some(parent) = state_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(
+        &state_path,
+        serde_json::to_string_pretty(&state)
+            .map_err(|e| CustodianError::Message(e.to_string()))?,
+    )?;
+    let legacy = bundles.join("app-bundle.zip");
+    if legacy.exists() {
+        let _ = fs::remove_file(&legacy);
+    }
+    Ok(state)
+}
+
+fn apply_app_bundle_zip_bytes(
+    app: &tauri::AppHandle,
+    job_id: &str,
+    ctx: &AppCtxHandle,
+    version: &str,
+    hash: &str,
+    zip_bytes: &[u8],
+) -> Result<AppBundleState, CustodianError> {
+    emit_bundle_apply_progress(app, job_id, "archiving", 0, 1, "Saving archive…", None);
+    let app_c = app.clone();
+    let job = job_id.to_string();
+    let state = with_workspace_fs_exclusive(ctx, |ctx| {
+        let ws = get_workspace_path(ctx)?;
+        emit_bundle_apply_progress(&app_c, &job, "archiving", 1, 1, "Saving archive…", None);
+        emit_bundle_apply_progress(
+            &app_c,
+            &job,
+            "extracting",
+            0,
+            0,
+            "Extracting bundle…",
+            None,
+        );
+        let mut extract_cb = |done: i64, total: i64, detail: Option<&str>| {
+            emit_bundle_apply_progress(
+                &app_c,
+                &job,
+                "extracting",
+                done,
+                total,
+                "Extracting bundle…",
+                detail,
+            );
+        };
+        apply_app_bundle_zip_at_workspace(
+            &ws,
+            version,
+            hash,
+            zip_bytes,
+            Some(&mut extract_cb),
+        )
+    })?;
+    Ok(state)
+}
+
+async fn download_synkronus_app_bundle_zip(
+    app: &tauri::AppHandle,
+    job_id: &str,
+    base_url: &str,
+    bearer_token: &str,
+    x_ode_version: &str,
+) -> Result<Vec<u8>, CustodianError> {
+    let url = format!(
+        "{}/api/app-bundle/download-zip",
+        base_url.trim().trim_end_matches('/')
+    );
+    let parsed = Url::parse(&url).map_err(|e| CustodianError::Message(format!("invalid URL: {e}")))?;
+    let client = reqwest::Client::new();
+    let res = client
+        .get(parsed)
+        .header(AUTHORIZATION, format!("Bearer {}", bearer_token.trim()))
+        .header("x-ode-version", x_ode_version.trim())
+        .send()
+        .await?;
+    if !res.status().is_success() {
+        return Err(CustodianError::Message(format!(
+            "bundle download failed: HTTP {}",
+            res.status()
+        )));
+    }
+    let total_bytes = res.content_length().map(|n| n as i64).unwrap_or(0);
+    emit_bundle_apply_progress(
+        app,
+        job_id,
+        "downloading",
+        0,
+        total_bytes,
+        "Downloading bundle from server…",
+        None,
+    );
+    let mut buf = Vec::new();
+    let mut received: i64 = 0;
+    let mut last_emit = Instant::now();
+    let mut last_emit_bytes: i64 = 0;
+    let mut stream = res.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        received += chunk.len() as i64;
+        buf.extend_from_slice(&chunk);
+        let elapsed = last_emit.elapsed();
+        let bytes_since = received - last_emit_bytes;
+        if elapsed >= Duration::from_millis(250) || bytes_since >= 512 * 1024 {
+            emit_bundle_apply_progress(
+                app,
+                job_id,
+                "downloading",
+                received,
+                total_bytes,
+                "Downloading bundle from server…",
+                Some(&format_byte_progress_mb(received, total_bytes)),
+            );
+            last_emit = Instant::now();
+            last_emit_bytes = received;
+        }
+    }
+    emit_bundle_apply_progress(
+        app,
+        job_id,
+        "downloading",
+        received,
+        total_bytes.max(received),
+        "Downloading bundle from server…",
+        Some(&format_byte_progress_mb(received, total_bytes.max(received))),
+    );
+    if buf.is_empty() {
+        return Err(CustodianError::Message("zip is empty".to_string()));
+    }
+    Ok(buf)
+}
+
+fn spawn_bundle_index_rebuild(app: tauri::AppHandle, ctx: AppCtxHandle, job_id: String) {
+    tauri::async_runtime::spawn_blocking(move || {
+        let app_config = match bundle_app_config_path(&ctx) {
+            Ok(p) if p.exists() => p,
+            _ => return,
+        };
+        let defs = observation_index::load_index_config(&app_config);
+        if defs.is_empty() {
+            return;
+        }
+        emit_bundle_index_rebuild_progress(
+            &app,
+            &job_id,
+            "indexing",
+            0,
+            0,
+            "Rebuilding observation indexes…",
+            None,
+        );
+        let conn = match open_db(&ctx) {
+            Ok(c) => c,
+            Err(err) => {
+                emit_bundle_index_rebuild_progress(
+                    &app,
+                    &job_id,
+                    "failed",
+                    0,
+                    0,
+                    "Rebuilding observation indexes…",
+                    Some(&err.to_string()),
+                );
+                return;
+            }
+        };
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM observations", [], |r| r.get(0))
+            .unwrap_or(0);
+        let mut progress_cb = |done: i64, tot: i64| {
+            emit_bundle_index_rebuild_progress(
+                &app,
+                &job_id,
+                "indexing",
+                done,
+                tot,
+                "Rebuilding observation indexes…",
+                None,
+            );
+        };
+        match observation_index::rebuild_all_indexes(&conn, &defs, Some(&mut progress_cb)) {
+            Ok(_) => emit_bundle_index_rebuild_progress(
+                &app,
+                &job_id,
+                "completed",
+                total,
+                total.max(1),
+                "Observation indexes rebuilt.",
+                None,
+            ),
+            Err(err) => emit_bundle_index_rebuild_progress(
+                &app,
+                &job_id,
+                "failed",
+                0,
+                0,
+                "Rebuilding observation indexes…",
+                Some(&err.to_string()),
+            ),
+        }
+    });
 }
 
 fn read_app_bundle_state_unlocked(
@@ -2202,7 +2555,8 @@ async fn rebuild_observation_indexes(
         let defs = load_active_index_defs(&ctx);
         let conn = open_db(&ctx).map_err(|err| err.to_string())?;
         let generation =
-            observation_index::rebuild_all_indexes(&conn, &defs).map_err(|err| err.to_string())?;
+            observation_index::rebuild_all_indexes(&conn, &defs, None)
+                .map_err(|err| err.to_string())?;
         let last_rebuild_at: Option<String> = conn
             .query_row(
                 "SELECT last_rebuild_at FROM observation_index_meta WHERE id = 1",
@@ -3424,15 +3778,30 @@ fn get_app_bundle_state(
     read_app_bundle_state_unlocked(&bundles).map_err(|e| e.to_string())
 }
 
-/// Writes `bundles/archives/{version}.zip`, replaces `bundles/active/` with extracted contents,
-/// and updates `bundles/state.json`. Removes legacy `bundles/app-bundle.zip` if present.
+/// Downloads the active app bundle from Synkronus and applies it under `bundles/active/`.
+/// Progress: `bundle/apply-progress` (download/archive/extract) and `bundle/index-rebuild` (background).
 #[tauri::command]
-fn apply_app_bundle_download(
+async fn download_and_apply_app_bundle(
+    app: tauri::AppHandle,
+    base_url: String,
+    bearer_token: String,
+    x_ode_version: String,
     version: String,
     hash: String,
-    zip_bytes: Vec<u8>,
     ctx: tauri::State<'_, AppCtxHandle>,
-) -> Result<AppBundleState, String> {
+) -> Result<DownloadAndApplyAppBundleResult, String> {
+    let base = base_url.trim();
+    if base.is_empty() {
+        return Err("base_url is required".to_string());
+    }
+    let token = bearer_token.trim();
+    if token.is_empty() {
+        return Err("bearer token is required".to_string());
+    }
+    let ode_ver = x_ode_version.trim();
+    if ode_ver.is_empty() {
+        return Err("x_ode_version is required".to_string());
+    }
     let ver = version.trim();
     if ver.is_empty() {
         return Err("version is required".to_string());
@@ -3441,61 +3810,83 @@ fn apply_app_bundle_download(
     if hash.is_empty() {
         return Err("hash is required".to_string());
     }
-    if zip_bytes.is_empty() {
-        return Err("zip is empty".to_string());
+
+    let job_id = Uuid::new_v4().to_string();
+    emit_bundle_apply_progress(
+        &app,
+        &job_id,
+        "downloading",
+        0,
+        0,
+        "Downloading bundle from server…",
+        None,
+    );
+
+    let zip_bytes = match download_synkronus_app_bundle_zip(
+        &app,
+        &job_id,
+        base,
+        token,
+        ode_ver,
+    )
+    .await
+    {
+        Ok(b) => b,
+        Err(e) => {
+            let msg = e.to_string();
+            emit_bundle_apply_progress(
+                &app,
+                &job_id,
+                "failed",
+                0,
+                0,
+                "Bundle download failed.",
+                Some(&msg),
+            );
+            return Err(msg);
+        }
+    };
+
+    let ctx_inner = ctx.inner().clone();
+    let state = match apply_app_bundle_zip_bytes(&app, &job_id, &ctx_inner, ver, hash, &zip_bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            let msg = e.to_string();
+            emit_bundle_apply_progress(
+                &app,
+                &job_id,
+                "failed",
+                0,
+                0,
+                "Applying bundle failed.",
+                Some(&msg),
+            );
+            return Err(msg);
+        }
+    };
+
+    emit_bundle_apply_progress(
+        &app,
+        &job_id,
+        "completed",
+        1,
+        1,
+        "Bundle applied.",
+        None,
+    );
+
+    let needs_index = bundle_app_config_path(&ctx_inner)
+        .ok()
+        .filter(|p| p.exists())
+        .is_some();
+    if needs_index {
+        spawn_bundle_index_rebuild(app.clone(), ctx_inner.clone(), job_id);
     }
-    with_workspace_fs_exclusive(&ctx, |ctx| {
-        let ws = get_workspace_path(ctx)?;
-        let bundles = ws.join("bundles");
-        let archives_dir = bundles.join("archives");
-        let active_dir = bundles.join("active");
-        fs::create_dir_all(&archives_dir)?;
-        let prev = read_app_bundle_state_unlocked(&bundles)?;
-        let mut archived = prev
-            .as_ref()
-            .map(|s| s.archived_versions.clone())
-            .unwrap_or_default();
-        if !archived.iter().any(|v| v == ver) {
-            archived.push(ver.to_string());
-        }
-        archived.sort();
-        let sanit = sanitize_version_for_filename(ver);
-        let archive_zip = archives_dir.join(format!("{sanit}.zip"));
-        fs::write(&archive_zip, &zip_bytes)?;
-        if active_dir.exists() {
-            fs::remove_dir_all(&active_dir)?;
-        }
-        fs::create_dir_all(&active_dir)?;
-        extract_zip_to_dir(&zip_bytes, &active_dir)?;
-        let state = AppBundleState {
-            schema_version: 1,
-            active_version: ver.to_string(),
-            active_hash: hash.to_string(),
-            downloaded_at: Utc::now().to_rfc3339(),
-            archived_versions: archived,
-        };
-        let state_path = bundles.join("state.json");
-        if let Some(parent) = state_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(
-            &state_path,
-            serde_json::to_string_pretty(&state)
-                .map_err(|e| CustodianError::Message(e.to_string()))?,
-        )?;
-        let legacy = bundles.join("app-bundle.zip");
-        if legacy.exists() {
-            let _ = fs::remove_file(&legacy);
-        }
-        let app_config = active_dir.join("app/app.config.json");
-        if app_config.exists() {
-            let defs = observation_index::load_index_config(&app_config);
-            let conn = open_db(ctx)?;
-            let _ = observation_index::rebuild_all_indexes(&conn, &defs);
-        }
-        Ok(state)
+
+    Ok(DownloadAndApplyAppBundleResult {
+        state,
+        index_rebuild_scheduled: needs_index,
     })
-    .map_err(|e: CustodianError| e.to_string())
 }
 
 fn reserved_form_dir_name(name: &str) -> bool {
@@ -4116,7 +4507,7 @@ pub fn run() {
             write_workspace_file,
             get_app_bundle_state,
             refresh_custom_app_dev_mirror,
-            apply_app_bundle_download,
+            download_and_apply_app_bundle,
             list_active_bundle_forms,
             read_bundle_form_spec,
             read_workspace_text_file,
@@ -4151,8 +4542,9 @@ mod tests {
     use std::path::Path;
 
     use super::{
-        bind_query_params, mirror_custom_app_dev_folder, parse_time, resolve_attachment_path,
-        should_mark_conflict, validate_custom_app_dev_source_folder,
+        apply_app_bundle_zip_at_workspace, bind_query_params, mirror_custom_app_dev_folder,
+        parse_time, resolve_attachment_path, should_mark_conflict,
+        validate_custom_app_dev_source_folder, CompressionMethod, SimpleFileOptions, ZipWriter,
     };
     use crate::observation_query::SqlParam;
     use rusqlite::Connection;
@@ -4271,5 +4663,53 @@ mod tests {
         assert_eq!(a, "household");
         assert_eq!(b, 7);
         assert!(rows.next().unwrap().is_none());
+    }
+
+    fn minimal_bundle_zip_bytes() -> Vec<u8> {
+        use std::io::Write;
+        let base = std::env::temp_dir().join(format!(
+            "ode_bundle_zip_fixture_{}",
+            std::process::id()
+        ));
+        let zip_path = base.join("fixture.zip");
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        {
+            let file = fs::File::create(&zip_path).unwrap();
+            let mut zip = ZipWriter::new(file);
+            let options =
+                SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+            zip.start_file("app/index.html", options).unwrap();
+            zip.write_all(b"<html></html>").unwrap();
+            zip.finish().unwrap();
+        }
+        let bytes = fs::read(&zip_path).unwrap();
+        let _ = fs::remove_dir_all(&base);
+        bytes
+    }
+
+    #[test]
+    fn apply_app_bundle_zip_at_workspace_writes_state_and_active() {
+        let base = std::env::temp_dir().join(format!(
+            "ode_bundle_apply_test_{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        let zip_bytes = minimal_bundle_zip_bytes();
+        let state = apply_app_bundle_zip_at_workspace(
+            Path::new(&base),
+            "1.0.0",
+            "abc123",
+            &zip_bytes,
+            None,
+        )
+        .unwrap();
+        assert_eq!(state.active_version, "1.0.0");
+        assert_eq!(state.active_hash, "abc123");
+        assert!(base.join("bundles/active/app/index.html").is_file());
+        assert!(base.join("bundles/archives/1.0.0.zip").is_file());
+        assert!(base.join("bundles/state.json").is_file());
+        let _ = fs::remove_dir_all(&base);
     }
 }

--- a/desktop/src-tauri/src/observation_index.rs
+++ b/desktop/src-tauri/src/observation_index.rs
@@ -148,6 +148,7 @@ fn scalar_to_columns(val: &Value, value_type: Option<&str>) -> (Option<String>, 
 pub fn rebuild_all_indexes(
     conn: &Connection,
     defs: &[ObservationIndexDef],
+    mut progress: Option<&mut dyn FnMut(i64, i64)>,
 ) -> rusqlite::Result<i64> {
     let active: i64 = conn.query_row(
         "SELECT active_generation FROM observation_index_meta WHERE id = 1",
@@ -166,6 +167,11 @@ pub fn rebuild_all_indexes(
         params![new_gen],
     )?;
 
+    let total: i64 = conn.query_row("SELECT COUNT(*) FROM observations", [], |r| r.get(0))?;
+    if let Some(ref mut cb) = progress {
+        cb(0, total);
+    }
+
     let mut stmt = conn.prepare("SELECT id, form_type, payload FROM observations")?;
     let rows = stmt.query_map([], |row| {
         Ok((
@@ -175,10 +181,17 @@ pub fn rebuild_all_indexes(
         ))
     })?;
 
+    let mut done = 0i64;
     for row in rows {
         let (id, form_type, payload) = row?;
         let ft = form_type.unwrap_or_default();
         reindex_observation(conn, &id, &ft, &payload, defs, new_gen)?;
+        done += 1;
+        if let Some(ref mut cb) = progress {
+            if total == 0 || done == total || done % 50 == 0 {
+                cb(done, total);
+            }
+        }
     }
 
     recreate_sqlite_indexes(conn, defs)?;
@@ -429,7 +442,7 @@ mod tests {
             [],
         )
         .unwrap();
-        let gen1 = rebuild_all_indexes(&conn, &defs).unwrap();
+        let gen1 = rebuild_all_indexes(&conn, &defs, None).unwrap();
         assert_eq!(gen1, 2);
         let active: i64 = active_generation(&conn).unwrap();
         assert_eq!(active, 2);

--- a/desktop/src-tauri/src/observation_index.rs
+++ b/desktop/src-tauri/src/observation_index.rs
@@ -187,10 +187,10 @@ pub fn rebuild_all_indexes(
         let ft = form_type.unwrap_or_default();
         reindex_observation(conn, &id, &ft, &payload, defs, new_gen)?;
         done += 1;
-        if let Some(ref mut cb) = progress {
-            if total == 0 || done == total || done % 50 == 0 {
-                cb(done, total);
-            }
+        if let Some(ref mut cb) = progress
+            && (total == 0 || done == total || done % 50 == 0)
+        {
+            cb(done, total);
         }
     }
 

--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -1041,6 +1041,21 @@ textarea {
   gap: 0.5rem;
   flex: 1;
   min-width: 0;
+  flex-wrap: wrap;
+}
+
+.activity-progress {
+  flex: 1 1 100%;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--color-text) 12%, transparent);
+  overflow: hidden;
+}
+
+.activity-progress-fill {
+  height: 100%;
+  background: var(--color-accent, #2563eb);
+  transition: width 0.2s ease;
 }
 
 .app-sync-banner-dismiss {

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -75,7 +75,7 @@ vi.mock('./lib/tauriClient', () => ({
       .fn()
       .mockResolvedValue('/tmp/custodian-ws/bundles/app-bundle.zip'),
     getAppBundleState: vi.fn().mockResolvedValue(null),
-    applyAppBundleDownload: vi.fn(),
+    downloadAndApplyAppBundle: vi.fn(),
     listActiveBundleForms: vi.fn().mockResolvedValue([]),
     readBundleFormSpec: vi.fn(),
     removeWorkspaceAttachment: vi.fn(),

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -24,6 +24,7 @@ import { WorkbenchCustomAppPage } from './pages/WorkbenchCustomAppPage';
 import { useSynkServerStatus } from './hooks/useSynkServerStatus';
 import {
   selectActiveProfileState,
+  selectBundleActivity,
   selectSyncActivity,
   useCustodianStore,
 } from './store/useCustodianStore';
@@ -31,6 +32,7 @@ import {
   selectImportActivity,
   useImportStagingStore,
 } from './store/useImportStagingStore';
+import { guardedProfileNavigation } from './store/useProfileDraftGuardStore';
 import { useToastStore } from './store/useToastStore';
 import './App.css';
 
@@ -82,7 +84,11 @@ function ModeSwitch() {
   const upsertProfileRemote = useCustodianStore(s => s.upsertProfileRemote);
 
   async function goData() {
-    navigate('/data/profiles');
+    await guardedProfileNavigation(
+      navigate,
+      '/data/profiles',
+      location.pathname,
+    );
     if (active) {
       await upsertProfileRemote({
         ...active,
@@ -92,7 +98,11 @@ function ModeSwitch() {
   }
 
   async function goWorkbench() {
-    navigate('/workbench/bundles');
+    await guardedProfileNavigation(
+      navigate,
+      '/workbench/bundles',
+      location.pathname,
+    );
     if (active) {
       await upsertProfileRemote({
         ...active,
@@ -159,6 +169,46 @@ function RootRedirect() {
   return <Navigate to={to} replace />;
 }
 
+function SidebarNavLink({
+  to,
+  end,
+  icon,
+  label,
+}: {
+  to: string;
+  end?: boolean;
+  icon: string;
+  label: string;
+}) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}
+      onClick={e => {
+        if (
+          e.metaKey ||
+          e.ctrlKey ||
+          e.shiftKey ||
+          e.altKey ||
+          e.button !== 0
+        ) {
+          return;
+        }
+        if (location.pathname === '/data/profiles' && to !== '/data/profiles') {
+          e.preventDefault();
+          void guardedProfileNavigation(navigate, to, location.pathname);
+        }
+      }}>
+      <span className="material-symbols-outlined">{icon}</span>
+      <span>{label}</span>
+    </NavLink>
+  );
+}
+
 function Shell() {
   const year = useMemo(() => new Date().getFullYear(), []);
   const location = useLocation();
@@ -168,11 +218,24 @@ function Shell() {
   const clearSyncMessage = useCustodianStore(s => s.clearSyncMessage);
   const pushToast = useToastStore(s => s.pushToast);
   const syncActivity = useCustodianStore(selectSyncActivity);
+  const bundleActivity = useCustodianStore(selectBundleActivity);
   const importActivity = useImportStagingStore(selectImportActivity);
   const activityText: string | null =
-    syncActivity?.statusText ?? importActivity?.statusText ?? null;
+    syncActivity?.statusText ??
+    bundleActivity?.statusText ??
+    importActivity?.statusText ??
+    null;
 
-  const activityPresent = syncActivity !== null || importActivity !== null;
+  const activityProgress =
+    bundleActivity && bundleActivity.total > 0
+      ? Math.min(
+          100,
+          Math.round((bundleActivity.done / bundleActivity.total) * 100),
+        )
+      : null;
+
+  const activityPresent =
+    syncActivity !== null || bundleActivity !== null || importActivity !== null;
   const [activityBannerDismissed, setActivityBannerDismissed] = useState(false);
 
   useEffect(() => {
@@ -225,18 +288,15 @@ function Shell() {
         <ModeSwitch />
         <nav className="nav">
           {navItems.map(item => (
-            <NavLink
+            <SidebarNavLink
               key={item.to}
               to={item.to}
               end={
                 item.to === '/data/profiles' || item.to === '/workbench/bundles'
               }
-              className={({ isActive }) =>
-                `nav-link${isActive ? ' active' : ''}`
-              }>
-              <span className="material-symbols-outlined">{item.icon}</span>
-              <span>{item.label}</span>
-            </NavLink>
+              icon={item.icon}
+              label={item.label}
+            />
           ))}
         </nav>
         <footer className="sidebar-footer">
@@ -257,6 +317,19 @@ function Shell() {
               <div className="app-sync-banner-body">
                 <span className="btn-spinner" aria-hidden />
                 <span>{activityText}</span>
+                {activityProgress !== null ? (
+                  <div
+                    className="activity-progress"
+                    role="progressbar"
+                    aria-valuenow={activityProgress}
+                    aria-valuemin={0}
+                    aria-valuemax={100}>
+                    <div
+                      className="activity-progress-fill"
+                      style={{ width: `${activityProgress}%` }}
+                    />
+                  </div>
+                ) : null}
               </div>
               <button
                 type="button"

--- a/desktop/src/lib/autoSynkAuth.ts
+++ b/desktop/src/lib/autoSynkAuth.ts
@@ -1,40 +1,6 @@
-import {
-  selectActiveProfileState,
-  selectAuthSessionForActiveProfile,
-  useCustodianStore,
-} from '../store/useCustodianStore';
-import { tauriClient } from './tauriClient';
+import { useCustodianStore } from '../store/useCustodianStore';
 
-/** Silent sign-in using profile username + keyring password. Returns true if authenticated. */
+/** Silent sign-in using saved refresh token or keyring password. Returns true if authenticated. */
 export async function tryAutoSynkAuth(): Promise<boolean> {
-  const state = useCustodianStore.getState();
-  const profile = selectActiveProfileState(state);
-  if (!profile) {
-    return false;
-  }
-  const existing = selectAuthSessionForActiveProfile(state);
-  if (existing?.token) {
-    return true;
-  }
-  const baseUrl = (profile.serverUrl ?? '').trim();
-  const username = (profile.username ?? '').trim();
-  if (!baseUrl || !username) {
-    return false;
-  }
-  let password = '';
-  try {
-    const cred = await tauriClient.credentialGet(profile.id);
-    password = cred.password ?? '';
-  } catch {
-    return false;
-  }
-  if (!password.trim()) {
-    return false;
-  }
-  try {
-    await state.synkLogin({ baseUrl, username, password });
-    return true;
-  } catch {
-    return false;
-  }
+  return useCustodianStore.getState().ensureActiveProfileAuth();
 }

--- a/desktop/src/lib/bundleTauriEvents.test.ts
+++ b/desktop/src/lib/bundleTauriEvents.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { bundleBannerLineFromProgress } from './bundleTauriEvents';
+import type { BundleApplyProgressPayload } from '../types/domain';
+
+function payload(
+  partial: Partial<BundleApplyProgressPayload> &
+    Pick<BundleApplyProgressPayload, 'phase'>,
+): BundleApplyProgressPayload {
+  return {
+    jobId: 'job-1',
+    done: 0,
+    total: 0,
+    message: 'Working…',
+    ...partial,
+  };
+}
+
+describe('bundleBannerLineFromProgress', () => {
+  it('includes byte detail when present', () => {
+    expect(
+      bundleBannerLineFromProgress(
+        payload({
+          phase: 'downloading',
+          message: 'Downloading bundle from server…',
+          detail: '12.4 / 48.2 MB',
+        }),
+      ),
+    ).toBe('Downloading bundle from server… — 12.4 / 48.2 MB');
+  });
+
+  it('appends fraction when total is known', () => {
+    expect(
+      bundleBannerLineFromProgress(
+        payload({
+          phase: 'extracting',
+          message: 'Extracting bundle…',
+          done: 3,
+          total: 10,
+        }),
+      ),
+    ).toBe('Extracting bundle… (3/10)');
+  });
+});

--- a/desktop/src/lib/bundleTauriEvents.ts
+++ b/desktop/src/lib/bundleTauriEvents.ts
@@ -1,0 +1,49 @@
+import type { BundleApplyProgressPayload } from '../types/domain';
+
+let pipelineRegistered = false;
+
+export type BundleApplyProgressHandler = (
+  p: BundleApplyProgressPayload,
+) => void;
+
+let applyProgressHandler: BundleApplyProgressHandler | null = null;
+let indexRebuildHandler: BundleApplyProgressHandler | null = null;
+
+export function setBundleApplyProgressHandler(
+  handler: BundleApplyProgressHandler | null,
+) {
+  applyProgressHandler = handler;
+}
+
+export function setBundleIndexRebuildHandler(
+  handler: BundleApplyProgressHandler | null,
+) {
+  indexRebuildHandler = handler;
+}
+
+export function bundleBannerLineFromProgress(
+  p: BundleApplyProgressPayload,
+): string {
+  const base = p.message.trimEnd();
+  if (p.detail?.trim()) {
+    return `${base} — ${p.detail.trim()}`;
+  }
+  if (p.total > 0 && p.phase !== 'completed' && p.phase !== 'failed') {
+    return `${base} (${p.done}/${p.total})`;
+  }
+  return base;
+}
+
+export async function ensureBundleApplyEventPipeline(): Promise<void> {
+  if (pipelineRegistered) {
+    return;
+  }
+  pipelineRegistered = true;
+  const { listen } = await import('@tauri-apps/api/event');
+  await listen<BundleApplyProgressPayload>('bundle/apply-progress', e => {
+    applyProgressHandler?.(e.payload);
+  });
+  await listen<BundleApplyProgressPayload>('bundle/index-rebuild', e => {
+    indexRebuildHandler?.(e.payload);
+  });
+}

--- a/desktop/src/lib/profileDraftDirty.test.ts
+++ b/desktop/src/lib/profileDraftDirty.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  baselineFromProfile,
+  isProfileDraftDirty,
+  type ProfileDraftBaseline,
+} from './profileDraftDirty';
+
+const base: ProfileDraftBaseline = {
+  profileId: 'p1',
+  label: 'Field site',
+  serverUrl: 'https://synk.example',
+  username: 'alice',
+  password: 'secret',
+};
+
+describe('isProfileDraftDirty', () => {
+  it('is false when draft matches baseline', () => {
+    expect(
+      isProfileDraftDirty(base, 'p1', {
+        label: 'Field site',
+        serverUrl: 'https://synk.example',
+        username: 'alice',
+        password: 'secret',
+      }),
+    ).toBe(false);
+  });
+
+  it('detects label, server, username, and password changes', () => {
+    expect(isProfileDraftDirty(base, 'p1', { ...base, label: 'Other' })).toBe(
+      true,
+    );
+    expect(
+      isProfileDraftDirty(base, 'p1', {
+        ...base,
+        serverUrl: 'https://other.example',
+      }),
+    ).toBe(true);
+    expect(isProfileDraftDirty(base, 'p1', { ...base, username: 'bob' })).toBe(
+      true,
+    );
+    expect(isProfileDraftDirty(base, 'p1', { ...base, password: 'new' })).toBe(
+      true,
+    );
+  });
+
+  it('is false when profile id mismatches', () => {
+    expect(isProfileDraftDirty(base, 'p2', base)).toBe(false);
+  });
+});
+
+describe('baselineFromProfile', () => {
+  it('trims profile fields', () => {
+    expect(
+      baselineFromProfile(
+        {
+          id: 'x',
+          label: '  Name  ',
+          serverUrl: ' https://a ',
+          username: ' u ',
+        },
+        'pw',
+      ),
+    ).toEqual({
+      profileId: 'x',
+      label: 'Name',
+      serverUrl: 'https://a',
+      username: 'u',
+      password: 'pw',
+    });
+  });
+});

--- a/desktop/src/lib/profileDraftDirty.ts
+++ b/desktop/src/lib/profileDraftDirty.ts
@@ -1,0 +1,48 @@
+export type ProfileDraftBaseline = {
+  profileId: string;
+  label: string;
+  serverUrl: string;
+  username: string;
+  password: string;
+};
+
+export type ProfileDraftFields = {
+  label: string;
+  serverUrl: string;
+  username: string;
+  password: string;
+};
+
+export function baselineFromProfile(
+  p: {
+    id: string;
+    label: string;
+    serverUrl?: string | null;
+    username?: string | null;
+  },
+  password: string,
+): ProfileDraftBaseline {
+  return {
+    profileId: p.id,
+    label: (p.label ?? '').trim(),
+    serverUrl: (p.serverUrl ?? '').trim(),
+    username: (p.username ?? '').trim(),
+    password,
+  };
+}
+
+export function isProfileDraftDirty(
+  baseline: ProfileDraftBaseline | null,
+  profileId: string | undefined,
+  draft: ProfileDraftFields,
+): boolean {
+  if (!profileId || !baseline || baseline.profileId !== profileId) {
+    return false;
+  }
+  return (
+    draft.label.trim() !== baseline.label ||
+    draft.serverUrl.trim() !== baseline.serverUrl ||
+    draft.username.trim() !== baseline.username ||
+    draft.password !== baseline.password
+  );
+}

--- a/desktop/src/lib/synkAuthErrors.test.ts
+++ b/desktop/src/lib/synkAuthErrors.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { ResponseError } from '../generated/synkronus-client';
+import { isUnauthorizedSynkError } from './synkAuthErrors';
+
+describe('isUnauthorizedSynkError', () => {
+  it('detects ResponseError 401', () => {
+    const err = new ResponseError(
+      new Response('nope', { status: 401 }),
+      'unauthorized',
+    );
+    expect(isUnauthorizedSynkError(err)).toBe(true);
+  });
+
+  it('detects message heuristics', () => {
+    expect(isUnauthorizedSynkError(new Error('HTTP 401 Unauthorized'))).toBe(
+      true,
+    );
+    expect(isUnauthorizedSynkError(new Error('network down'))).toBe(false);
+  });
+});

--- a/desktop/src/lib/synkAuthErrors.ts
+++ b/desktop/src/lib/synkAuthErrors.ts
@@ -1,0 +1,9 @@
+import { ResponseError } from '../generated/synkronus-client';
+
+export function isUnauthorizedSynkError(error: unknown): boolean {
+  if (error instanceof ResponseError) {
+    return error.response.status === 401;
+  }
+  const msg = error instanceof Error ? error.message : String(error);
+  return /\b401\b/.test(msg) || /unauthorized/i.test(msg);
+}

--- a/desktop/src/lib/tauriClient.ts
+++ b/desktop/src/lib/tauriClient.ts
@@ -20,6 +20,7 @@ import type {
   ServerProfile,
   ActiveBundleFormEntry,
   AppBundleState,
+  DownloadAndApplyAppBundleResult,
   CreateObservationSqliteIndexesResult,
   CustomAppDevMirrorResult,
   BundleFormSpec,
@@ -194,24 +195,31 @@ export const tauriClient = {
   writeWorkspaceFile: (relativePath: string, data: Uint8Array) =>
     invokeSafe<string>('write_workspace_file', {
       relativePath,
-      data: Array.from(data),
+      data,
     }),
   getAppBundleState: () =>
     invokeSafe<AppBundleState | null>('get_app_bundle_state'),
   /** Mirrors profile `customAppLocalFolder` into `bundles/dev-local/app/`. */
   refreshCustomAppDevMirror: () =>
     invokeSafe<CustomAppDevMirrorResult>('refresh_custom_app_dev_mirror'),
-  /** Writes `bundles/archives/{version}.zip`, extracts to `bundles/active/`, updates `state.json`. */
-  applyAppBundleDownload: (args: {
+  /** Native download + apply from Synkronus (no binary IPC). Progress via bundle/* events. */
+  downloadAndApplyAppBundle: (args: {
+    baseUrl: string;
+    bearerToken: string;
+    xOdeVersion: string;
     version: string;
     hash: string;
-    zipBytes: Uint8Array;
   }) =>
-    invokeSafe<AppBundleState>('apply_app_bundle_download', {
-      version: args.version,
-      hash: args.hash,
-      zipBytes: Array.from(args.zipBytes),
-    }),
+    invokeSafe<DownloadAndApplyAppBundleResult>(
+      'download_and_apply_app_bundle',
+      {
+        baseUrl: args.baseUrl,
+        bearerToken: args.bearerToken,
+        xOdeVersion: args.xOdeVersion,
+        version: args.version,
+        hash: args.hash,
+      },
+    ),
   listActiveBundleForms: () =>
     invokeSafe<ActiveBundleFormEntry[]>('list_active_bundle_forms'),
   readBundleFormSpec: (formType: string) =>

--- a/desktop/src/pages/ProfilesPage.tsx
+++ b/desktop/src/pages/ProfilesPage.tsx
@@ -1,7 +1,13 @@
-import { open, save } from '@tauri-apps/plugin-dialog';
+import { open, save, confirm } from '@tauri-apps/plugin-dialog';
 import { openPath } from '@tauri-apps/plugin-opener';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { isTauri } from '@tauri-apps/api/core';
 import { tauriClient } from '../lib/tauriClient';
+import {
+  baselineFromProfile,
+  isProfileDraftDirty,
+  type ProfileDraftBaseline,
+} from '../lib/profileDraftDirty';
 import {
   workspaceAttachmentsDir,
   workspaceSqlitePath,
@@ -12,6 +18,7 @@ import {
   selectAuthSessionForActiveProfile,
   useCustodianStore,
 } from '../store/useCustodianStore';
+import { useProfileDraftGuardStore } from '../store/useProfileDraftGuardStore';
 import { confirmDestructiveAction } from '../lib/destructivePolicy';
 
 function PasswordField({
@@ -92,6 +99,12 @@ export function ProfilesPage() {
   const [profileNoticeTone, setProfileNoticeTone] = useState<
     'warn' | 'success'
   >('warn');
+  const [savedBaseline, setSavedBaseline] =
+    useState<ProfileDraftBaseline | null>(null);
+  const setProfileDraftDirty = useProfileDraftGuardStore(s => s.setIsDirty);
+  const setProfileDraftAttemptLeave = useProfileDraftGuardStore(
+    s => s.setAttemptLeave,
+  );
 
   const syncDraftFromActive = useCallback(async (p: ServerProfile | null) => {
     if (!p) {
@@ -106,16 +119,128 @@ export function ProfilesPage() {
     try {
       const res = await tauriClient.credentialGet(p.id);
       setPasswordStorageAvailable(res.storageAvailable);
-      setPassword(res.password ?? '');
+      const pwd = res.password ?? '';
+      setPassword(pwd);
+      setSavedBaseline(baselineFromProfile(p, pwd));
     } catch {
       setPasswordStorageAvailable(false);
       setPassword('');
+      setSavedBaseline(baselineFromProfile(p, ''));
     }
   }, []);
+
+  const isDirty = useMemo(
+    () =>
+      isProfileDraftDirty(savedBaseline, active?.id, {
+        label,
+        serverUrl,
+        username,
+        password,
+      }),
+    [savedBaseline, active?.id, label, serverUrl, username, password],
+  );
+
+  async function promptUnsavedProfileChanges(): Promise<boolean> {
+    const message = 'Some settings were changed. Save profile?';
+    if (isTauri()) {
+      return confirm(message, {
+        title: 'Unsaved changes',
+        kind: 'warning',
+      });
+    }
+    return window.confirm(message);
+  }
+
+  const saveCurrent = useCallback(async (): Promise<boolean> => {
+    if (!active) {
+      return false;
+    }
+    const ws = workspacePath.trim();
+    if (!ws) {
+      setProfileNotice(
+        'Choose a workspace folder. The app stores sqlite, attachments, and exports under it.',
+      );
+      return false;
+    }
+    setProfileNotice(null);
+    setProfileNoticeTone('warn');
+    const databasePath = workspaceSqlitePath(ws);
+    const profile: ServerProfile = {
+      ...active,
+      label: label.trim() || active.label,
+      serverUrl: serverUrl.trim(),
+      username: username.trim() || null,
+      workspacePath: ws,
+      databasePath,
+      attachmentsPath: null,
+      environment: 'production',
+    };
+    await upsertProfileRemote(profile);
+    if (password.trim()) {
+      const cred = await tauriClient.credentialSet(active.id, password);
+      if (!cred.saved && cred.warning) {
+        setProfileNotice(cred.warning);
+      }
+    } else {
+      const del = await tauriClient.credentialDelete(active.id);
+      if (!del.cleared && del.warning) {
+        setProfileNotice(
+          `Could not clear stored password: ${del.warning}. Other fields were saved.`,
+        );
+      }
+    }
+    await refreshSettings();
+    return true;
+  }, [
+    active,
+    workspacePath,
+    label,
+    serverUrl,
+    username,
+    password,
+    upsertProfileRemote,
+    refreshSettings,
+  ]);
+
+  async function handleProfileSelect(nextId: string) {
+    if (nextId === activeProfileId) {
+      return;
+    }
+    if (isDirty) {
+      const shouldSave = await promptUnsavedProfileChanges();
+      if (shouldSave) {
+        const ok = await saveCurrent();
+        if (!ok) {
+          return;
+        }
+      } else {
+        await syncDraftFromActive(active);
+      }
+    }
+    await selectActiveProfile(nextId);
+  }
 
   useEffect(() => {
     void syncDraftFromActive(active);
   }, [active, syncDraftFromActive]);
+
+  useEffect(() => {
+    setProfileDraftDirty(isDirty);
+    return () => setProfileDraftDirty(false);
+  }, [isDirty, setProfileDraftDirty]);
+
+  useEffect(() => {
+    const attemptLeave = async (): Promise<boolean> => {
+      const shouldSave = await promptUnsavedProfileChanges();
+      if (shouldSave) {
+        return saveCurrent();
+      }
+      await syncDraftFromActive(active);
+      return true;
+    };
+    setProfileDraftAttemptLeave(attemptLeave);
+    return () => setProfileDraftAttemptLeave(null);
+  }, [active, saveCurrent, syncDraftFromActive, setProfileDraftAttemptLeave]);
 
   async function pickDirectory(title: string) {
     const selected = await open({
@@ -209,48 +334,18 @@ export function ProfilesPage() {
     }
   }
 
-  async function saveCurrent() {
-    if (!active) {
-      return;
-    }
-    const ws = workspacePath.trim();
-    if (!ws) {
-      setProfileNotice(
-        'Choose a workspace folder. The app stores sqlite, attachments, and exports under it.',
-      );
-      return;
-    }
-    setProfileNotice(null);
-    setProfileNoticeTone('warn');
-    const databasePath = workspaceSqlitePath(ws);
-    const profile: ServerProfile = {
-      ...active,
-      label: label.trim() || active.label,
-      serverUrl: serverUrl.trim(),
-      username: username.trim() || null,
-      workspacePath: ws,
-      databasePath,
-      attachmentsPath: null,
-      environment: 'production',
-    };
-    await upsertProfileRemote(profile);
-    if (password.trim()) {
-      const cred = await tauriClient.credentialSet(active.id, password);
-      if (!cred.saved && cred.warning) {
-        setProfileNotice(cred.warning);
-      }
-    } else {
-      const del = await tauriClient.credentialDelete(active.id);
-      if (!del.cleared && del.warning) {
-        setProfileNotice(
-          `Could not clear stored password: ${del.warning}. Other fields were saved.`,
-        );
-      }
-    }
-    await refreshSettings();
-  }
-
   async function addProfile() {
+    if (isDirty) {
+      const shouldSave = await promptUnsavedProfileChanges();
+      if (shouldSave) {
+        const ok = await saveCurrent();
+        if (!ok) {
+          return;
+        }
+      } else {
+        await syncDraftFromActive(active);
+      }
+    }
     const p = emptyProfile(
       dataDirectory || (await tauriClient.getSettings()).dataDirectory,
     );
@@ -294,6 +389,10 @@ export function ProfilesPage() {
     }
     setProfileNotice(null);
     setProfileNoticeTone('warn');
+    const saved = await saveCurrent();
+    if (!saved) {
+      return;
+    }
     try {
       let pwd = password;
       if (!pwd.trim()) {
@@ -330,7 +429,7 @@ export function ProfilesPage() {
           <select
             aria-label="Profile"
             value={activeProfileId}
-            onChange={e => void selectActiveProfile(e.target.value)}>
+            onChange={e => void handleProfileSelect(e.target.value)}>
             {profiles.map(p => (
               <option key={p.id} value={p.id}>
                 {p.label || p.id}

--- a/desktop/src/pages/WorkbenchBundlesPage.tsx
+++ b/desktop/src/pages/WorkbenchBundlesPage.tsx
@@ -1,12 +1,21 @@
 import { useCallback, useEffect, useState } from 'react';
-import { confirm } from '@tauri-apps/plugin-dialog';
+import { useNavigate } from 'react-router-dom';
+import { isTauri } from '@tauri-apps/api/core';
+import { confirm, message } from '@tauri-apps/plugin-dialog';
 import {
   Configuration,
   DefaultApi,
   type AppBundleManifest,
 } from '../generated/synkronus-client';
 import { appBundleUpdateAvailable } from '../lib/appBundleStatus';
+import {
+  bundleBannerLineFromProgress,
+  ensureBundleApplyEventPipeline,
+  setBundleApplyProgressHandler,
+  setBundleIndexRebuildHandler,
+} from '../lib/bundleTauriEvents';
 import { readBundleCache, writeBundleCache } from '../lib/bundleCacheMeta';
+import { isUnauthorizedSynkError } from '../lib/synkAuthErrors';
 import { SYNKRONUS_CLIENT_VERSION } from '../lib/synkConstants';
 import { tauriClient } from '../lib/tauriClient';
 import {
@@ -14,24 +23,137 @@ import {
   selectAuthSessionForActiveProfile,
   useCustodianStore,
 } from '../store/useCustodianStore';
-import type { AppBundleState } from '../types/domain';
+import type {
+  AppBundleState,
+  BundleApplyProgressPayload,
+} from '../types/domain';
 
 function shortHash(h: string, n = 10): string {
   if (h.length <= n) return h;
   return `${h.slice(0, n)}…`;
 }
 
+function bundleButtonLabel(
+  progress: BundleApplyProgressPayload | null,
+): string {
+  if (!progress || progress.phase === 'completed') {
+    return 'Download & apply';
+  }
+  if (progress.phase === 'failed') {
+    return 'Download & apply';
+  }
+  switch (progress.phase) {
+    case 'downloading':
+      return 'Downloading…';
+    case 'archiving':
+      return 'Saving archive…';
+    case 'extracting':
+      return 'Extracting…';
+    case 'indexing':
+      return 'Rebuilding indexes…';
+    default:
+      return 'Applying…';
+  }
+}
+
+async function alertAuthRequired(body: string): Promise<void> {
+  if (isTauri()) {
+    await message(body, {
+      title: 'Authentication required',
+      kind: 'warning',
+    });
+  } else {
+    window.alert(body);
+  }
+}
+
+async function fetchServerBundleInfoFromApi(
+  baseUrl: string,
+  token: string,
+  recoverActiveProfileAuth: () => Promise<boolean>,
+  retryOnUnauthorized = true,
+): Promise<{ versions: string[]; manifest: AppBundleManifest }> {
+  const api = new DefaultApi(
+    new Configuration({ basePath: baseUrl, accessToken: token }),
+  );
+  try {
+    const [vRes, mRes] = await Promise.all([
+      api.getAppBundleVersions({ xOdeVersion: SYNKRONUS_CLIENT_VERSION }),
+      api.getAppBundleManifest({ xOdeVersion: SYNKRONUS_CLIENT_VERSION }),
+    ]);
+    return { versions: vRes.versions ?? [], manifest: mRes };
+  } catch (e) {
+    if (retryOnUnauthorized && isUnauthorizedSynkError(e)) {
+      const recovered = await recoverActiveProfileAuth();
+      const nextToken = selectAuthSessionForActiveProfile(
+        useCustodianStore.getState(),
+      )?.token;
+      if (recovered && nextToken) {
+        return fetchServerBundleInfoFromApi(
+          baseUrl,
+          nextToken,
+          recoverActiveProfileAuth,
+          false,
+        );
+      }
+    }
+    throw e;
+  }
+}
+
 export function WorkbenchBundlesPage() {
+  const navigate = useNavigate();
   const active = useCustodianStore(selectActiveProfileState);
-  const auth = useCustodianStore(selectAuthSessionForActiveProfile);
+  const ensureActiveProfileAuth = useCustodianStore(
+    s => s.ensureActiveProfileAuth,
+  );
+  const recoverActiveProfileAuth = useCustodianStore(
+    s => s.recoverActiveProfileAuth,
+  );
+  const setBundleActivity = useCustodianStore(s => s.setBundleActivity);
+  const clearBundleActivity = useCustodianStore(s => s.clearBundleActivity);
   const [versions, setVersions] = useState<string[]>([]);
   const [manifest, setManifest] = useState<AppBundleManifest | null>(null);
   const [localState, setLocalState] = useState<AppBundleState | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [checking, setChecking] = useState(false);
   const [zipLoading, setZipLoading] = useState(false);
+  const [applyProgress, setApplyProgress] =
+    useState<BundleApplyProgressPayload | null>(null);
 
   const baseUrl = (active?.serverUrl ?? '').trim().replace(/\/+$/, '');
+  const busy = checking || zipLoading;
+
+  const updateBundleActivity = useCallback(
+    (p: BundleApplyProgressPayload) => {
+      setApplyProgress(p);
+      if (p.phase === 'failed') {
+        setBundleActivity({
+          jobId: p.jobId,
+          statusText: bundleBannerLineFromProgress(p),
+          done: p.done,
+          total: p.total,
+        });
+        return;
+      }
+      if (p.phase === 'completed') {
+        setBundleActivity({
+          jobId: p.jobId,
+          statusText: bundleBannerLineFromProgress(p),
+          done: p.done,
+          total: p.total,
+        });
+        return;
+      }
+      setBundleActivity({
+        jobId: p.jobId,
+        statusText: bundleBannerLineFromProgress(p),
+        done: p.done,
+        total: p.total,
+      });
+    },
+    [setBundleActivity],
+  );
 
   const loadLocalBundleState = useCallback(async () => {
     try {
@@ -41,24 +163,133 @@ export function WorkbenchBundlesPage() {
     }
   }, []);
 
-  const refresh = useCallback(async () => {
-    if (!auth?.token || !baseUrl) {
-      setError('Authenticate in Profiles first.');
-      setVersions([]);
-      setManifest(null);
+  const fetchServerBundleInfo = useCallback(
+    (token: string, retryOnUnauthorized = true) =>
+      fetchServerBundleInfoFromApi(
+        baseUrl,
+        token,
+        recoverActiveProfileAuth,
+        retryOnUnauthorized,
+      ),
+    [baseUrl, recoverActiveProfileAuth],
+  );
+
+  const promptNavigateToProfiles = useCallback(
+    async (body: string) => {
+      await alertAuthRequired(body);
+      navigate('/data/profiles');
+    },
+    [navigate],
+  );
+
+  const ensureAuthForBundleOps = useCallback(async (): Promise<
+    string | null
+  > => {
+    if (!active) {
+      await promptNavigateToProfiles(
+        'Select a profile in Profiles before checking for app bundle updates.',
+      );
+      return null;
+    }
+    if (!baseUrl) {
+      await promptNavigateToProfiles(
+        'Set a server URL for this profile in Profiles before checking for app bundle updates.',
+      );
+      return null;
+    }
+    const ok = await ensureActiveProfileAuth();
+    const token = selectAuthSessionForActiveProfile(
+      useCustodianStore.getState(),
+    )?.token;
+    if (!ok || !token) {
+      await promptNavigateToProfiles(
+        'Could not sign in automatically. Open Profiles to authenticate (save a password or sign in manually).',
+      );
+      return null;
+    }
+    return token;
+  }, [active, baseUrl, ensureActiveProfileAuth, promptNavigateToProfiles]);
+
+  const applyDownloadedBundle = useCallback(
+    async (m: AppBundleManifest, token: string, skipConfirm: boolean) => {
+      if (!skipConfirm) {
+        if (
+          !(await confirm(
+            'Download and apply the active app bundle from the server?',
+            { title: 'Download bundle', kind: 'warning' },
+          ))
+        ) {
+          return;
+        }
+      }
+      setZipLoading(true);
+      setError(null);
+      setApplyProgress(null);
+      await ensureBundleApplyEventPipeline();
+      setBundleApplyProgressHandler(updateBundleActivity);
+      setBundleIndexRebuildHandler(p => {
+        if (p.phase === 'indexing') {
+          updateBundleActivity({ ...p, phase: 'indexing' });
+          return;
+        }
+        if (p.phase === 'completed') {
+          clearBundleActivity();
+          setBundleIndexRebuildHandler(null);
+          return;
+        }
+        if (p.phase === 'failed') {
+          setBundleActivity({
+            jobId: p.jobId,
+            statusText: bundleBannerLineFromProgress(p),
+            done: p.done,
+            total: p.total,
+          });
+          setBundleIndexRebuildHandler(null);
+        }
+      });
+      try {
+        const result = await tauriClient.downloadAndApplyAppBundle({
+          baseUrl,
+          bearerToken: token,
+          xOdeVersion: SYNKRONUS_CLIENT_VERSION,
+          version: m.version,
+          hash: m.hash,
+        });
+        setLocalState(result.state);
+        setManifest(m);
+        useCustodianStore.setState(s => ({
+          devMirrorGeneration: s.devMirrorGeneration + 1,
+        }));
+        if (!result.indexRebuildScheduled) {
+          clearBundleActivity();
+          setBundleIndexRebuildHandler(null);
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        clearBundleActivity();
+        setBundleIndexRebuildHandler(null);
+      } finally {
+        setZipLoading(false);
+        setApplyProgress(null);
+        setBundleApplyProgressHandler(null);
+      }
+    },
+    [baseUrl, clearBundleActivity, setBundleActivity, updateBundleActivity],
+  );
+
+  async function checkForUpdatedBundle() {
+    if (busy) {
       return;
     }
-    setLoading(true);
+    setChecking(true);
     setError(null);
     try {
-      const api = new DefaultApi(
-        new Configuration({ basePath: baseUrl, accessToken: auth.token }),
-      );
-      const [vRes, mRes] = await Promise.all([
-        api.getAppBundleVersions({ xOdeVersion: SYNKRONUS_CLIENT_VERSION }),
-        api.getAppBundleManifest({ xOdeVersion: SYNKRONUS_CLIENT_VERSION }),
-      ]);
-      const list = vRes.versions ?? [];
+      const token = await ensureAuthForBundleOps();
+      if (!token) {
+        return;
+      }
+      const { versions: list, manifest: mRes } =
+        await fetchServerBundleInfo(token);
       setVersions(list);
       setManifest(mRes);
       if (active?.id) {
@@ -67,15 +298,38 @@ export function WorkbenchBundlesPage() {
           fetchedAt: new Date().toISOString(),
         });
       }
-      await loadLocalBundleState();
+      const local = await tauriClient.getAppBundleState();
+      setLocalState(local);
+      if (appBundleUpdateAvailable(mRes, local)) {
+        const shouldDownload = await confirm(
+          `A newer app bundle is available (version ${mRes.version}). Download and apply now?`,
+          { title: 'App bundle update', kind: 'info' },
+        );
+        if (shouldDownload) {
+          await applyDownloadedBundle(mRes, token, true);
+        }
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
-      setVersions([]);
-      setManifest(null);
     } finally {
-      setLoading(false);
+      setChecking(false);
     }
-  }, [auth, baseUrl, active, loadLocalBundleState]);
+  }
+
+  async function downloadAndApply() {
+    const token = await ensureAuthForBundleOps();
+    if (!token) {
+      return;
+    }
+    let m = manifest;
+    if (!m) {
+      const fetched = await fetchServerBundleInfo(token);
+      m = fetched.manifest;
+      setVersions(fetched.versions);
+      setManifest(m);
+    }
+    await applyDownloadedBundle(m, token, false);
+  }
 
   useEffect(() => {
     if (active?.id) {
@@ -94,56 +348,7 @@ export function WorkbenchBundlesPage() {
     void loadLocalBundleState();
   }, [loadLocalBundleState, active?.id]);
 
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
-
   const updateAvailable = appBundleUpdateAvailable(manifest, localState);
-
-  async function downloadAndApply() {
-    if (!auth?.token || !baseUrl) {
-      setError('Authenticate first.');
-      return;
-    }
-    if (
-      !(await confirm(
-        'Download and apply the active app bundle from the server?',
-        { title: 'Download bundle', kind: 'warning' },
-      ))
-    ) {
-      return;
-    }
-    setZipLoading(true);
-    setError(null);
-    try {
-      const api = new DefaultApi(
-        new Configuration({ basePath: baseUrl, accessToken: auth.token }),
-      );
-      const m =
-        manifest ??
-        (await api.getAppBundleManifest({
-          xOdeVersion: SYNKRONUS_CLIENT_VERSION,
-        }));
-      const blob = await api.downloadAppBundleZip({
-        xOdeVersion: SYNKRONUS_CLIENT_VERSION,
-      });
-      const buf = new Uint8Array(await blob.arrayBuffer());
-      const state = await tauriClient.applyAppBundleDownload({
-        version: m.version,
-        hash: m.hash,
-        zipBytes: buf,
-      });
-      setLocalState(state);
-      setManifest(m);
-      useCustodianStore.setState(s => ({
-        devMirrorGeneration: s.devMirrorGeneration + 1,
-      }));
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setZipLoading(false);
-    }
-  }
 
   return (
     <div className="page workbench-page">
@@ -152,9 +357,9 @@ export function WorkbenchBundlesPage() {
         <div className="button-row">
           <button
             type="button"
-            disabled={loading}
-            onClick={() => void refresh()}>
-            {loading ? 'Refreshing…' : 'Refresh from server'}
+            disabled={busy}
+            onClick={() => void checkForUpdatedBundle()}>
+            {checking ? 'Checking…' : 'Check for updated app bundle'}
           </button>
         </div>
       </header>
@@ -178,9 +383,11 @@ export function WorkbenchBundlesPage() {
                   <button
                     type="button"
                     className="btn-compact"
-                    disabled={zipLoading || !auth}
+                    disabled={busy}
                     onClick={() => void downloadAndApply()}>
-                    {zipLoading ? 'Downloading…' : 'Download & apply'}
+                    {zipLoading
+                      ? bundleButtonLabel(applyProgress)
+                      : 'Download & apply'}
                   </button>
                 </td>
               </tr>
@@ -193,7 +400,11 @@ export function WorkbenchBundlesPage() {
             </tbody>
           </table>
         ) : (
-          <p className="muted">{loading ? 'Loading…' : 'No manifest.'}</p>
+          <p className="muted">
+            {checking
+              ? 'Checking server…'
+              : 'Use “Check for updated app bundle” to load server version info.'}
+          </p>
         )}
         {versions.length > 0 ? (
           <table

--- a/desktop/src/store/useCustodianStore.ts
+++ b/desktop/src/store/useCustodianStore.ts
@@ -211,6 +211,12 @@ interface CustodianState {
     op: 'pull' | 'push' | 'reset';
     statusText: string;
   } | null;
+  bundleActivity: {
+    jobId: string;
+    statusText: string;
+    done: number;
+    total: number;
+  } | null;
   /** Persisted Rust sync job awaiting resume (transient stall, auth, or cold start). */
   syncPausedJob: SyncJobRowOut | null;
   /** Bumped after each successful `refresh_custom_app_dev_mirror` (Workbench embeds). */
@@ -222,6 +228,8 @@ interface CustodianState {
   indexCreateError: string | null;
   refreshDevMirror: () => Promise<boolean>;
   setDevError: (message: string | null) => void;
+  setBundleActivity: (activity: CustodianState['bundleActivity']) => void;
+  clearBundleActivity: () => void;
   dismissObservationIndexPrompt: () => void;
   createPendingObservationIndexes: () => Promise<boolean>;
   refreshSettings: () => Promise<void>;
@@ -251,6 +259,10 @@ interface CustodianState {
   synkResetServerRepository: (request?: { baseUrl?: string }) => Promise<void>;
   refreshPausedSyncJob: () => Promise<void>;
   resumePausedSyncEngineJob: () => Promise<void>;
+  /** Returns true when the active profile has a bearer token (silent refresh/login if needed). */
+  ensureActiveProfileAuth: () => Promise<boolean>;
+  /** Re-runs refresh-token / saved-password login (e.g. after HTTP 401). */
+  recoverActiveProfileAuth: () => Promise<boolean>;
   syncPauseInFlight: () => Promise<void>;
   syncContinueInFlight: () => Promise<void>;
   syncCancelJob: (jobId?: string | null) => Promise<void>;
@@ -352,6 +364,7 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
   error: null,
   syncMessage: null,
   syncActivity: null,
+  bundleActivity: null,
   syncPausedJob: null,
   devMirrorGeneration: 0,
   devBusy: false,
@@ -361,6 +374,30 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
   indexCreateError: null,
 
   setDevError: message => set({ devError: message }),
+
+  setBundleActivity: activity => set({ bundleActivity: activity }),
+  clearBundleActivity: () => set({ bundleActivity: null }),
+
+  ensureActiveProfileAuth: async () => {
+    if (selectAuthSessionForActiveProfile(get())?.token) {
+      return true;
+    }
+    try {
+      await reauthenticateActiveProfile(set, get);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  recoverActiveProfileAuth: async () => {
+    try {
+      await reauthenticateActiveProfile(set, get);
+      return true;
+    } catch {
+      return false;
+    }
+  },
 
   dismissObservationIndexPrompt: () =>
     set({ observationIndexPrompt: null, indexCreateError: null }),
@@ -909,6 +946,10 @@ export function selectAuthSessionForActiveProfile(state: CustodianState) {
 
 export function selectSyncActivity(state: CustodianState) {
   return state.syncActivity;
+}
+
+export function selectBundleActivity(state: CustodianState) {
+  return state.bundleActivity;
 }
 
 export function selectPausedSyncJob(state: CustodianState) {

--- a/desktop/src/store/useProfileDraftGuardStore.test.ts
+++ b/desktop/src/store/useProfileDraftGuardStore.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  guardedProfileNavigation,
+  useProfileDraftGuardStore,
+} from './useProfileDraftGuardStore';
+
+describe('guardedProfileNavigation', () => {
+  beforeEach(() => {
+    useProfileDraftGuardStore.setState({
+      isDirty: false,
+      attemptLeave: null,
+    });
+  });
+
+  it('navigates immediately when not leaving profiles', async () => {
+    const navigate = vi.fn();
+    await guardedProfileNavigation(navigate, '/data/sync', '/data/sync');
+    expect(navigate).toHaveBeenCalledWith('/data/sync');
+  });
+
+  it('navigates immediately when profile draft is clean', async () => {
+    const navigate = vi.fn();
+    await guardedProfileNavigation(navigate, '/data/sync', '/data/profiles');
+    expect(navigate).toHaveBeenCalledWith('/data/sync');
+  });
+
+  it('prompts before navigating away from dirty profiles', async () => {
+    const navigate = vi.fn();
+    const attemptLeave = vi.fn().mockResolvedValue(true);
+    useProfileDraftGuardStore.setState({ isDirty: true, attemptLeave });
+
+    await guardedProfileNavigation(navigate, '/data/sync', '/data/profiles');
+
+    expect(attemptLeave).toHaveBeenCalledOnce();
+    expect(navigate).toHaveBeenCalledWith('/data/sync');
+  });
+
+  it('stays on profiles when leave handler returns false', async () => {
+    const navigate = vi.fn();
+    useProfileDraftGuardStore.setState({
+      isDirty: true,
+      attemptLeave: vi.fn().mockResolvedValue(false),
+    });
+
+    await guardedProfileNavigation(navigate, '/data/sync', '/data/profiles');
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/store/useProfileDraftGuardStore.ts
+++ b/desktop/src/store/useProfileDraftGuardStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+
+type ProfileDraftGuardState = {
+  isDirty: boolean;
+  setIsDirty: (dirty: boolean) => void;
+  attemptLeave: (() => Promise<boolean>) | null;
+  setAttemptLeave: (fn: (() => Promise<boolean>) | null) => void;
+};
+
+export const useProfileDraftGuardStore = create<ProfileDraftGuardState>(
+  set => ({
+    isDirty: false,
+    setIsDirty: dirty => set({ isDirty: dirty }),
+    attemptLeave: null,
+    setAttemptLeave: fn => set({ attemptLeave: fn }),
+  }),
+);
+
+/** Returns true when navigation should proceed. */
+export async function guardedProfileNavigation(
+  navigate: (to: string) => void,
+  to: string,
+  fromPathname: string,
+): Promise<void> {
+  const { isDirty, attemptLeave } = useProfileDraftGuardStore.getState();
+  if (
+    fromPathname !== '/data/profiles' ||
+    to === '/data/profiles' ||
+    !isDirty ||
+    !attemptLeave
+  ) {
+    navigate(to);
+    return;
+  }
+  const proceed = await attemptLeave();
+  if (proceed) {
+    navigate(to);
+  }
+}

--- a/desktop/src/types/domain.ts
+++ b/desktop/src/types/domain.ts
@@ -218,6 +218,29 @@ export interface AppBundleState {
   archivedVersions: string[];
 }
 
+export interface DownloadAndApplyAppBundleResult {
+  state: AppBundleState;
+  indexRebuildScheduled: boolean;
+}
+
+export type BundleApplyPhase =
+  | 'downloading'
+  | 'archiving'
+  | 'extracting'
+  | 'indexing'
+  | 'completed'
+  | 'failed';
+
+/** Rust `bundle/apply-progress` and `bundle/index-rebuild` payloads. */
+export interface BundleApplyProgressPayload {
+  jobId: string;
+  phase: BundleApplyPhase;
+  done: number;
+  total: number;
+  message: string;
+  detail?: string;
+}
+
 /** One form folder under `bundles/active/forms/` (or `bundles/active/app/forms/`). */
 export interface ActiveBundleFormEntry {
   formType: string;


### PR DESCRIPTION
# Enhanced the app bundle management

## Description

- Enhanced the app bundle management by adding a new `downloadAndApplyAppBundle` function in the Tauri client, which supports native downloading and applying of app bundles.
- Introduced progress tracking for bundle downloads and index rebuilding, emitting events for UI updates.
- Updated the UI to reflect the download and apply progress, including a new progress bar.
- Modified the `ProfilesPage` and `WorkbenchBundlesPage` components to handle unsaved changes and integrate the new bundle functionality.
- Added new types and interfaces to manage bundle application state and progress.

<!-- Provide a clear description of what changed and why -->

## Type of Change

- [x] Bug Fix
- [x] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [x] **Desktop** (Tauri app)
- [ ] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:** <!-- Please specify -->

---

## Related Issue(s)

<!-- Use keywords: Closes #123, Fixes #456, Resolves #789 -->

**Closes/Fixes/Resolves:** <!-- e.g., Closes #123 -->

---

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
- [ ] Tested on multiple platforms (if applicable)
- [ ] Not applicable

---

## Breaking Changes

- [ ] This PR introduces breaking changes
- [x] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:**

---

## Documentation Updates

- [ ] Documentation has been updated
- [x] Documentation update is not required

---

## Checklist

- [x] Code follows project style guidelines
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**
