### PR TITLE
fix: numeric fields exporting as null in parquet export

### DIFF
--- a/synkronus/pkg/dataexport/postgres.go
+++ b/synkronus/pkg/dataexport/postgres.go
@@ -148,7 +148,7 @@ func (p *postgresDB) GetObservationsForFormType(ctx context.Context, formType st
 	for _, col := range schema.Columns {
 		switch col.SQLType {
 		case "numeric":
-			selectParts = append(selectParts, fmt.Sprintf("(data ->> '%s')::numeric AS data_%s", col.Key, col.Key))
+			selectParts = append(selectParts, fmt.Sprintf("(data ->> '%s')::double precision AS data_%s", col.Key, col.Key))
 		case "boolean":
 			selectParts = append(selectParts, fmt.Sprintf("(data ->> '%s')::boolean AS data_%s", col.Key, col.Key))
 		case "adate":


### PR DESCRIPTION
Fixes #707. Numeric fields were casting to `::numeric` in the export query, but lib/pq doesn't decode that type, so it came back as raw bytes and silently failed the `float64` assertion in the parquet builder. Switched the cast to `double precision`, which lib/pq decodes as `float64` directly.