### PR TITLE
feat(desktop): Dimension selector for previews

### DIFF
--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -243,6 +243,13 @@ body {
   flex: 1;
   min-height: 0;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.page.page-form-preview > .notice {
+  flex-shrink: 0;
+  margin: 0 var(--space-md) var(--space-sm);
 }
 
 .page.page-custom-app {
@@ -255,6 +262,21 @@ body {
 
 .page.page-custom-app > .page-header {
   flex-shrink: 0;
+}
+
+.page.page-custom-app .custom-app-bundle-row {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: 0 var(--space-md) var(--space-sm);
+}
+
+.page.page-custom-app .custom-app-bundle-row .custom-app-bundle-line {
+  margin: 0;
+  flex: 1;
+  min-width: 0;
 }
 
 .page.page-custom-app > .notice,
@@ -536,6 +558,28 @@ body {
   background: #101828;
 }
 
+.custom-app-device-toolbar--split {
+  justify-content: space-between;
+}
+
+.custom-app-device-toolbar-start {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+  min-width: 0;
+  flex: 1;
+}
+
+.custom-app-device-toolbar-end {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
 .custom-app-device-toolbar-label {
   display: inline-flex;
   align-items: center;
@@ -560,8 +604,61 @@ body {
   font-size: 1.25rem;
 }
 
-.custom-app-device-toolbar-label select {
+.custom-app-device-toolbar-label select,
+.custom-app-device-toolbar-controls select {
   min-width: 14rem;
+}
+
+.form-preview-toolbar-fields {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.form-preview-toolbar-fields select {
+  min-width: 10rem;
+}
+
+.form-preview-toolbar-status {
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+}
+
+.form-preview-advanced-btn {
+  min-height: var(--control-height);
+  min-width: var(--control-height);
+  padding: 0;
+}
+
+.page.page-form-preview .form-preview-embed-panel {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.form-preview-advanced-dialog {
+  width: min(36rem, 92vw);
+}
+
+.form-preview-advanced-dialog-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.form-preview-advanced-field {
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+}
+
+.form-preview-advanced-field span {
+  flex-shrink: 0;
 }
 
 .custom-app-device-toolbar-meta {
@@ -663,6 +760,7 @@ body {
   align-content: stretch;
 }
 
+/* legacy sidebar layout — kept for reference if nested elsewhere */
 .panel.panel-form-preview-sidebar {
   display: flex;
   flex-direction: column;

--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -517,6 +517,142 @@ body {
   overflow: hidden;
 }
 
+.custom-app-device-shell {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.custom-app-device-toolbar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--color-border);
+  background: #101828;
+}
+
+.custom-app-device-toolbar-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: var(--font-size-sm);
+  color: #90a3cb;
+}
+
+.custom-app-device-toolbar-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.custom-app-device-orientation-btn {
+  min-height: var(--control-height);
+  min-width: var(--control-height);
+  padding: 0;
+}
+
+.custom-app-device-orientation-btn .material-symbols-outlined {
+  font-size: 1.25rem;
+}
+
+.custom-app-device-toolbar-label select {
+  min-width: 14rem;
+}
+
+.custom-app-device-toolbar-meta {
+  font-size: var(--font-size-sm);
+}
+
+.custom-app-device-viewport {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: var(--space-md);
+  background:
+    radial-gradient(
+      circle at 50% 0%,
+      rgba(107, 138, 232, 0.06),
+      transparent 55%
+    ),
+    #0b1326;
+}
+
+.custom-app-device-viewport--responsive {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  align-items: stretch;
+  justify-content: flex-start;
+}
+
+.custom-app-device-viewport--responsive .formplayer-embed-wrap,
+.custom-app-device-viewport--responsive .custom-app-embed-wrap {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  width: 100%;
+}
+
+.custom-app-device-viewport--responsive .formplayer-embed-frame {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+}
+
+.custom-app-device-scaler {
+  flex-shrink: 0;
+  position: relative;
+}
+
+.custom-app-device-frame {
+  transform-origin: top left;
+  overflow: hidden;
+  border: 1px solid #455070;
+  border-radius: 0.75rem;
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.35),
+    0 12px 40px rgba(0, 0, 0, 0.45);
+  background: #0b1326;
+}
+
+.custom-app-embed-wrap--fill {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  gap: 0;
+}
+
+.custom-app-embed-wrap--fill > .notice,
+.custom-app-embed-wrap--fill > .muted {
+  position: absolute;
+  z-index: 2;
+  left: var(--space-md);
+  right: var(--space-md);
+  top: var(--space-md);
+  margin: 0;
+}
+
+.custom-app-embed-wrap--fill .formplayer-embed-frame {
+  position: absolute;
+  inset: 0;
+  flex: none;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  border: none;
+  border-radius: 0;
+}
+
 .split.split-form-preview {
   flex: 1;
   min-height: 0;

--- a/desktop/src/components/CustomAppDeviceViewport.tsx
+++ b/desktop/src/components/CustomAppDeviceViewport.tsx
@@ -1,0 +1,162 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  computeDeviceFitScale,
+  getCustomAppDevicePreset,
+  isResponsiveDevicePreset,
+  loadStoredDeviceViewport,
+  resolveDeviceDimensions,
+  storeDeviceViewport,
+  CUSTOM_APP_DEVICE_PRESETS,
+  type CustomAppDevicePresetId,
+} from '../lib/customAppDevicePresets';
+
+export interface CustomAppDeviceViewportProps {
+  children: (ctx: { fillFrame: boolean }) => ReactNode;
+}
+
+export function CustomAppDeviceViewport({
+  children,
+}: CustomAppDeviceViewportProps) {
+  const [viewport, setViewport] = useState(loadStoredDeviceViewport);
+  const { presetId, landscape } = viewport;
+
+  const preset = getCustomAppDevicePreset(presetId);
+  const responsive = isResponsiveDevicePreset(preset);
+  const { width: deviceWidth, height: deviceHeight } = resolveDeviceDimensions(
+    preset,
+    landscape,
+  );
+
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+
+  const recomputeScale = useCallback(() => {
+    if (responsive) {
+      setScale(1);
+      return;
+    }
+    const el = viewportRef.current;
+    if (!el) {
+      return;
+    }
+    setScale(
+      computeDeviceFitScale(
+        el.clientWidth,
+        el.clientHeight,
+        deviceWidth,
+        deviceHeight,
+      ),
+    );
+  }, [deviceHeight, deviceWidth, responsive]);
+
+  useEffect(() => {
+    recomputeScale();
+  }, [recomputeScale]);
+
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (!el || responsive) {
+      return undefined;
+    }
+    const ro = new ResizeObserver(() => recomputeScale());
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [recomputeScale, responsive]);
+
+  function persist(
+    nextPresetId: CustomAppDevicePresetId,
+    nextLandscape: boolean,
+  ) {
+    const next = { presetId: nextPresetId, landscape: nextLandscape };
+    setViewport(next);
+    storeDeviceViewport(nextPresetId, nextLandscape);
+  }
+
+  function onPresetChange(nextId: CustomAppDevicePresetId) {
+    const nextLandscape = nextId === 'responsive' ? false : landscape;
+    persist(nextId, nextLandscape);
+  }
+
+  function toggleOrientation() {
+    if (responsive) {
+      return;
+    }
+    persist(presetId, !landscape);
+  }
+
+  const scaledWidth = deviceWidth * scale;
+  const scaledHeight = deviceHeight * scale;
+  const scaleLabel = `${Math.round(scale * 100)}%`;
+  const orientationLabel = landscape ? 'Landscape' : 'Portrait';
+
+  return (
+    <div className="custom-app-device-shell">
+      <div className="custom-app-device-toolbar">
+        <div className="custom-app-device-toolbar-controls">
+          <label className="custom-app-device-toolbar-label">
+            <span>Viewport</span>
+            <select
+              value={presetId}
+              onChange={e =>
+                onPresetChange(e.target.value as CustomAppDevicePresetId)
+              }>
+              {CUSTOM_APP_DEVICE_PRESETS.map(p => (
+                <option key={p.id} value={p.id}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            className="secondary btn-icon custom-app-device-orientation-btn"
+            disabled={responsive}
+            aria-label="Switch orientation"
+            title="Switch orientation"
+            onClick={toggleOrientation}>
+            <span className="material-symbols-outlined" aria-hidden>
+              screen_rotation
+            </span>
+          </button>
+        </div>
+        {!responsive ? (
+          <span className="muted custom-app-device-toolbar-meta">
+            {deviceWidth} × {deviceHeight} · {orientationLabel} · {scaleLabel}
+          </span>
+        ) : (
+          <span className="muted custom-app-device-toolbar-meta">
+            Fills available panel space
+          </span>
+        )}
+      </div>
+
+      <div
+        ref={viewportRef}
+        className={`custom-app-device-viewport${responsive ? ' custom-app-device-viewport--responsive' : ''}`}>
+        {responsive ? (
+          children({ fillFrame: false })
+        ) : (
+          <div
+            className="custom-app-device-scaler"
+            style={{ width: scaledWidth, height: scaledHeight }}>
+            <div
+              className="custom-app-device-frame"
+              style={{
+                width: deviceWidth,
+                height: deviceHeight,
+                transform: `scale(${scale})`,
+              }}>
+              {children({ fillFrame: true })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/CustomAppDeviceViewport.tsx
+++ b/desktop/src/components/CustomAppDeviceViewport.tsx
@@ -1,25 +1,26 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import {
   computeDeviceFitScale,
+  formatDevicePixelRatioLabel,
   getCustomAppDevicePreset,
   isResponsiveDevicePreset,
   loadStoredDeviceViewport,
   resolveDeviceDimensions,
+  resolveDevicePixelRatio,
   storeDeviceViewport,
   CUSTOM_APP_DEVICE_PRESETS,
   type CustomAppDevicePresetId,
 } from '../lib/customAppDevicePresets';
 
+export interface CustomAppDeviceViewportContext {
+  fillFrame: boolean;
+  devicePixelRatio: number;
+}
+
 export interface CustomAppDeviceViewportProps {
   /** Optional controls rendered on the left (Form preview: form/locale selectors). */
   toolbarStart?: ReactNode;
-  children: (ctx: { fillFrame: boolean }) => ReactNode;
+  children: (ctx: CustomAppDeviceViewportContext) => ReactNode;
 }
 
 export function CustomAppDeviceViewport({
@@ -31,6 +32,7 @@ export function CustomAppDeviceViewport({
 
   const preset = getCustomAppDevicePreset(presetId);
   const responsive = isResponsiveDevicePreset(preset);
+  const devicePixelRatio = resolveDevicePixelRatio(preset);
   const { width: deviceWidth, height: deviceHeight } = resolveDeviceDimensions(
     preset,
     landscape,
@@ -39,38 +41,30 @@ export function CustomAppDeviceViewport({
   const viewportRef = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
 
-  const recomputeScale = useCallback(() => {
+  useEffect(() => {
     if (responsive) {
       setScale(1);
-      return;
+      return undefined;
     }
     const el = viewportRef.current;
     if (!el) {
-      return;
-    }
-    setScale(
-      computeDeviceFitScale(
-        el.clientWidth,
-        el.clientHeight,
-        deviceWidth,
-        deviceHeight,
-      ),
-    );
-  }, [deviceHeight, deviceWidth, responsive]);
-
-  useEffect(() => {
-    recomputeScale();
-  }, [recomputeScale]);
-
-  useEffect(() => {
-    const el = viewportRef.current;
-    if (!el || responsive) {
       return undefined;
     }
-    const ro = new ResizeObserver(() => recomputeScale());
+    const updateScale = () => {
+      setScale(
+        computeDeviceFitScale(
+          el.clientWidth,
+          el.clientHeight,
+          deviceWidth,
+          deviceHeight,
+        ),
+      );
+    };
+    updateScale();
+    const ro = new ResizeObserver(() => updateScale());
     ro.observe(el);
     return () => ro.disconnect();
-  }, [recomputeScale, responsive]);
+  }, [deviceHeight, deviceWidth, responsive]);
 
   function persist(
     nextPresetId: CustomAppDevicePresetId,
@@ -127,7 +121,9 @@ export function CustomAppDeviceViewport({
       </div>
       {!responsive ? (
         <span className="muted custom-app-device-toolbar-meta">
-          {deviceWidth} × {deviceHeight} · {orientationLabel} · {scaleLabel}
+          {deviceWidth} × {deviceHeight} CSS ·{' '}
+          {formatDevicePixelRatioLabel(devicePixelRatio)} · {orientationLabel} ·{' '}
+          {scaleLabel}
         </span>
       ) : (
         <span className="muted custom-app-device-toolbar-meta">
@@ -151,7 +147,7 @@ export function CustomAppDeviceViewport({
         ref={viewportRef}
         className={`custom-app-device-viewport${responsive ? ' custom-app-device-viewport--responsive' : ''}`}>
         {responsive ? (
-          children({ fillFrame: false })
+          children({ fillFrame: false, devicePixelRatio: 1 })
         ) : (
           <div
             className="custom-app-device-scaler"
@@ -163,7 +159,7 @@ export function CustomAppDeviceViewport({
                 height: deviceHeight,
                 transform: `scale(${scale})`,
               }}>
-              {children({ fillFrame: true })}
+              {children({ fillFrame: true, devicePixelRatio })}
             </div>
           </div>
         )}

--- a/desktop/src/components/CustomAppDeviceViewport.tsx
+++ b/desktop/src/components/CustomAppDeviceViewport.tsx
@@ -17,10 +17,13 @@ import {
 } from '../lib/customAppDevicePresets';
 
 export interface CustomAppDeviceViewportProps {
+  /** Optional controls rendered on the left (Form preview: form/locale selectors). */
+  toolbarStart?: ReactNode;
   children: (ctx: { fillFrame: boolean }) => ReactNode;
 }
 
 export function CustomAppDeviceViewport({
+  toolbarStart,
   children,
 }: CustomAppDeviceViewportProps) {
   const [viewport, setViewport] = useState(loadStoredDeviceViewport);
@@ -95,45 +98,53 @@ export function CustomAppDeviceViewport({
   const scaleLabel = `${Math.round(scale * 100)}%`;
   const orientationLabel = landscape ? 'Landscape' : 'Portrait';
 
+  const viewportControls = (
+    <>
+      <div className="custom-app-device-toolbar-controls">
+        <select
+          aria-label="Viewport"
+          value={presetId}
+          onChange={e =>
+            onPresetChange(e.target.value as CustomAppDevicePresetId)
+          }>
+          {CUSTOM_APP_DEVICE_PRESETS.map(p => (
+            <option key={p.id} value={p.id}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="secondary btn-icon custom-app-device-orientation-btn"
+          disabled={responsive}
+          aria-label="Switch orientation"
+          title="Switch orientation"
+          onClick={toggleOrientation}>
+          <span className="material-symbols-outlined" aria-hidden>
+            screen_rotation
+          </span>
+        </button>
+      </div>
+      {!responsive ? (
+        <span className="muted custom-app-device-toolbar-meta">
+          {deviceWidth} × {deviceHeight} · {orientationLabel} · {scaleLabel}
+        </span>
+      ) : (
+        <span className="muted custom-app-device-toolbar-meta">
+          Fills available panel space
+        </span>
+      )}
+    </>
+  );
+
   return (
     <div className="custom-app-device-shell">
-      <div className="custom-app-device-toolbar">
-        <div className="custom-app-device-toolbar-controls">
-          <label className="custom-app-device-toolbar-label">
-            <span>Viewport</span>
-            <select
-              value={presetId}
-              onChange={e =>
-                onPresetChange(e.target.value as CustomAppDevicePresetId)
-              }>
-              {CUSTOM_APP_DEVICE_PRESETS.map(p => (
-                <option key={p.id} value={p.id}>
-                  {p.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <button
-            type="button"
-            className="secondary btn-icon custom-app-device-orientation-btn"
-            disabled={responsive}
-            aria-label="Switch orientation"
-            title="Switch orientation"
-            onClick={toggleOrientation}>
-            <span className="material-symbols-outlined" aria-hidden>
-              screen_rotation
-            </span>
-          </button>
-        </div>
-        {!responsive ? (
-          <span className="muted custom-app-device-toolbar-meta">
-            {deviceWidth} × {deviceHeight} · {orientationLabel} · {scaleLabel}
-          </span>
-        ) : (
-          <span className="muted custom-app-device-toolbar-meta">
-            Fills available panel space
-          </span>
-        )}
+      <div
+        className={`custom-app-device-toolbar${toolbarStart ? ' custom-app-device-toolbar--split' : ''}`}>
+        {toolbarStart ? (
+          <div className="custom-app-device-toolbar-start">{toolbarStart}</div>
+        ) : null}
+        <div className="custom-app-device-toolbar-end">{viewportControls}</div>
       </div>
 
       <div

--- a/desktop/src/components/CustomAppEmbed.tsx
+++ b/desktop/src/components/CustomAppEmbed.tsx
@@ -74,6 +74,8 @@ export type CustomAppEmbedProps = {
   loadingLabel?: string;
   /** Fired when the iframe document loads (bridge routing in WebView2). */
   onContentWindowReady?: (contentWindow: Window | null) => void;
+  /** When true, iframe fills its parent (device frame) instead of flex-growing in the panel. */
+  fillFrame?: boolean;
 };
 
 function defaultIndexRelativePath(mode: CustomAppEmbedMode): string {
@@ -95,7 +97,14 @@ export const CustomAppEmbed = forwardRef<
   HTMLIFrameElement,
   CustomAppEmbedProps
 >(function CustomAppEmbed(
-  { mountKey, mode, indexRelativePath, loadingLabel, onContentWindowReady },
+  {
+    mountKey,
+    mode,
+    indexRelativePath,
+    loadingLabel,
+    onContentWindowReady,
+    fillFrame = false,
+  },
   ref,
 ) {
   const innerRef = useRef<HTMLIFrameElement | null>(null);
@@ -173,7 +182,8 @@ export const CustomAppEmbed = forwardRef<
       : 'Loading custom app from active bundle…';
 
   return (
-    <div className="formplayer-embed-wrap custom-app-embed-wrap">
+    <div
+      className={`formplayer-embed-wrap custom-app-embed-wrap${fillFrame ? ' custom-app-embed-wrap--fill' : ''}`}>
       {error ? <p className="notice warn">{error}</p> : null}
       {loading && !error ? (
         <p className="muted">{loadingLabel ?? defaultLoadingLabel}</p>

--- a/desktop/src/components/CustomAppEmbed.tsx
+++ b/desktop/src/components/CustomAppEmbed.tsx
@@ -9,6 +9,7 @@ import {
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { dirname, join } from '@tauri-apps/api/path';
 import { patchWorkspaceAppBundleAbsolutePaths } from '../lib/patchWorkspaceAppBundleAbsolutePaths';
+import { buildDevicePixelRatioInjectionScript } from '../lib/devicePixelRatioStub';
 import {
   rewriteEmbeddedBundleHtml,
   stripOdeDesktopInjection,
@@ -32,10 +33,12 @@ function shellFormulusInjectionUrl(): string {
  * Injects `ReactNativeWebView` + `formulus-injection.js` (same contract as Formulus mobile).
  * Custom apps do not receive `FormInitData` via `onFormInit` (unlike embedded formplayer).
  */
-function buildHostStub(): string {
+function buildHostStub(devicePixelRatio = 1): string {
   const injectionUrl = shellFormulusInjectionUrl();
   const esc = injectionUrl.replace(/"/g, '&quot;');
+  const dprStub = buildDevicePixelRatioInjectionScript(devicePixelRatio);
   return (
+    dprStub +
     '<script>' +
     '(function(){' +
     'window.ReactNativeWebView={postMessage:function(m){' +
@@ -76,6 +79,8 @@ export type CustomAppEmbedProps = {
   onContentWindowReady?: (contentWindow: Window | null) => void;
   /** When true, iframe fills its parent (device frame) instead of flex-growing in the panel. */
   fillFrame?: boolean;
+  /** Simulated `window.devicePixelRatio` inside the iframe (1 = desktop default). */
+  devicePixelRatio?: number;
 };
 
 function defaultIndexRelativePath(mode: CustomAppEmbedMode): string {
@@ -104,6 +109,7 @@ export const CustomAppEmbed = forwardRef<
     loadingLabel,
     onContentWindowReady,
     fillFrame = false,
+    devicePixelRatio = 1,
   },
   ref,
 ) {
@@ -154,7 +160,7 @@ export const CustomAppEmbed = forwardRef<
       const baseHref = appDirAssetUrl.endsWith('/')
         ? appDirAssetUrl
         : `${appDirAssetUrl}/`;
-      const stub = buildHostStub();
+      const stub = buildHostStub(devicePixelRatio);
       const doc = injectIntoHead(html, stub, baseHref);
       const enc = new TextEncoder();
       await tauriClient.writeWorkspaceFile(indexRel, enc.encode(doc));
@@ -170,7 +176,7 @@ export const CustomAppEmbed = forwardRef<
       setError(e instanceof Error ? e.message : String(e));
       setLoading(false);
     }
-  }, [indexRel, mode]);
+  }, [indexRel, mode, devicePixelRatio]);
 
   useEffect(() => {
     void mountBlob();

--- a/desktop/src/components/FormPreviewAdvancedParamsDialog.tsx
+++ b/desktop/src/components/FormPreviewAdvancedParamsDialog.tsx
@@ -1,0 +1,72 @@
+type Props = {
+  open: boolean;
+  paramsJson: string;
+  savedJson: string;
+  parseError: string | null;
+  disabled: boolean;
+  onParamsChange: (value: string) => void;
+  onSavedChange: (value: string) => void;
+  onApply: () => void;
+  onCancel: () => void;
+};
+
+export function FormPreviewAdvancedParamsDialog({
+  open,
+  paramsJson,
+  savedJson,
+  parseError,
+  disabled,
+  onParamsChange,
+  onSavedChange,
+  onApply,
+  onCancel,
+}: Props) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="modal-overlay" role="presentation">
+      <div
+        className="card modal-card form-preview-advanced-dialog"
+        role="dialog"
+        aria-labelledby="form-preview-advanced-title"
+        aria-modal="true">
+        <h3 id="form-preview-advanced-title">Advanced params</h3>
+        <div className="form-preview-advanced-dialog-fields">
+          <label className="custom-app-device-toolbar-label form-preview-advanced-field">
+            <span>params</span>
+            <textarea
+              className="form-preview-json"
+              spellCheck={false}
+              disabled={disabled}
+              value={paramsJson}
+              onChange={e => onParamsChange(e.target.value)}
+              rows={6}
+            />
+          </label>
+          <label className="custom-app-device-toolbar-label form-preview-advanced-field">
+            <span>savedData</span>
+            <textarea
+              className="form-preview-json"
+              spellCheck={false}
+              disabled={disabled}
+              value={savedJson}
+              onChange={e => onSavedChange(e.target.value)}
+              rows={6}
+            />
+          </label>
+        </div>
+        {parseError ? <p className="notice error">{parseError}</p> : null}
+        <div className="button-row">
+          <button type="button" disabled={disabled} onClick={onApply}>
+            Apply
+          </button>
+          <button type="button" className="secondary" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/FormplayerEmbed.tsx
+++ b/desktop/src/components/FormplayerEmbed.tsx
@@ -43,6 +43,8 @@ export type FormplayerEmbedProps = {
   emptyMessage?: string;
   /** Fired when the iframe document loads (used to register `contentWindow` for bridge routing). */
   onContentWindowReady?: (contentWindow: Window | null) => void;
+  /** When true, iframe fills its parent (device frame) instead of flex-growing in the panel. */
+  fillFrame?: boolean;
 };
 
 /** Imperative handle for bridge delivery into the iframe document (WebView2-safe). */
@@ -68,6 +70,7 @@ export const FormplayerEmbed = forwardRef<
     formInitData,
     emptyMessage = 'Select a form type and apply params/saved JSON to load the preview.',
     onContentWindowReady,
+    fillFrame = false,
   },
   ref,
 ) {
@@ -174,16 +177,18 @@ export const FormplayerEmbed = forwardRef<
     };
   }, [mountBlob]);
 
+  const wrapClass = `formplayer-embed-wrap${fillFrame ? ' custom-app-embed-wrap--fill' : ''}`;
+
   if (formInitData === null) {
     return (
-      <div className="formplayer-embed-wrap">
+      <div className={wrapClass}>
         <p className="muted">{emptyMessage}</p>
       </div>
     );
   }
 
   return (
-    <div className="formplayer-embed-wrap">
+    <div className={wrapClass}>
       {error ? <p className="notice warn">{error}</p> : null}
       {loading && !error ? <p className="muted">Loading formplayer…</p> : null}
       <iframe

--- a/desktop/src/components/FormplayerEmbed.tsx
+++ b/desktop/src/components/FormplayerEmbed.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from 'react';
 import { postFormplayerBridgeReply } from '../lib/formPreviewBridge';
+import { buildDevicePixelRatioInjectionScript } from '../lib/devicePixelRatioStub';
 import type { FormInitData } from '../lib/formplayerHost';
 
 const FORMSPLAYER_INDEX = `${import.meta.env.BASE_URL}formplayer_dist/index.html`;
@@ -45,6 +46,8 @@ export type FormplayerEmbedProps = {
   onContentWindowReady?: (contentWindow: Window | null) => void;
   /** When true, iframe fills its parent (device frame) instead of flex-growing in the panel. */
   fillFrame?: boolean;
+  /** Simulated `window.devicePixelRatio` inside the iframe (1 = desktop default). */
+  devicePixelRatio?: number;
 };
 
 /** Imperative handle for bridge delivery into the iframe document (WebView2-safe). */
@@ -71,6 +74,7 @@ export const FormplayerEmbed = forwardRef<
     emptyMessage = 'Select a form type and apply params/saved JSON to load the preview.',
     onContentWindowReady,
     fillFrame = false,
+    devicePixelRatio = 1,
   },
   ref,
 ) {
@@ -135,8 +139,9 @@ export const FormplayerEmbed = forwardRef<
       );
       const baseHref = new URL('./', formplayerIndexUrl).toString();
       const initJson = JSON.stringify(formInitData).replace(/</g, '\\u003c');
+      const dprStub = buildDevicePixelRatioInjectionScript(devicePixelRatio);
       const stub = `<!--ode-formplayer-host-stub-->
-<script id="ode-formplayer-init-data" type="application/json">${initJson}</script>
+${dprStub}<script id="ode-formplayer-init-data" type="application/json">${initJson}</script>
 <script src="${HOST_STUB_SCRIPT}"></script>
 <script src="${INJECTION_SCRIPT}"></script>`;
       html = html.replace(
@@ -165,7 +170,7 @@ export const FormplayerEmbed = forwardRef<
       setError(e instanceof Error ? e.message : String(e));
       setLoading(false);
     }
-  }, [formInitData]);
+  }, [formInitData, devicePixelRatio]);
 
   useEffect(() => {
     void mountBlob();

--- a/desktop/src/lib/customAppDevicePresets.test.ts
+++ b/desktop/src/lib/customAppDevicePresets.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
   computeDeviceFitScale,
+  formatDevicePixelRatioLabel,
   getCustomAppDevicePreset,
   loadStoredDeviceViewport,
   resolveDeviceDimensions,
+  resolveDevicePixelRatio,
 } from './customAppDevicePresets';
+import { buildDevicePixelRatioInjectionScript } from './devicePixelRatioStub';
 
 describe('computeDeviceFitScale', () => {
   it('returns 1 when container is smaller than padding', () => {
@@ -25,39 +28,85 @@ describe('computeDeviceFitScale', () => {
 });
 
 describe('resolveDeviceDimensions', () => {
-  it('keeps portrait dimensions when landscape is false', () => {
+  it('uses layout CSS viewport for android presets', () => {
     const preset = getCustomAppDevicePreset('android-compact-phone-high');
     expect(resolveDeviceDimensions(preset, false)).toEqual({
-      width: 1080,
-      height: 2340,
+      width: 360,
+      height: 780,
     });
+    expect(preset.label).toBe('Compact phone 6.1″ · 360×780 · 3×');
   });
 
-  it('scales medium and low DPI from the high reference', () => {
-    expect(
-      resolveDeviceDimensions(
-        getCustomAppDevicePreset('android-compact-phone-medium'),
-        false,
-      ),
-    ).toEqual({ width: 720, height: 1560 });
-    expect(
-      resolveDeviceDimensions(
-        getCustomAppDevicePreset('android-compact-phone-low'),
-        false,
-      ),
-    ).toEqual({ width: 540, height: 1170 });
+  it('keeps layout constant across DPI tiers and varies DPR', () => {
+    const high = getCustomAppDevicePreset('android-compact-phone-high');
+    const medium = getCustomAppDevicePreset('android-compact-phone-medium');
+    const low = getCustomAppDevicePreset('android-compact-phone-low');
+    expect(resolveDeviceDimensions(medium, false)).toEqual({
+      width: 360,
+      height: 780,
+    });
+    expect(resolveDeviceDimensions(low, false)).toEqual({
+      width: 360,
+      height: 780,
+    });
+    expect(high.devicePixelRatio).toBe(3);
+    expect(medium.devicePixelRatio).toBe(2.5);
+    expect(low.devicePixelRatio).toBe(2);
+  });
+
+  it('uses higher DPR for large phone high tier', () => {
+    const preset = getCustomAppDevicePreset('android-large-phone-high');
+    expect(resolveDeviceDimensions(preset, false)).toEqual({
+      width: 412,
+      height: 915,
+    });
+    expect(preset.devicePixelRatio).toBe(3.5);
   });
 
   it('swaps dimensions in landscape', () => {
     const preset = getCustomAppDevicePreset('android-small-tablet-high');
     expect(resolveDeviceDimensions(preset, false)).toEqual({
-      width: 1200,
-      height: 1920,
+      width: 600,
+      height: 960,
     });
     expect(resolveDeviceDimensions(preset, true)).toEqual({
-      width: 1920,
-      height: 1200,
+      width: 960,
+      height: 600,
     });
+  });
+});
+
+describe('resolveDevicePixelRatio', () => {
+  it('returns 1 for responsive preset', () => {
+    expect(
+      resolveDevicePixelRatio(getCustomAppDevicePreset('responsive')),
+    ).toBe(1);
+  });
+
+  it('returns preset DPR for fixed devices', () => {
+    expect(resolveDevicePixelRatio(getCustomAppDevicePreset('iphone-se'))).toBe(
+      2,
+    );
+  });
+});
+
+describe('formatDevicePixelRatioLabel', () => {
+  it('formats integer and fractional multipliers', () => {
+    expect(formatDevicePixelRatioLabel(2)).toBe('2×');
+    expect(formatDevicePixelRatioLabel(2.5)).toBe('2.5×');
+    expect(formatDevicePixelRatioLabel(3.5)).toBe('3.5×');
+  });
+});
+
+describe('buildDevicePixelRatioInjectionScript', () => {
+  it('skips injection when DPR is 1', () => {
+    expect(buildDevicePixelRatioInjectionScript(1)).toBe('');
+  });
+
+  it('emits override script for non-unity DPR', () => {
+    const script = buildDevicePixelRatioInjectionScript(3.5);
+    expect(script).toContain('devicePixelRatio');
+    expect(script).toContain('3.5');
   });
 });
 

--- a/desktop/src/lib/customAppDevicePresets.test.ts
+++ b/desktop/src/lib/customAppDevicePresets.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeDeviceFitScale,
+  getCustomAppDevicePreset,
+  loadStoredDeviceViewport,
+  resolveDeviceDimensions,
+} from './customAppDevicePresets';
+
+describe('computeDeviceFitScale', () => {
+  it('returns 1 when container is smaller than padding', () => {
+    expect(computeDeviceFitScale(10, 10, 390, 844)).toBe(1);
+  });
+
+  it('scales down when device is larger than container', () => {
+    const scale = computeDeviceFitScale(400, 800, 390, 844, 24);
+    expect(scale).toBeLessThan(1);
+    expect(scale).toBeCloseTo(752 / 844, 3);
+  });
+
+  it('scales up when device is smaller than container', () => {
+    const scale = computeDeviceFitScale(1200, 900, 375, 667, 24);
+    expect(scale).toBeGreaterThan(1);
+    expect(scale).toBeCloseTo(852 / 667, 3);
+  });
+});
+
+describe('resolveDeviceDimensions', () => {
+  it('keeps portrait dimensions when landscape is false', () => {
+    const preset = getCustomAppDevicePreset('android-compact-phone');
+    expect(resolveDeviceDimensions(preset, false)).toEqual({
+      width: 1080,
+      height: 2340,
+    });
+  });
+
+  it('swaps dimensions in landscape', () => {
+    const preset = getCustomAppDevicePreset('android-small-tablet');
+    expect(resolveDeviceDimensions(preset, false)).toEqual({
+      width: 1200,
+      height: 1920,
+    });
+    expect(resolveDeviceDimensions(preset, true)).toEqual({
+      width: 1920,
+      height: 1200,
+    });
+  });
+});
+
+describe('loadStoredDeviceViewport', () => {
+  it('migrates legacy landscape preset ids', () => {
+    localStorage.setItem(
+      'ode-desktop.custom-app-device-preset',
+      'android-medium-phone-landscape',
+    );
+    expect(loadStoredDeviceViewport()).toEqual({
+      presetId: 'android-medium-phone',
+      landscape: true,
+    });
+    localStorage.removeItem('ode-desktop.custom-app-device-preset');
+  });
+});

--- a/desktop/src/lib/customAppDevicePresets.test.ts
+++ b/desktop/src/lib/customAppDevicePresets.test.ts
@@ -26,15 +26,30 @@ describe('computeDeviceFitScale', () => {
 
 describe('resolveDeviceDimensions', () => {
   it('keeps portrait dimensions when landscape is false', () => {
-    const preset = getCustomAppDevicePreset('android-compact-phone');
+    const preset = getCustomAppDevicePreset('android-compact-phone-high');
     expect(resolveDeviceDimensions(preset, false)).toEqual({
       width: 1080,
       height: 2340,
     });
   });
 
+  it('scales medium and low DPI from the high reference', () => {
+    expect(
+      resolveDeviceDimensions(
+        getCustomAppDevicePreset('android-compact-phone-medium'),
+        false,
+      ),
+    ).toEqual({ width: 720, height: 1560 });
+    expect(
+      resolveDeviceDimensions(
+        getCustomAppDevicePreset('android-compact-phone-low'),
+        false,
+      ),
+    ).toEqual({ width: 540, height: 1170 });
+  });
+
   it('swaps dimensions in landscape', () => {
-    const preset = getCustomAppDevicePreset('android-small-tablet');
+    const preset = getCustomAppDevicePreset('android-small-tablet-high');
     expect(resolveDeviceDimensions(preset, false)).toEqual({
       width: 1200,
       height: 1920,
@@ -53,8 +68,20 @@ describe('loadStoredDeviceViewport', () => {
       'android-medium-phone-landscape',
     );
     expect(loadStoredDeviceViewport()).toEqual({
-      presetId: 'android-medium-phone',
+      presetId: 'android-medium-phone-high',
       landscape: true,
+    });
+    localStorage.removeItem('ode-desktop.custom-app-device-preset');
+  });
+
+  it('migrates legacy android preset ids without dpi suffix to high', () => {
+    localStorage.setItem(
+      'ode-desktop.custom-app-device-preset',
+      'android-large-phone',
+    );
+    expect(loadStoredDeviceViewport()).toEqual({
+      presetId: 'android-large-phone-high',
+      landscape: false,
     });
     localStorage.removeItem('ode-desktop.custom-app-device-preset');
   });

--- a/desktop/src/lib/customAppDevicePresets.ts
+++ b/desktop/src/lib/customAppDevicePresets.ts
@@ -1,0 +1,225 @@
+export type CustomAppDevicePresetId =
+  | 'responsive'
+  | 'iphone-se'
+  | 'ipad-air'
+  | 'android-compact-phone'
+  | 'android-medium-phone'
+  | 'android-large-phone'
+  | 'android-small-tablet'
+  | 'android-standard-tablet'
+  | 'android-large-tablet';
+
+export type CustomAppDeviceOrientation = 'portrait' | 'landscape';
+
+/** Width × height in portrait (width is the narrow side). */
+export interface CustomAppDevicePreset {
+  id: CustomAppDevicePresetId;
+  label: string;
+  width: number;
+  height: number;
+}
+
+export const CUSTOM_APP_DEVICE_PRESETS: CustomAppDevicePreset[] = [
+  { id: 'responsive', label: 'Responsive (fill panel)', width: 0, height: 0 },
+  { id: 'iphone-se', label: 'iPhone SE', width: 375, height: 667 },
+  { id: 'ipad-air', label: 'iPad Air', width: 820, height: 1180 },
+  {
+    id: 'android-compact-phone',
+    label: 'Compact phone 6.1″',
+    width: 1080,
+    height: 2340,
+  },
+  {
+    id: 'android-medium-phone',
+    label: 'Medium phone 6.5″',
+    width: 1080,
+    height: 2400,
+  },
+  {
+    id: 'android-large-phone',
+    label: 'Large phone 6.8″',
+    width: 1440,
+    height: 3120,
+  },
+  {
+    id: 'android-small-tablet',
+    label: 'Small tablet 8″',
+    width: 1200,
+    height: 1920,
+  },
+  {
+    id: 'android-standard-tablet',
+    label: 'Standard tablet 10″',
+    width: 1200,
+    height: 2000,
+  },
+  {
+    id: 'android-large-tablet',
+    label: 'Large tablet 12″',
+    width: 1600,
+    height: 2560,
+  },
+];
+
+export const CUSTOM_APP_DEVICE_PRESET_STORAGE_KEY =
+  'ode-desktop.custom-app-device-preset';
+
+export const CUSTOM_APP_DEVICE_ORIENTATION_STORAGE_KEY =
+  'ode-desktop.custom-app-device-orientation';
+
+/** Maps legacy preset ids (portrait/landscape split in dropdown) to preset + orientation. */
+const LEGACY_PRESET_ID_MAP: Record<
+  string,
+  { id: CustomAppDevicePresetId; landscape: boolean }
+> = {
+  'iphone-se-portrait': { id: 'iphone-se', landscape: false },
+  'iphone-se-landscape': { id: 'iphone-se', landscape: true },
+  'ipad-air-portrait': { id: 'ipad-air', landscape: false },
+  'ipad-air-landscape': { id: 'ipad-air', landscape: true },
+  'android-compact-phone-portrait': {
+    id: 'android-compact-phone',
+    landscape: false,
+  },
+  'android-compact-phone-landscape': {
+    id: 'android-compact-phone',
+    landscape: true,
+  },
+  'android-medium-phone-portrait': {
+    id: 'android-medium-phone',
+    landscape: false,
+  },
+  'android-medium-phone-landscape': {
+    id: 'android-medium-phone',
+    landscape: true,
+  },
+  'android-large-phone-portrait': {
+    id: 'android-large-phone',
+    landscape: false,
+  },
+  'android-large-phone-landscape': {
+    id: 'android-large-phone',
+    landscape: true,
+  },
+  'android-small-tablet-portrait': {
+    id: 'android-small-tablet',
+    landscape: false,
+  },
+  'android-small-tablet-landscape': {
+    id: 'android-small-tablet',
+    landscape: true,
+  },
+  'android-standard-tablet-portrait': {
+    id: 'android-standard-tablet',
+    landscape: false,
+  },
+  'android-standard-tablet-landscape': {
+    id: 'android-standard-tablet',
+    landscape: true,
+  },
+  'android-large-tablet-portrait': {
+    id: 'android-large-tablet',
+    landscape: false,
+  },
+  'android-large-tablet-landscape': {
+    id: 'android-large-tablet',
+    landscape: true,
+  },
+};
+
+export function getCustomAppDevicePreset(
+  id: CustomAppDevicePresetId,
+): CustomAppDevicePreset {
+  return (
+    CUSTOM_APP_DEVICE_PRESETS.find(p => p.id === id) ??
+    CUSTOM_APP_DEVICE_PRESETS[0]
+  );
+}
+
+export function isResponsiveDevicePreset(
+  preset: CustomAppDevicePreset,
+): boolean {
+  return preset.id === 'responsive' || preset.width <= 0 || preset.height <= 0;
+}
+
+export function resolveDeviceDimensions(
+  preset: CustomAppDevicePreset,
+  landscape: boolean,
+): { width: number; height: number } {
+  if (landscape) {
+    return { width: preset.height, height: preset.width };
+  }
+  return { width: preset.width, height: preset.height };
+}
+
+/** Scale device frame to fit container while preserving aspect ratio. */
+export function computeDeviceFitScale(
+  containerWidth: number,
+  containerHeight: number,
+  deviceWidth: number,
+  deviceHeight: number,
+  padding = 24,
+): number {
+  const availW = Math.max(0, containerWidth - padding * 2);
+  const availH = Math.max(0, containerHeight - padding * 2);
+  if (availW <= 0 || availH <= 0 || deviceWidth <= 0 || deviceHeight <= 0) {
+    return 1;
+  }
+  return Math.min(availW / deviceWidth, availH / deviceHeight);
+}
+
+export interface StoredCustomAppDeviceViewport {
+  presetId: CustomAppDevicePresetId;
+  landscape: boolean;
+}
+
+export function loadStoredDeviceViewport(): StoredCustomAppDeviceViewport {
+  try {
+    const rawPreset = localStorage.getItem(
+      CUSTOM_APP_DEVICE_PRESET_STORAGE_KEY,
+    );
+    if (rawPreset) {
+      const legacy = LEGACY_PRESET_ID_MAP[rawPreset];
+      if (legacy) {
+        return { presetId: legacy.id, landscape: legacy.landscape };
+      }
+      if (CUSTOM_APP_DEVICE_PRESETS.some(p => p.id === rawPreset)) {
+        const rawOrientation = localStorage.getItem(
+          CUSTOM_APP_DEVICE_ORIENTATION_STORAGE_KEY,
+        );
+        const landscape = rawOrientation === 'landscape';
+        return {
+          presetId: rawPreset as CustomAppDevicePresetId,
+          landscape,
+        };
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return { presetId: 'responsive', landscape: false };
+}
+
+export function storeDeviceViewport(
+  presetId: CustomAppDevicePresetId,
+  landscape: boolean,
+): void {
+  try {
+    localStorage.setItem(CUSTOM_APP_DEVICE_PRESET_STORAGE_KEY, presetId);
+    localStorage.setItem(
+      CUSTOM_APP_DEVICE_ORIENTATION_STORAGE_KEY,
+      landscape ? 'landscape' : 'portrait',
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
+/** @deprecated Use {@link loadStoredDeviceViewport} */
+export function loadStoredDevicePresetId(): CustomAppDevicePresetId {
+  return loadStoredDeviceViewport().presetId;
+}
+
+/** @deprecated Use {@link storeDeviceViewport} */
+export function storeDevicePresetId(id: CustomAppDevicePresetId): void {
+  storeDeviceViewport(id, false);
+}

--- a/desktop/src/lib/customAppDevicePresets.ts
+++ b/desktop/src/lib/customAppDevicePresets.ts
@@ -2,14 +2,28 @@ export type CustomAppDevicePresetId =
   | 'responsive'
   | 'iphone-se'
   | 'ipad-air'
-  | 'android-compact-phone'
-  | 'android-medium-phone'
-  | 'android-large-phone'
-  | 'android-small-tablet'
-  | 'android-standard-tablet'
-  | 'android-large-tablet';
+  | 'android-compact-phone-high'
+  | 'android-compact-phone-medium'
+  | 'android-compact-phone-low'
+  | 'android-medium-phone-high'
+  | 'android-medium-phone-medium'
+  | 'android-medium-phone-low'
+  | 'android-large-phone-high'
+  | 'android-large-phone-medium'
+  | 'android-large-phone-low'
+  | 'android-small-tablet-high'
+  | 'android-small-tablet-medium'
+  | 'android-small-tablet-low'
+  | 'android-standard-tablet-high'
+  | 'android-standard-tablet-medium'
+  | 'android-standard-tablet-low'
+  | 'android-large-tablet-high'
+  | 'android-large-tablet-medium'
+  | 'android-large-tablet-low';
 
 export type CustomAppDeviceOrientation = 'portrait' | 'landscape';
+
+export type AndroidDeviceDpi = 'high' | 'medium' | 'low';
 
 /** Width × height in portrait (width is the narrow side). */
 export interface CustomAppDevicePreset {
@@ -19,46 +33,91 @@ export interface CustomAppDevicePreset {
   height: number;
 }
 
-export const CUSTOM_APP_DEVICE_PRESETS: CustomAppDevicePreset[] = [
-  { id: 'responsive', label: 'Responsive (fill panel)', width: 0, height: 0 },
-  { id: 'iphone-se', label: 'iPhone SE', width: 375, height: 667 },
-  { id: 'ipad-air', label: 'iPad Air', width: 820, height: 1180 },
+interface AndroidDeviceSize {
+  key: string;
+  label: string;
+  /** Portrait width × height at high DPI (xxhdpi-class reference). */
+  width: number;
+  height: number;
+}
+
+const ANDROID_DEVICE_SIZES: AndroidDeviceSize[] = [
   {
-    id: 'android-compact-phone',
+    key: 'compact-phone',
     label: 'Compact phone 6.1″',
     width: 1080,
     height: 2340,
   },
   {
-    id: 'android-medium-phone',
+    key: 'medium-phone',
     label: 'Medium phone 6.5″',
     width: 1080,
     height: 2400,
   },
   {
-    id: 'android-large-phone',
+    key: 'large-phone',
     label: 'Large phone 6.8″',
     width: 1440,
     height: 3120,
   },
   {
-    id: 'android-small-tablet',
+    key: 'small-tablet',
     label: 'Small tablet 8″',
     width: 1200,
     height: 1920,
   },
   {
-    id: 'android-standard-tablet',
+    key: 'standard-tablet',
     label: 'Standard tablet 10″',
     width: 1200,
     height: 2000,
   },
   {
-    id: 'android-large-tablet',
+    key: 'large-tablet',
     label: 'Large tablet 12″',
     width: 1600,
     height: 2560,
   },
+];
+
+/** Scale high-DPI reference pixels to medium (xhdpi) and low (hdpi) variants. */
+const ANDROID_DPI_SCALE: Record<AndroidDeviceDpi, number> = {
+  high: 1,
+  medium: 2 / 3,
+  low: 0.5,
+};
+
+const ANDROID_DPI_LABEL: Record<AndroidDeviceDpi, string> = {
+  high: 'High DPI',
+  medium: 'Medium DPI',
+  low: 'Low DPI',
+};
+
+function scaleDimension(value: number, scale: number): number {
+  return Math.round(value * scale);
+}
+
+function buildAndroidPresets(): CustomAppDevicePreset[] {
+  const presets: CustomAppDevicePreset[] = [];
+  for (const size of ANDROID_DEVICE_SIZES) {
+    for (const dpi of ['high', 'medium', 'low'] as const) {
+      const scale = ANDROID_DPI_SCALE[dpi];
+      presets.push({
+        id: `android-${size.key}-${dpi}` as CustomAppDevicePresetId,
+        label: `${size.label} · ${ANDROID_DPI_LABEL[dpi]}`,
+        width: scaleDimension(size.width, scale),
+        height: scaleDimension(size.height, scale),
+      });
+    }
+  }
+  return presets;
+}
+
+export const CUSTOM_APP_DEVICE_PRESETS: CustomAppDevicePreset[] = [
+  { id: 'responsive', label: 'Responsive (fill panel)', width: 0, height: 0 },
+  { id: 'iphone-se', label: 'iPhone SE', width: 375, height: 667 },
+  { id: 'ipad-air', label: 'iPad Air', width: 820, height: 1180 },
+  ...buildAndroidPresets(),
 ];
 
 export const CUSTOM_APP_DEVICE_PRESET_STORAGE_KEY =
@@ -76,52 +135,76 @@ const LEGACY_PRESET_ID_MAP: Record<
   'iphone-se-landscape': { id: 'iphone-se', landscape: true },
   'ipad-air-portrait': { id: 'ipad-air', landscape: false },
   'ipad-air-landscape': { id: 'ipad-air', landscape: true },
+  'android-compact-phone': {
+    id: 'android-compact-phone-high',
+    landscape: false,
+  },
   'android-compact-phone-portrait': {
-    id: 'android-compact-phone',
+    id: 'android-compact-phone-high',
     landscape: false,
   },
   'android-compact-phone-landscape': {
-    id: 'android-compact-phone',
+    id: 'android-compact-phone-high',
     landscape: true,
   },
+  'android-medium-phone': {
+    id: 'android-medium-phone-high',
+    landscape: false,
+  },
   'android-medium-phone-portrait': {
-    id: 'android-medium-phone',
+    id: 'android-medium-phone-high',
     landscape: false,
   },
   'android-medium-phone-landscape': {
-    id: 'android-medium-phone',
+    id: 'android-medium-phone-high',
     landscape: true,
   },
+  'android-large-phone': {
+    id: 'android-large-phone-high',
+    landscape: false,
+  },
   'android-large-phone-portrait': {
-    id: 'android-large-phone',
+    id: 'android-large-phone-high',
     landscape: false,
   },
   'android-large-phone-landscape': {
-    id: 'android-large-phone',
+    id: 'android-large-phone-high',
     landscape: true,
   },
+  'android-small-tablet': {
+    id: 'android-small-tablet-high',
+    landscape: false,
+  },
   'android-small-tablet-portrait': {
-    id: 'android-small-tablet',
+    id: 'android-small-tablet-high',
     landscape: false,
   },
   'android-small-tablet-landscape': {
-    id: 'android-small-tablet',
+    id: 'android-small-tablet-high',
     landscape: true,
   },
+  'android-standard-tablet': {
+    id: 'android-standard-tablet-high',
+    landscape: false,
+  },
   'android-standard-tablet-portrait': {
-    id: 'android-standard-tablet',
+    id: 'android-standard-tablet-high',
     landscape: false,
   },
   'android-standard-tablet-landscape': {
-    id: 'android-standard-tablet',
+    id: 'android-standard-tablet-high',
     landscape: true,
   },
+  'android-large-tablet': {
+    id: 'android-large-tablet-high',
+    landscape: false,
+  },
   'android-large-tablet-portrait': {
-    id: 'android-large-tablet',
+    id: 'android-large-tablet-high',
     landscape: false,
   },
   'android-large-tablet-landscape': {
-    id: 'android-large-tablet',
+    id: 'android-large-tablet-high',
     landscape: true,
   },
 };

--- a/desktop/src/lib/customAppDevicePresets.ts
+++ b/desktop/src/lib/customAppDevicePresets.ts
@@ -29,14 +29,16 @@ export type AndroidDeviceDpi = 'high' | 'medium' | 'low';
 export interface CustomAppDevicePreset {
   id: CustomAppDevicePresetId;
   label: string;
+  /** CSS layout viewport width (portrait). */
   width: number;
+  /** CSS layout viewport height (portrait). */
   height: number;
+  devicePixelRatio: number;
 }
 
 interface AndroidDeviceSize {
   key: string;
   label: string;
-  /** Portrait width × height at high DPI (xxhdpi-class reference). */
   width: number;
   height: number;
 }
@@ -45,68 +47,92 @@ const ANDROID_DEVICE_SIZES: AndroidDeviceSize[] = [
   {
     key: 'compact-phone',
     label: 'Compact phone 6.1″',
-    width: 1080,
-    height: 2340,
+    width: 360,
+    height: 780,
   },
   {
     key: 'medium-phone',
     label: 'Medium phone 6.5″',
-    width: 1080,
-    height: 2400,
+    width: 393,
+    height: 852,
   },
   {
     key: 'large-phone',
     label: 'Large phone 6.8″',
-    width: 1440,
-    height: 3120,
+    width: 412,
+    height: 915,
   },
   {
     key: 'small-tablet',
     label: 'Small tablet 8″',
-    width: 1200,
-    height: 1920,
+    width: 600,
+    height: 960,
   },
   {
     key: 'standard-tablet',
     label: 'Standard tablet 10″',
-    width: 1200,
-    height: 2000,
+    width: 800,
+    height: 1280,
   },
   {
     key: 'large-tablet',
     label: 'Large tablet 12″',
-    width: 1600,
-    height: 2560,
+    width: 1024,
+    height: 1366,
   },
 ];
 
-/** Scale high-DPI reference pixels to medium (xhdpi) and low (hdpi) variants. */
-const ANDROID_DPI_SCALE: Record<AndroidDeviceDpi, number> = {
-  high: 1,
-  medium: 2 / 3,
-  low: 0.5,
+/** DPR tiers for the same layout size (simulates sharper vs budget panels). */
+const ANDROID_DPI_TO_DPR: Record<AndroidDeviceDpi, number> = {
+  low: 2,
+  medium: 2.5,
+  high: 3,
 };
 
-const ANDROID_DPI_LABEL: Record<AndroidDeviceDpi, string> = {
-  high: 'High DPI',
-  medium: 'Medium DPI',
-  low: 'Low DPI',
-};
+/** Large flagship phones often report slightly higher DPR than compact devices. */
+const ANDROID_LARGE_PHONE_HIGH_DPR = 3.5;
 
-function scaleDimension(value: number, scale: number): number {
-  return Math.round(value * scale);
+export function formatDevicePixelRatioLabel(devicePixelRatio: number): string {
+  const rounded = Math.round(devicePixelRatio * 10) / 10;
+  const text = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+  return `${text}×`;
+}
+
+function layoutFirstLabel(
+  deviceLabel: string,
+  width: number,
+  height: number,
+  devicePixelRatio: number,
+): string {
+  return `${deviceLabel} · ${width}×${height} · ${formatDevicePixelRatioLabel(devicePixelRatio)}`;
+}
+
+function androidDpiDevicePixelRatio(
+  sizeKey: string,
+  dpi: AndroidDeviceDpi,
+): number {
+  if (sizeKey === 'large-phone' && dpi === 'high') {
+    return ANDROID_LARGE_PHONE_HIGH_DPR;
+  }
+  return ANDROID_DPI_TO_DPR[dpi];
 }
 
 function buildAndroidPresets(): CustomAppDevicePreset[] {
   const presets: CustomAppDevicePreset[] = [];
   for (const size of ANDROID_DEVICE_SIZES) {
     for (const dpi of ['high', 'medium', 'low'] as const) {
-      const scale = ANDROID_DPI_SCALE[dpi];
+      const devicePixelRatio = androidDpiDevicePixelRatio(size.key, dpi);
       presets.push({
         id: `android-${size.key}-${dpi}` as CustomAppDevicePresetId,
-        label: `${size.label} · ${ANDROID_DPI_LABEL[dpi]}`,
-        width: scaleDimension(size.width, scale),
-        height: scaleDimension(size.height, scale),
+        label: layoutFirstLabel(
+          size.label,
+          size.width,
+          size.height,
+          devicePixelRatio,
+        ),
+        width: size.width,
+        height: size.height,
+        devicePixelRatio,
       });
     }
   }
@@ -114,9 +140,27 @@ function buildAndroidPresets(): CustomAppDevicePreset[] {
 }
 
 export const CUSTOM_APP_DEVICE_PRESETS: CustomAppDevicePreset[] = [
-  { id: 'responsive', label: 'Responsive (fill panel)', width: 0, height: 0 },
-  { id: 'iphone-se', label: 'iPhone SE', width: 375, height: 667 },
-  { id: 'ipad-air', label: 'iPad Air', width: 820, height: 1180 },
+  {
+    id: 'responsive',
+    label: 'Responsive (fill panel)',
+    width: 0,
+    height: 0,
+    devicePixelRatio: 1,
+  },
+  {
+    id: 'iphone-se',
+    label: layoutFirstLabel('iPhone SE', 375, 667, 2),
+    width: 375,
+    height: 667,
+    devicePixelRatio: 2,
+  },
+  {
+    id: 'ipad-air',
+    label: layoutFirstLabel('iPad Air', 820, 1180, 2),
+    width: 820,
+    height: 1180,
+    devicePixelRatio: 2,
+  },
   ...buildAndroidPresets(),
 ];
 
@@ -232,6 +276,13 @@ export function resolveDeviceDimensions(
     return { width: preset.height, height: preset.width };
   }
   return { width: preset.width, height: preset.height };
+}
+
+export function resolveDevicePixelRatio(preset: CustomAppDevicePreset): number {
+  if (isResponsiveDevicePreset(preset)) {
+    return 1;
+  }
+  return preset.devicePixelRatio > 0 ? preset.devicePixelRatio : 1;
 }
 
 /** Scale device frame to fit container while preserving aspect ratio. */

--- a/desktop/src/lib/devicePixelRatioStub.ts
+++ b/desktop/src/lib/devicePixelRatioStub.ts
@@ -1,0 +1,16 @@
+/** Returns an inline script that overrides `window.devicePixelRatio` before app code runs. */
+export function buildDevicePixelRatioInjectionScript(
+  devicePixelRatio: number,
+): string {
+  if (devicePixelRatio <= 0 || Math.abs(devicePixelRatio - 1) < 0.001) {
+    return '';
+  }
+  const dprLiteral = JSON.stringify(devicePixelRatio);
+  return (
+    '<script id="ode-device-pixel-ratio-stub">' +
+    '(function(){try{' +
+    `Object.defineProperty(window,"devicePixelRatio",{get:function(){return ${dprLiteral};},configurable:true});` +
+    '}catch(e){}})();' +
+    '</script>'
+  );
+}

--- a/desktop/src/pages/FormPreviewPage.tsx
+++ b/desktop/src/pages/FormPreviewPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { FormFinalizeDialog } from '../components/FormFinalizeDialog';
+import { FormPreviewAdvancedParamsDialog } from '../components/FormPreviewAdvancedParamsDialog';
+import { CustomAppDeviceViewport } from '../components/CustomAppDeviceViewport';
 import {
   FormplayerEmbed,
   type FormplayerEmbedHandle,
@@ -87,6 +89,12 @@ export function FormPreviewPage() {
   const [scannedFormLocales, setScannedFormLocales] = useState<string[]>([]);
 
   const [formInitData, setFormInitData] = useState<FormInitData | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [advancedDraftParams, setAdvancedDraftParams] = useState(DEFAULT_JSON);
+  const [advancedDraftSaved, setAdvancedDraftSaved] = useState(DEFAULT_JSON);
+  const [advancedParseError, setAdvancedParseError] = useState<string | null>(
+    null,
+  );
 
   const iframeRef = useRef<FormplayerEmbedHandle>(null);
   const rootContentWindowRef = useRef<Window | null>(null);
@@ -332,25 +340,43 @@ export function FormPreviewPage() {
     };
   }, [buildInitFromSpec, location.pathname, location.state, navigate]);
 
-  const applyJsonToPreview = useCallback(async () => {
-    if (!spec) {
-      return;
-    }
-    const p = parseJsonObject(paramsJson, 'params');
-    const sv = parseJsonObject(savedJson, 'savedData');
+  const openAdvancedDialog = useCallback(() => {
+    setAdvancedDraftParams(paramsJson);
+    setAdvancedDraftSaved(savedJson);
+    setAdvancedParseError(null);
+    setAdvancedOpen(true);
+  }, [paramsJson, savedJson]);
+
+  const applyAdvancedDialog = useCallback(async () => {
+    const p = parseJsonObject(advancedDraftParams, 'params');
+    const sv = parseJsonObject(advancedDraftSaved, 'savedData');
     if (!p.ok) {
-      setParseError(p.error);
+      setAdvancedParseError(p.error);
       return;
     }
     if (!sv.ok) {
-      setParseError(sv.error);
+      setAdvancedParseError(sv.error);
       return;
     }
+    setAdvancedParseError(null);
+    setParamsJson(advancedDraftParams);
+    setSavedJson(advancedDraftSaved);
     setParseError(null);
+    if (!spec) {
+      setAdvancedOpen(false);
+      return;
+    }
     setFormInitData(
       await buildInitFromSpec(spec, p.value, sv.value, previewObservationId),
     );
-  }, [paramsJson, savedJson, spec, buildInitFromSpec, previewObservationId]);
+    setAdvancedOpen(false);
+  }, [
+    advancedDraftParams,
+    advancedDraftSaved,
+    spec,
+    buildInitFromSpec,
+    previewObservationId,
+  ]);
 
   const onFinalize = useCallback((request: FinalizeRequest) => {
     return new Promise<{ result?: string; error?: string }>(resolve => {
@@ -619,160 +645,145 @@ export function FormPreviewPage() {
         </div>
       ) : null}
 
-      <header className="page-header">
-        <h2>Form preview</h2>
-      </header>
+      <FormPreviewAdvancedParamsDialog
+        open={advancedOpen}
+        paramsJson={advancedDraftParams}
+        savedJson={advancedDraftSaved}
+        parseError={advancedParseError}
+        disabled={!selectedFormType}
+        onParamsChange={setAdvancedDraftParams}
+        onSavedChange={setAdvancedDraftSaved}
+        onApply={() => void applyAdvancedDialog()}
+        onCancel={() => setAdvancedOpen(false)}
+      />
 
-      <div className="split split-form-preview">
-        <aside className="panel panel-form-preview-sidebar card">
-          <div className="form-preview-controls">
-            <select
-              id="form-type-select"
-              className="form-preview-type-select"
-              aria-label="Form type"
-              value={selectedFormType}
-              disabled={listLoading}
-              onChange={e => {
-                const v = e.target.value;
-                setSelectedFormType(v);
-                void loadSpec(v);
-              }}>
-              <option value="">{listLoading ? 'Loading…' : 'Form type'}</option>
-              {formOptions}
-            </select>
-            <label className="form-preview-label" htmlFor="ui-locale-select">
-              UI language
-            </label>
-            <select
-              id="ui-locale-select"
-              className="form-preview-type-select"
-              value={uiLocalePreference}
-              onChange={e => {
-                const v = e.target.value as UiLocalePreference;
-                setUiLocalePreference(v);
-                setDesktopLocalePreference(v);
-                if (spec) {
-                  void (async () => {
-                    const p = parseJsonObject(paramsJson, 'params');
-                    const sv = parseJsonObject(savedJson, 'savedData');
-                    if (p.ok && sv.ok) {
-                      setFormInitData(
-                        await buildInitFromSpec(
-                          spec,
-                          p.value,
-                          sv.value,
-                          previewObservationId,
-                        ),
-                      );
-                    }
-                  })();
-                }
-              }}>
-              <option value="auto">Auto (device)</option>
-              <option value="en">English</option>
-              <option value="pt">Português</option>
-              <option value="fr">Français</option>
-            </select>
-            <label className="form-preview-label" htmlFor="form-locale-select">
-              Form language
-            </label>
-            <select
-              id="form-locale-select"
-              className="form-preview-type-select"
-              value={formLocalePreference}
-              disabled={scannedFormLocales.length === 0}
-              onChange={e => {
-                const v = e.target.value;
-                setFormLocalePreference(v);
-                setDesktopFormLocalePreference(v);
-                if (spec) {
-                  void (async () => {
-                    const p = parseJsonObject(paramsJson, 'params');
-                    const sv = parseJsonObject(savedJson, 'savedData');
-                    if (p.ok && sv.ok) {
-                      setFormInitData(
-                        await buildInitFromSpec(
-                          spec,
-                          { ...p.value, formLocale: v },
-                          sv.value,
-                          previewObservationId,
-                        ),
-                      );
-                    }
-                  })();
-                }
-              }}>
-              <option value={FORM_LOCALE_DEFAULT}>Default</option>
-              {scannedFormLocales.map(code => (
-                <option key={code} value={code}>
-                  {code}
+      {listError ? <p className="notice error">{listError}</p> : null}
+      {specError ? <p className="notice error">{specError}</p> : null}
+      {parseError && !advancedOpen ? (
+        <p className="notice error">{parseError}</p>
+      ) : null}
+
+      <section className="panel panel-embed-flush form-preview-embed-panel">
+        <CustomAppDeviceViewport
+          toolbarStart={
+            <div className="form-preview-toolbar-fields">
+              <select
+                id="form-type-select"
+                aria-label="Form type"
+                value={selectedFormType}
+                disabled={listLoading}
+                onChange={e => {
+                  const v = e.target.value;
+                  setSelectedFormType(v);
+                  void loadSpec(v);
+                }}>
+                <option value="">
+                  {listLoading ? 'Loading…' : 'Form type'}
                 </option>
-              ))}
-            </select>
-            {listError ? (
-              <p className="notice error">{listError}</p>
-            ) : forms.length === 0 && !listLoading ? (
-              <p className="muted">No forms in bundle.</p>
-            ) : null}
-
-            {specLoading ? <p className="muted">Loading form spec…</p> : null}
-            {specError ? <p className="notice error">{specError}</p> : null}
-
-            <details className="form-preview-advanced">
-              <summary>Advanced params</summary>
-              <div className="form-preview-row form-preview-row-stacked">
-                <label className="form-preview-label" htmlFor="params-json">
-                  params
-                </label>
-                <textarea
-                  id="params-json"
-                  className="form-preview-json"
-                  spellCheck={false}
-                  disabled={!selectedFormType}
-                  value={paramsJson}
-                  onChange={e => setParamsJson(e.target.value)}
-                  rows={5}
-                />
-              </div>
-              <div className="form-preview-row form-preview-row-stacked">
-                <label className="form-preview-label" htmlFor="saved-json">
-                  savedData
-                </label>
-                <textarea
-                  id="saved-json"
-                  className="form-preview-json"
-                  spellCheck={false}
-                  disabled={!selectedFormType}
-                  value={savedJson}
-                  onChange={e => setSavedJson(e.target.value)}
-                  rows={5}
-                />
-              </div>
-              {parseError ? <p className="notice error">{parseError}</p> : null}
-              <div className="button-row">
-                <button
-                  type="button"
-                  disabled={!spec}
-                  onClick={() => void applyJsonToPreview()}>
-                  Apply
-                </button>
-              </div>
-            </details>
-          </div>
-        </aside>
-
-        <div className="panel panel-form-preview-embed panel-embed-flush">
-          <FormplayerEmbed
-            key={`${devMirrorGeneration}-${selectedFormType || 'none'}`}
-            ref={iframeRef}
-            onContentWindowReady={cw => {
-              rootContentWindowRef.current = cw;
-            }}
-            formInitData={formInitData}
-            emptyMessage="Choose a form type to load schema and ui from the active bundle, then adjust params / saved JSON and click Apply."
-          />
-        </div>
-      </div>
+                {formOptions}
+              </select>
+              <select
+                id="ui-locale-select"
+                aria-label="UI language"
+                value={uiLocalePreference}
+                onChange={e => {
+                  const v = e.target.value as UiLocalePreference;
+                  setUiLocalePreference(v);
+                  setDesktopLocalePreference(v);
+                  if (spec) {
+                    void (async () => {
+                      const p = parseJsonObject(paramsJson, 'params');
+                      const sv = parseJsonObject(savedJson, 'savedData');
+                      if (p.ok && sv.ok) {
+                        setFormInitData(
+                          await buildInitFromSpec(
+                            spec,
+                            p.value,
+                            sv.value,
+                            previewObservationId,
+                          ),
+                        );
+                      }
+                    })();
+                  }
+                }}>
+                <option value="auto">UI Language (auto)</option>
+                <option value="en">English</option>
+                <option value="pt">Português</option>
+                <option value="fr">Français</option>
+              </select>
+              <select
+                id="form-locale-select"
+                aria-label="Form language"
+                value={formLocalePreference}
+                disabled={scannedFormLocales.length === 0}
+                onChange={e => {
+                  const v = e.target.value;
+                  setFormLocalePreference(v);
+                  setDesktopFormLocalePreference(v);
+                  if (spec) {
+                    void (async () => {
+                      const p = parseJsonObject(paramsJson, 'params');
+                      const sv = parseJsonObject(savedJson, 'savedData');
+                      if (p.ok && sv.ok) {
+                        setFormInitData(
+                          await buildInitFromSpec(
+                            spec,
+                            { ...p.value, formLocale: v },
+                            sv.value,
+                            previewObservationId,
+                          ),
+                        );
+                      }
+                    })();
+                  }
+                }}>
+                <option value={FORM_LOCALE_DEFAULT}>
+                  Form language (default)
+                </option>
+                {scannedFormLocales.map(code => (
+                  <option key={code} value={code}>
+                    {code}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="secondary btn-icon form-preview-advanced-btn"
+                disabled={!selectedFormType}
+                aria-label="Advanced params"
+                title="Advanced params"
+                onClick={openAdvancedDialog}>
+                <span className="material-symbols-outlined" aria-hidden>
+                  data_object
+                </span>
+              </button>
+              {specLoading ? (
+                <span className="muted form-preview-toolbar-status">
+                  Loading form spec…
+                </span>
+              ) : null}
+              {!listLoading && forms.length === 0 ? (
+                <span className="muted form-preview-toolbar-status">
+                  No forms in bundle.
+                </span>
+              ) : null}
+            </div>
+          }>
+          {({ fillFrame }) => (
+            <FormplayerEmbed
+              key={`${devMirrorGeneration}-${selectedFormType || 'none'}`}
+              ref={iframeRef}
+              fillFrame={fillFrame}
+              onContentWindowReady={cw => {
+                rootContentWindowRef.current = cw;
+              }}
+              formInitData={formInitData}
+              emptyMessage="Choose a form type to load schema and ui from the active bundle, then adjust params / saved JSON in Advanced params."
+            />
+          )}
+        </CustomAppDeviceViewport>
+      </section>
     </div>
   );
 }

--- a/desktop/src/pages/FormPreviewPage.tsx
+++ b/desktop/src/pages/FormPreviewPage.tsx
@@ -770,11 +770,12 @@ export function FormPreviewPage() {
               ) : null}
             </div>
           }>
-          {({ fillFrame }) => (
+          {({ fillFrame, devicePixelRatio }) => (
             <FormplayerEmbed
-              key={`${devMirrorGeneration}-${selectedFormType || 'none'}`}
+              key={`${devMirrorGeneration}-${selectedFormType || 'none'}-${devicePixelRatio}`}
               ref={iframeRef}
               fillFrame={fillFrame}
+              devicePixelRatio={devicePixelRatio}
               onContentWindowReady={cw => {
                 rootContentWindowRef.current = cw;
               }}

--- a/desktop/src/pages/WorkbenchCustomAppPage.tsx
+++ b/desktop/src/pages/WorkbenchCustomAppPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { CustomAppDeviceViewport } from '../components/CustomAppDeviceViewport';
 import { CustomAppEmbed } from '../components/CustomAppEmbed';
 import { FormFinalizeDialog } from '../components/FormFinalizeDialog';
 import { useDeveloperMode } from '../hooks/useDeveloperMode';
@@ -181,14 +182,19 @@ export function WorkbenchCustomAppPage() {
 
       <section className="panel panel-embed-flush custom-app-embed-panel">
         {canLoadEmbed ? (
-          <CustomAppEmbed
-            ref={iframeRef}
-            mountKey={mountKey}
-            mode={embedMode}
-            onContentWindowReady={cw => {
-              customAppContentWindowRef.current = cw;
-            }}
-          />
+          <CustomAppDeviceViewport>
+            {({ fillFrame }) => (
+              <CustomAppEmbed
+                ref={iframeRef}
+                mountKey={mountKey}
+                mode={embedMode}
+                fillFrame={fillFrame}
+                onContentWindowReady={cw => {
+                  customAppContentWindowRef.current = cw;
+                }}
+              />
+            )}
+          </CustomAppDeviceViewport>
         ) : developerMode ? (
           <p className="notice warn">
             Configure developer mode on the Bundles page, then use Refresh app

--- a/desktop/src/pages/WorkbenchCustomAppPage.tsx
+++ b/desktop/src/pages/WorkbenchCustomAppPage.tsx
@@ -133,12 +133,32 @@ export function WorkbenchCustomAppPage() {
           setFinalizeRequest(null);
         }}
       />
-      <header className="page-header page-header-inline">
-        <div>
-          <h2>Custom app</h2>
-        </div>
-        {!developerMode ? (
-          <div className="button-row">
+      {devError ? <p className="notice error">{devError}</p> : null}
+      {bundleError ? (
+        <p className="notice error">{bundleError}</p>
+      ) : bundleState ? (
+        <div className="custom-app-bundle-row">
+          <p className="muted custom-app-bundle-line">
+            {developerMode ? (
+              <>
+                Developer mirror active — downloaded bundle{' '}
+                <strong>{bundleState.activeVersion}</strong> (hash{' '}
+                <code className="custom-app-hash">
+                  {bundleState.activeHash}
+                </code>
+                ) remains on disk for sync.
+              </>
+            ) : (
+              <>
+                Active bundle <strong>{bundleState.activeVersion}</strong> (hash{' '}
+                <code className="custom-app-hash">
+                  {bundleState.activeHash}
+                </code>
+                ) — state file <code>{WORKSPACE_BUNDLE_STATE_FILE}</code>
+              </>
+            )}
+          </p>
+          {!developerMode ? (
             <button
               type="button"
               className="secondary"
@@ -146,30 +166,8 @@ export function WorkbenchCustomAppPage() {
               onClick={() => setReloadToken(t => t + 1)}>
               Reload app
             </button>
-          </div>
-        ) : null}
-      </header>
-
-      {devError ? <p className="notice error">{devError}</p> : null}
-      {bundleError ? (
-        <p className="notice error">{bundleError}</p>
-      ) : bundleState ? (
-        <p className="muted custom-app-bundle-line">
-          {developerMode ? (
-            <>
-              Developer mirror active — downloaded bundle{' '}
-              <strong>{bundleState.activeVersion}</strong> (hash{' '}
-              <code className="custom-app-hash">{bundleState.activeHash}</code>)
-              remains on disk for sync.
-            </>
-          ) : (
-            <>
-              Active bundle <strong>{bundleState.activeVersion}</strong> (hash{' '}
-              <code className="custom-app-hash">{bundleState.activeHash}</code>)
-              — state file <code>{WORKSPACE_BUNDLE_STATE_FILE}</code>
-            </>
-          )}
-        </p>
+          ) : null}
+        </div>
       ) : !developerMode ? (
         <p className="muted">
           No local bundle state yet. Download an app bundle on the Bundles page.

--- a/desktop/src/pages/WorkbenchCustomAppPage.tsx
+++ b/desktop/src/pages/WorkbenchCustomAppPage.tsx
@@ -181,12 +181,13 @@ export function WorkbenchCustomAppPage() {
       <section className="panel panel-embed-flush custom-app-embed-panel">
         {canLoadEmbed ? (
           <CustomAppDeviceViewport>
-            {({ fillFrame }) => (
+            {({ fillFrame, devicePixelRatio }) => (
               <CustomAppEmbed
                 ref={iframeRef}
                 mountKey={mountKey}
                 mode={embedMode}
                 fillFrame={fillFrame}
+                devicePixelRatio={devicePixelRatio}
                 onContentWindowReady={cw => {
                   customAppContentWindowRef.current = cw;
                 }}


### PR DESCRIPTION
# Pull Request Title
This PR adds a dropdown to select device dimensions in ODE Desktop and cleans up the form preview page..
<img width="2517" height="1584" alt="image" src="https://github.com/user-attachments/assets/ae71b464-778c-4cc1-adc2-c8926080ed00" />
