### PR TITLE
fix(formplayer): include non-input elements in counts

### DIFF
--- a/formulus-formplayer/src/renderers/swipeLayoutVisibility.test.ts
+++ b/formulus-formplayer/src/renderers/swipeLayoutVisibility.test.ts
@@ -155,6 +155,82 @@ describe('pageIsVisibleInSwipe', () => {
     expect(pageIsVisibleInSwipe(page as any, {}, '', ajv, config)).toBe(true);
   });
 
+  it('returns true for label-only VerticalLayout', () => {
+    const page = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Label',
+          text: 'Visiting: {{data.p_names}}, Date of visit: {{data.obsdate}}',
+          html: false,
+        },
+        {
+          type: 'Label',
+          text: 'Before starting this section: read the response card.',
+          html: false,
+        },
+      ],
+    };
+    expect(pageIsVisibleInSwipe(page as any, {}, '', ajv, config)).toBe(true);
+  });
+
+  it('returns false when all labels are hidden by SHOW rules', () => {
+    const page = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Label',
+          text: 'Only when enabled',
+          rule: {
+            effect: 'SHOW',
+            condition: {
+              scope: '#/properties/on',
+              schema: { const: true },
+            },
+          },
+        },
+      ],
+    };
+    expect(
+      pageIsVisibleInSwipe(page as any, { on: false }, '', ajv, config),
+    ).toBe(false);
+    expect(
+      pageIsVisibleInSwipe(page as any, { on: true }, '', ajv, config),
+    ).toBe(true);
+  });
+
+  it('returns true when only labels are visible but controls are hidden', () => {
+    const page = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Label',
+          text: 'Instructions for this section.',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/detail',
+          rule: {
+            effect: 'SHOW',
+            condition: {
+              scope: '#/properties/showDetail',
+              schema: { const: true },
+            },
+          },
+        },
+      ],
+    };
+    expect(
+      pageIsVisibleInSwipe(
+        page as any,
+        { showDetail: false, detail: '' },
+        '',
+        ajv,
+        config,
+      ),
+    ).toBe(true);
+  });
+
   it('hides page when VerticalLayout has SHOW rule that fails', () => {
     const page = {
       type: 'VerticalLayout',
@@ -177,6 +253,46 @@ describe('pageIsVisibleInSwipe', () => {
 });
 
 describe('visiblePageIndicesFromLayouts', () => {
+  it('keeps label-only pages while filtering out control-only pages with hidden controls', () => {
+    const layouts = [
+      {
+        type: 'VerticalLayout',
+        elements: [
+          {
+            type: 'Label',
+            text: 'Section intro',
+          },
+        ],
+      },
+      {
+        type: 'VerticalLayout',
+        elements: [
+          {
+            type: 'Control',
+            scope: '#/properties/a',
+            rule: {
+              effect: 'SHOW',
+              condition: {
+                scope: '#/properties/toggle',
+                schema: { const: 'one' },
+              },
+            },
+          },
+        ],
+      },
+      { type: 'Finalize' },
+    ];
+    const dataOne = { toggle: 'one', a: 1 };
+    expect(
+      visiblePageIndicesFromLayouts(layouts as any, dataOne, '', ajv, config),
+    ).toEqual([0, 1, 2]);
+
+    const dataTwo = { toggle: 'two', a: 1 };
+    expect(
+      visiblePageIndicesFromLayouts(layouts as any, dataTwo, '', ajv, config),
+    ).toEqual([0, 2]);
+  });
+
   it('filters out pages with no visible interactive content', () => {
     const layouts = [
       {

--- a/formulus-formplayer/src/renderers/swipeLayoutVisibility.ts
+++ b/formulus-formplayer/src/renderers/swipeLayoutVisibility.ts
@@ -25,7 +25,7 @@ export function dispatchPathForLayoutChild(parentDispatchPath: string): string {
   return parentDispatchPath ?? '';
 }
 
-function subtreeHasVisibleInteractiveContent(
+function isVisibleLeafContent(
   element: UISchemaElement,
   rootData: unknown,
   dispatchPath: string,
@@ -38,21 +38,32 @@ function subtreeHasVisibleInteractiveContent(
   if (isControl(element)) {
     return true;
   }
+  if ((element as { type?: string }).type === 'Label') {
+    return true;
+  }
+  return false;
+}
+
+function subtreeHasVisiblePageContent(
+  element: UISchemaElement,
+  rootData: unknown,
+  dispatchPath: string,
+  ajv: Ajv,
+  config: unknown,
+): boolean {
+  if (isVisibleLeafContent(element, rootData, dispatchPath, ajv, config)) {
+    return true;
+  }
+  if (!jsonFormsIsVisible(element, rootData, dispatchPath, ajv, config)) {
+    return false;
+  }
   const children = (element as { elements?: UISchemaElement[] }).elements;
   if (!Array.isArray(children) || children.length === 0) {
     return false;
   }
   const childPath = dispatchPathForLayoutChild(dispatchPath);
   for (const child of children) {
-    if (
-      subtreeHasVisibleInteractiveContent(
-        child,
-        rootData,
-        childPath,
-        ajv,
-        config,
-      )
-    ) {
+    if (subtreeHasVisiblePageContent(child, rootData, childPath, ajv, config)) {
       return true;
     }
   }
@@ -62,7 +73,7 @@ function subtreeHasVisibleInteractiveContent(
 /**
  * Whether a swipe "screen" should participate in next/prev/progress.
  * - Finalize is always included (matches legacy SwipeLayout behavior).
- * - Label-only screens do not count as interactive; nested Groups are walked.
+ * - Label-only screens count as visible page content; nested Groups are walked.
  */
 export function pageIsVisibleInSwipe(
   page: UISchemaElement,
@@ -94,13 +105,7 @@ export function pageIsVisibleInSwipe(
 
   const childPath = dispatchPathForLayoutChild(dispatchPath);
   return typed.elements.some(child =>
-    subtreeHasVisibleInteractiveContent(
-      child,
-      rootData,
-      childPath,
-      ajv,
-      config,
-    ),
+    subtreeHasVisiblePageContent(child, rootData, childPath, ajv, config),
   );
 }
 


### PR DESCRIPTION
# Don't skip label-only screens

## Description

The swipeLayout component auto-skipped screens with no visible input-fields. This caused label-only screens to also be skipped. This PR fixes that mistake.

## Type of Change

- [x] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [ ] **formulus** (React Native mobile app)
- [x] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:** <!-- Please specify -->

---
