### PR TITLE
fix: More robust index building after sync

### DIFF
--- a/desktop/docs/UI_FEEDBACK.md
+++ b/desktop/docs/UI_FEEDBACK.md
@@ -10,6 +10,7 @@ Single source of truth for how the shell surfaces status, errors, and confirmati
 - Shows spinner + status text; optional determinate progress bar when `bundleActivity.total > 0`.
 - Dismissible but reappears on next activity.
 - Bundle apply: Rust emits `bundle/apply-progress` and `bundle/index-rebuild`; `bundleActivity` in `useCustodianStore` drives the banner.
+- Sync completion: keep the banner for short **summary** lines when a downloadable `syncDetailReport` is attached (e.g. missing-attachment push details). Offer **Save report** instead of dumping long ID lists into the banner.
 - Do not use for quick actions (save, auth, dev mirror refresh).
 
 ## Toasts (bottom-right stack)
@@ -32,7 +33,7 @@ Single source of truth for how the shell surfaces status, errors, and confirmati
 
 ## Native confirm (Tauri)
 
-**Use for:** destructive actions, import-with-issues, skip already-synced import rows, closing unsaved observation tabs.
+**Use for:** destructive actions, skip already-synced import rows, closing unsaved observation tabs.
 
 - `confirmDestructiveAction()` for destructive flows (clear, profile-scoped wording).
 - `confirm()` from `@tauri-apps/plugin-dialog` for save-anyway / import-anyway / tab discard (Save / Don't save / Cancel via separate flows).
@@ -41,7 +42,8 @@ Single source of truth for how the shell surfaces status, errors, and confirmati
 
 - `window.alert` — replace with toast or inline notice.
 - `window.confirm` — replace with Tauri `confirm`.
-- Duplicate sync success in both banner and toast — prefer toast for short messages; keep banner only for multi-line sync summaries.
+- Dumping long per-observation lists into the sync banner — use a short highlight + **Save report** (`syncDetailReport`).
+- Duplicate sync success in both banner and toast — prefer toast for short messages; keep banner when a detail report is available or the message is multi-line.
 
 ## Dev mode bar
 

--- a/desktop/docs/UI_FEEDBACK.md
+++ b/desktop/docs/UI_FEEDBACK.md
@@ -32,7 +32,7 @@ Single source of truth for how the shell surfaces status, errors, and confirmati
 
 ## Native confirm (Tauri)
 
-**Use for:** destructive actions, import-with-issues, closing unsaved observation tabs.
+**Use for:** destructive actions, import-with-issues, skip already-synced import rows, closing unsaved observation tabs.
 
 - `confirmDestructiveAction()` for destructive flows (clear, profile-scoped wording).
 - `confirm()` from `@tauri-apps/plugin-dialog` for save-anyway / import-anyway / tab discard (Save / Don't save / Cancel via separate flows).

--- a/desktop/docs/screens/import.md
+++ b/desktop/docs/screens/import.md
@@ -11,10 +11,10 @@ Bring external JSON observation files into the active profile’s local reposito
 ## What to include
 
 - Drag-and-drop and multi-file picker for `.json`
-- Pre-flight summary (counts, form types, attachment hints)
-- Per-file parse/normalization issues
-- Import action and clear/reset
-- Optional skip of Formulus-export rows that already appear synced (`syncedAt` ≥ `updatedAt`) — confirm dialog before write
+- **Validate** then review results in-page (no “import anyway?” popup)
+- Import action on the validation results panel (available with or without errors)
+- Clear label when validation finds no errors
+- Optional skip of Formulus-export rows that already appear synced (`syncedAt` ≥ `updatedAt`) — confirm dialog at staging time
 
 ## What to exclude
 
@@ -24,7 +24,7 @@ Bring external JSON observation files into the active profile’s local reposito
 
 ## Key actions
 
-- Stage files, review summary, import, clear
+- Stage files → **Validate** → review results → **Import into local store** (or clear)
 - When import JSON carries Formulus `syncedAt` metadata, confirm whether to skip already-synced observations and write only unsynced ones
 
 ## Data dependencies
@@ -35,12 +35,10 @@ Bring external JSON observation files into the active profile’s local reposito
 
 ## Observation indexes
 
-When the active app bundle declares `observationIndexes` in `app.config.json`:
-
-1. Import writes observations in batches (default 2000 rows per IPC call); intermediate batches skip index work.
-2. After the final batch commits, Rust schedules **one** coalesced background full index rebuild (`bundle/index-rebuild` progress events). Overlapping rebuild requests while one is running are merged into a single follow-up pass.
-3. Sync pull uses incremental indexing per page instead (no full rebuild after each pull).
+When the active app bundle declares `observationIndexes` in `app.config.json`, local file import updates indexes **incrementally** for the written rows (same as sync pull). A full background rebuild is reserved for bundle apply / empty index / explicit rebuild — not for import.
 
 ## Large Formulus exports
 
 After staging JSON (folder / drop / Add JSON), Desktop runs a lightweight host scan of `syncedAt` / `updatedAt` and may offer to drop already-synced files **before** full parse + schema validation. Staging lists truncate after ~50 rows so tens of thousands of files do not freeze the UI.
+
+Import parse + JSON Schema validation + attachment reference checks run in **Rust (Rayon)** in one pass (`parse_and_validate_import_json_paths`), with form schemas loaded once from the active bundle.

--- a/desktop/docs/screens/import.md
+++ b/desktop/docs/screens/import.md
@@ -40,3 +40,7 @@ When the active app bundle declares `observationIndexes` in `app.config.json`:
 1. Import writes observations in batches (default 2000 rows per IPC call); intermediate batches skip index work.
 2. After the final batch commits, Rust schedules **one** coalesced background full index rebuild (`bundle/index-rebuild` progress events). Overlapping rebuild requests while one is running are merged into a single follow-up pass.
 3. Sync pull uses incremental indexing per page instead (no full rebuild after each pull).
+
+## Large Formulus exports
+
+After staging JSON (folder / drop / Add JSON), Desktop runs a lightweight host scan of `syncedAt` / `updatedAt` and may offer to drop already-synced files **before** full parse + schema validation. Staging lists truncate after ~50 rows so tens of thousands of files do not freeze the UI.

--- a/desktop/docs/screens/import.md
+++ b/desktop/docs/screens/import.md
@@ -14,6 +14,7 @@ Bring external JSON observation files into the active profile’s local reposito
 - Pre-flight summary (counts, form types, attachment hints)
 - Per-file parse/normalization issues
 - Import action and clear/reset
+- Optional skip of Formulus-export rows that already appear synced (`syncedAt` ≥ `updatedAt`) — confirm dialog before write
 
 ## What to exclude
 
@@ -24,11 +25,13 @@ Bring external JSON observation files into the active profile’s local reposito
 ## Key actions
 
 - Stage files, review summary, import, clear
+- When import JSON carries Formulus `syncedAt` metadata, confirm whether to skip already-synced observations and write only unsynced ones
 
 ## Data dependencies
 
 - Store: `import` flow via `tauriClient.importObservations`, refresh `loadObservations` / `loadHealth` after import
 - Active profile determines target SQLite repository
+- Sync appearance: Formulus hail-mary export includes `syncedAt`; Desktop treats a row as already synced when `syncedAt` is meaningful and `updatedAt <= syncedAt` (same rule as Formulus pending detection)
 
 ## Observation indexes
 

--- a/desktop/docs/screens/profiles.md
+++ b/desktop/docs/screens/profiles.md
@@ -14,6 +14,7 @@ Define units of custody: each profile has its own Synkronus server, credentials,
 - Edit: display name, server URL, username, password (OS keyring when available)
 - Local repository file picker, workspace folder, optional attachments folder
 - Reload, save profile, clear saved password
+- Authenticate button: auto-recovers session (refresh token / saved password) on load and profile switch; shows **Authenticated** only after a successful check, otherwise **Authenticate**
 - Warnings when secure storage is unavailable (password not persisted)
 
 ## What to exclude

--- a/desktop/docs/screens/sync.md
+++ b/desktop/docs/screens/sync.md
@@ -18,6 +18,7 @@ Operational console to authenticate with Synkronus and exchange data: pull into 
 - Pull and push actions
 - Recent operation log (per-session, on this screen)
 - Store-level `syncMessage` / `error` after operations
+- Danger zone: reset local data (full, or **pending-only** so synced rows + sync offsets stay for a continued pull), re-create index, reset server repository
 
 ## What to exclude
 
@@ -28,6 +29,7 @@ Operational console to authenticate with Synkronus and exchange data: pull into 
 ## Key actions
 
 - Login, pull, push
+- Reset local data (optional: pending observations only)
 
 ## Data dependencies
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -129,7 +130,7 @@ checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
 dependencies = [
  "bytes",
  "half",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-traits",
 ]
 
@@ -499,6 +500,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +531,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1154,6 +1167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1292,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1351,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1390,6 +1434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -2368,6 +2423,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2486,12 @@ dependencies = [
  "indexmap 2.13.0",
  "selectors 0.24.0",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -2757,6 +2845,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,6 +2877,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -2787,6 +2905,27 @@ version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2952,6 +3091,7 @@ dependencies = [
  "arrow",
  "chrono",
  "futures-util",
+ "jsonschema",
  "keyring",
  "parquet",
  "rayon",
@@ -3051,6 +3191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,7 +3268,7 @@ dependencies = [
  "chrono",
  "half",
  "hashbrown 0.17.1",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
  "seq-macro",
@@ -3786,6 +3932,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3823,6 +3983,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -5555,6 +5716,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,6 +5743,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vswhom"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -38,4 +38,5 @@ urlencoding = "2"
 tokio = { version = "1", features = ["sync", "time", "macros"] }
 arrow = { version = "59", default-features = false, features = ["chrono-tz"] }
 parquet = { version = "59", default-features = false, features = ["arrow", "snap"] }
+jsonschema = "0.30"
 

--- a/desktop/src-tauri/src/import_validate/attachments.rs
+++ b/desktop/src-tauri/src/import_validate/attachments.rs
@@ -1,0 +1,483 @@
+//! Attachment basename extraction for import validation (TS parity).
+
+use std::collections::HashSet;
+
+use serde_json::Value;
+
+const ATTACHMENT_SCHEMA_FORMATS: &[&str] = &["photo", "select_file", "signature", "audio", "video"];
+
+const ATTACHMENT_BASENAME_EXT: &[&str] = &[
+    ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".heic", ".tif", ".tiff", ".pdf", ".doc",
+    ".docx", ".xls", ".xlsx", ".ppt", ".pptx", ".csv", ".txt", ".mp3", ".mp4", ".m4a", ".wav",
+    ".aac", ".flac", ".webm", ".mov", ".mkv", ".svg",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SchemaPathSegment {
+    Key(String),
+    Each,
+}
+
+fn is_object(v: &Value) -> bool {
+    v.is_object()
+}
+
+fn resolve_json_pointer<'a>(root: &'a Value, ref_str: &str) -> Option<&'a Value> {
+    if !ref_str.starts_with("#/") {
+        return None;
+    }
+    let mut cur = root;
+    for raw in ref_str[2..].split('/') {
+        let p = raw.replace("~1", "/").replace("~0", "~");
+        cur = cur.as_object()?.get(&p)?;
+    }
+    Some(cur)
+}
+
+fn has_attachment_format(schema: &Value) -> bool {
+    schema
+        .get("format")
+        .and_then(|f| f.as_str())
+        .is_some_and(|fmt| ATTACHMENT_SCHEMA_FORMATS.contains(&fmt))
+}
+
+fn path_sig(path: &[SchemaPathSegment]) -> String {
+    path.iter()
+        .map(|s| match s {
+            SchemaPathSegment::Key(k) => k.as_str(),
+            SchemaPathSegment::Each => "*",
+        })
+        .collect::<Vec<_>>()
+        .join("\0")
+}
+
+/// Walk JSON Schema (draft-07 style) and collect property paths with attachment formats.
+fn collect_attachment_paths_from_schema(schema_root: &Value) -> Vec<Vec<SchemaPathSegment>> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    let mut stack: HashSet<*const Value> = HashSet::new();
+
+    fn visit(
+        schema_root: &Value,
+        schema: &Value,
+        path_prefix: &[SchemaPathSegment],
+        stack: &mut HashSet<*const Value>,
+        seen: &mut HashSet<String>,
+        out: &mut Vec<Vec<SchemaPathSegment>>,
+    ) {
+        if !schema.is_object() {
+            return;
+        }
+        let ptr = schema as *const Value;
+        if !stack.insert(ptr) {
+            return;
+        }
+
+        if let Some(Value::String(r)) = schema.get("$ref") {
+            if let Some(resolved) = resolve_json_pointer(schema_root, r) {
+                visit(schema_root, resolved, path_prefix, stack, seen, out);
+            }
+            stack.remove(&ptr);
+            return;
+        }
+
+        for combiner in ["allOf", "anyOf", "oneOf"] {
+            if let Some(Value::Array(arr)) = schema.get(combiner) {
+                for branch in arr {
+                    visit(schema_root, branch, path_prefix, stack, seen, out);
+                }
+            }
+        }
+        if let Some(then_schema) = schema.get("then")
+            && then_schema.is_object()
+        {
+            visit(schema_root, then_schema, path_prefix, stack, seen, out);
+        }
+        if let Some(else_schema) = schema.get("else")
+            && else_schema.is_object()
+        {
+            visit(schema_root, else_schema, path_prefix, stack, seen, out);
+        }
+
+        if has_attachment_format(schema) && !path_prefix.is_empty() {
+            let sig = path_sig(path_prefix);
+            if seen.insert(sig) {
+                out.push(path_prefix.to_vec());
+            }
+            stack.remove(&ptr);
+            return;
+        }
+
+        if let Some(Value::Object(props)) = schema.get("properties") {
+            for (key, sub) in props {
+                if !sub.is_object() {
+                    continue;
+                }
+                let mut next_path = path_prefix.to_vec();
+                next_path.push(SchemaPathSegment::Key(key.clone()));
+
+                if has_attachment_format(sub) {
+                    let sig = path_sig(&next_path);
+                    if seen.insert(sig) {
+                        out.push(next_path);
+                    }
+                } else {
+                    let is_array = match sub.get("type") {
+                        Some(Value::String(t)) => t == "array",
+                        Some(Value::Array(arr)) => arr.iter().any(|x| x.as_str() == Some("array")),
+                        _ => false,
+                    };
+                    if is_array {
+                        if let Some(items) = sub.get("items")
+                            && items.is_object()
+                        {
+                            if has_attachment_format(items) {
+                                let mut segs = next_path;
+                                segs.push(SchemaPathSegment::Each);
+                                let sig = path_sig(&segs);
+                                if seen.insert(sig) {
+                                    out.push(segs);
+                                }
+                            } else {
+                                let mut segs = next_path;
+                                segs.push(SchemaPathSegment::Each);
+                                visit(schema_root, items, &segs, stack, seen, out);
+                            }
+                        }
+                    } else {
+                        visit(schema_root, sub, &next_path, stack, seen, out);
+                    }
+                }
+            }
+        }
+
+        match schema.get("additionalProperties") {
+            Some(Value::Bool(true)) => {
+                visit(
+                    schema_root,
+                    &Value::Object(Default::default()),
+                    path_prefix,
+                    stack,
+                    seen,
+                    out,
+                );
+            }
+            Some(addl) if addl.is_object() => {
+                visit(schema_root, addl, path_prefix, stack, seen, out);
+            }
+            _ => {}
+        }
+
+        stack.remove(&ptr);
+    }
+
+    visit(
+        schema_root,
+        schema_root,
+        &[],
+        &mut stack,
+        &mut seen,
+        &mut out,
+    );
+    out
+}
+
+fn basename_only(raw: &str) -> String {
+    let t = raw.trim().replace('\\', "/");
+    t.rsplit('/').next().unwrap_or("").trim().to_string()
+}
+
+fn has_attachment_ext(basename: &str) -> bool {
+    let lower = basename.to_lowercase();
+    ATTACHMENT_BASENAME_EXT
+        .iter()
+        .any(|ext| lower.ends_with(ext))
+}
+
+fn string_looks_like_attachment_ref(raw: &str) -> bool {
+    let t = raw.trim();
+    if t.is_empty() || t == "*" {
+        return false;
+    }
+    if regex_is_mime(t) {
+        return false;
+    }
+    let b = basename_only(t);
+    if b.is_empty() || b == "*" || b.contains("..") {
+        return false;
+    }
+    if has_attachment_ext(&b) {
+        return true;
+    }
+    if regex_is_uuid(&b) {
+        return true;
+    }
+    if b.len() >= 12
+        && b.chars().any(|c| c == '/' || c == '_' || c == '-')
+        && t.replace('\\', "/")
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '/' | '-'))
+    {
+        return true;
+    }
+    false
+}
+
+fn regex_is_mime(t: &str) -> bool {
+    // image/jpeg etc.
+    let bytes = t.as_bytes();
+    if bytes.is_empty() || !bytes[0].is_ascii_alphabetic() {
+        return false;
+    }
+    let Some(slash) = t.find('/') else {
+        return false;
+    };
+    if slash == 0 || slash + 1 >= t.len() {
+        return false;
+    }
+    t[..slash]
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '+' | '-'))
+        && t[slash + 1..]
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '+' | '-' | '/'))
+}
+
+fn regex_is_uuid(b: &str) -> bool {
+    if b.len() != 36 {
+        return false;
+    }
+    let bytes = b.as_bytes();
+    for (i, ch) in bytes.iter().enumerate() {
+        match i {
+            8 | 13 | 18 | 23 => {
+                if *ch != b'-' {
+                    return false;
+                }
+            }
+            _ => {
+                if !ch.is_ascii_hexdigit() {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+fn extract_attachment_names_from_field_value(value: &Value) -> Vec<String> {
+    let mut names = Vec::new();
+
+    fn walk(v: &Value, depth: usize, names: &mut Vec<String>) {
+        if depth > 16 {
+            return;
+        }
+        match v {
+            Value::Null => {}
+            Value::String(s) => {
+                if string_looks_like_attachment_ref(s) {
+                    let b = basename_only(s);
+                    if !b.is_empty() && !b.contains("..") {
+                        names.push(b);
+                    }
+                }
+            }
+            Value::Array(arr) => {
+                for el in arr {
+                    walk(el, depth + 1, names);
+                }
+            }
+            Value::Object(obj) => {
+                let id = obj
+                    .get("attachmentId")
+                    .and_then(|x| x.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| {
+                        obj.get("attachment_id")
+                            .and_then(|x| x.as_str())
+                            .map(str::trim)
+                            .filter(|s| !s.is_empty())
+                    });
+                if let Some(id) = id {
+                    names.push(basename_only(id));
+                }
+                if let Some(fn_) = obj.get("filename").and_then(|x| x.as_str())
+                    && !fn_.trim().is_empty()
+                {
+                    let b = basename_only(fn_);
+                    if !b.is_empty() && !b.contains("..") {
+                        names.push(b);
+                    }
+                }
+                for (k, val) in obj {
+                    if k == "filename" || k == "attachmentId" || k == "attachment_id" {
+                        continue;
+                    }
+                    walk(val, depth + 1, names);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    walk(value, 0, &mut names);
+    let mut uniq = HashSet::new();
+    names
+        .into_iter()
+        .filter(|n| !n.is_empty() && uniq.insert(n.clone()))
+        .collect()
+}
+
+fn values_at_schema_paths(data: &Value, paths: &[Vec<SchemaPathSegment>]) -> Vec<Value> {
+    let mut values = Vec::new();
+
+    fn follow(
+        current: &Value,
+        segments: &[SchemaPathSegment],
+        idx: usize,
+        values: &mut Vec<Value>,
+    ) {
+        if idx >= segments.len() {
+            values.push(current.clone());
+            return;
+        }
+        match &segments[idx] {
+            SchemaPathSegment::Each => {
+                if let Value::Array(arr) = current {
+                    for el in arr {
+                        follow(el, segments, idx + 1, values);
+                    }
+                }
+            }
+            SchemaPathSegment::Key(key) => {
+                if let Value::Object(obj) = current
+                    && let Some(next) = obj.get(key)
+                {
+                    follow(next, segments, idx + 1, values);
+                }
+            }
+        }
+    }
+
+    if !is_object(data) {
+        return values;
+    }
+    for p in paths {
+        follow(data, p, 0, &mut values);
+    }
+    values
+}
+
+pub fn referenced_attachment_names_from_schema_and_data(
+    form_schema: &Value,
+    data: &Value,
+) -> HashSet<String> {
+    let paths = collect_attachment_paths_from_schema(form_schema);
+    let mut names = HashSet::new();
+    for v in values_at_schema_paths(data, &paths) {
+        for n in extract_attachment_names_from_field_value(&v) {
+            names.insert(n);
+        }
+    }
+    names
+}
+
+pub fn referenced_attachment_names_heuristic(data: &Value) -> HashSet<String> {
+    let mut names = HashSet::new();
+
+    fn walk(v: &Value, depth: usize, names: &mut HashSet<String>) {
+        if depth > 14 {
+            return;
+        }
+        match v {
+            Value::Array(arr) => {
+                for el in arr {
+                    walk(el, depth + 1, names);
+                }
+            }
+            Value::Object(obj) => {
+                for (k, val) in obj {
+                    let kl = k.to_lowercase();
+                    if (k == "attachmentId" || kl == "attachment_id")
+                        && let Some(s) = val.as_str()
+                        && !s.trim().is_empty()
+                    {
+                        names.insert(basename_only(s));
+                    }
+                    if kl == "attachments"
+                        && let Value::Array(arr) = val
+                    {
+                        for el in arr {
+                            if let Value::Object(el_obj) = el {
+                                let id = el_obj
+                                    .get("attachmentId")
+                                    .and_then(|x| x.as_str())
+                                    .or_else(|| {
+                                        el_obj.get("attachment_id").and_then(|x| x.as_str())
+                                    })
+                                    .or_else(|| el_obj.get("id").and_then(|x| x.as_str()));
+                                if let Some(id) = id
+                                    && !id.trim().is_empty()
+                                {
+                                    names.insert(basename_only(id));
+                                }
+                                if let Some(fn_) = el_obj.get("filename").and_then(|x| x.as_str())
+                                    && !fn_.trim().is_empty()
+                                {
+                                    names.insert(basename_only(fn_));
+                                }
+                            }
+                        }
+                    }
+                    walk(val, depth + 1, names);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    walk(data, 0, &mut names);
+    names
+}
+
+/// Schema paths + heuristic (same union as TS `referencedNamesForObservation`).
+pub fn referenced_attachment_names_for_observation(
+    form_schema: Option<&Value>,
+    data: &Value,
+) -> HashSet<String> {
+    let mut names = HashSet::new();
+    if let Some(schema) = form_schema {
+        names.extend(referenced_attachment_names_from_schema_and_data(
+            schema, data,
+        ));
+    }
+    names.extend(referenced_attachment_names_heuristic(data));
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn schema_photo_path_extracts_filename() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "pic": { "type": "object", "format": "photo" }
+            }
+        });
+        let data = json!({ "pic": { "filename": "a.jpg" } });
+        let names = referenced_attachment_names_from_schema_and_data(&schema, &data);
+        assert!(names.contains("a.jpg"));
+    }
+
+    #[test]
+    fn heuristic_finds_attachment_id() {
+        let data = json!({ "x": { "attachment_id": "uuid-here-12" } });
+        let names = referenced_attachment_names_heuristic(&data);
+        assert!(names.contains("uuid-here-12"));
+    }
+}

--- a/desktop/src-tauri/src/import_validate/mod.rs
+++ b/desktop/src-tauri/src/import_validate/mod.rs
@@ -1,0 +1,532 @@
+//! Parallel import parse + JSON Schema validation + attachment reference checks.
+//!
+//! Mirrors Desktop TS `importValidation.ts` / `attachmentReferenceExtraction.ts` closely enough
+//! for import preflight (AJV with `strict: false` and `validateFormats: false`).
+
+mod attachments;
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::Arc;
+
+use jsonschema::{Draft, Validator};
+use rayon::prelude::*;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::{ApiObservation, ParsedImportFileResult, parse_import_json_file};
+
+pub use attachments::referenced_attachment_names_for_observation;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportIssue {
+    pub severity: &'static str,
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub form_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportValidateBatchResult {
+    pub files: Vec<ParsedImportFileResult>,
+    pub issues: Vec<ImportIssue>,
+    pub observation_count: usize,
+    pub form_type_count: usize,
+    pub referenced_attachment_names: Vec<String>,
+    pub missing_attachment_names: Vec<String>,
+    pub orphan_attachment_names: Vec<String>,
+}
+
+enum SchemaCompileState {
+    Ok(Arc<Validator>),
+    CompileError(String),
+    Missing,
+}
+
+/// Build reusable validators once per form type (AJV-like: formats not enforced).
+fn compile_validators(
+    form_types: &HashSet<String>,
+    schemas_by_form_type: &HashMap<String, Value>,
+) -> HashMap<String, SchemaCompileState> {
+    let mut out = HashMap::new();
+    for ft in form_types {
+        match schemas_by_form_type.get(ft) {
+            None => {
+                out.insert(ft.clone(), SchemaCompileState::Missing);
+            }
+            Some(schema) => match build_validator(schema) {
+                Ok(v) => {
+                    out.insert(ft.clone(), SchemaCompileState::Ok(Arc::new(v)));
+                }
+                Err(e) => {
+                    out.insert(ft.clone(), SchemaCompileState::CompileError(e));
+                }
+            },
+        }
+    }
+    out
+}
+
+fn build_validator(schema: &Value) -> Result<Validator, String> {
+    jsonschema::options()
+        .with_draft(Draft::Draft7)
+        .should_validate_formats(false)
+        .build(schema)
+        .map_err(|e| e.to_string())
+}
+
+fn normalize_basename(s: &str) -> String {
+    s.trim().to_lowercase()
+}
+
+fn schema_error_message(instance_path: &str, error: &str) -> String {
+    let path = if instance_path.is_empty() {
+        "(root)"
+    } else {
+        instance_path
+    };
+    format!("{path}: {error}")
+}
+
+struct FileValidateOutcome {
+    file: ParsedImportFileResult,
+    issues: Vec<ImportIssue>,
+    referenced: HashSet<String>,
+    form_types: HashSet<String>,
+    observation_count: usize,
+}
+
+fn push_observation_issues(
+    file_name: &str,
+    obs: &ApiObservation,
+    validators: &HashMap<String, SchemaCompileState>,
+    schemas_by_form_type: &HashMap<String, Value>,
+    issues: &mut Vec<ImportIssue>,
+    referenced: &mut HashSet<String>,
+    form_types: &mut HashSet<String>,
+) {
+    let ft = obs
+        .form_type
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    let schema = ft
+        .as_ref()
+        .and_then(|t| schemas_by_form_type.get(t.as_str()));
+
+    match &ft {
+        None => {
+            issues.push(ImportIssue {
+                severity: "warning",
+                code: "missing_form_type".to_string(),
+                message: format!(
+                    "Observation {} has no formType; schema validation was skipped (attachment checks use heuristics only).",
+                    obs.observation_id
+                ),
+                file_name: Some(file_name.to_string()),
+                observation_id: Some(obs.observation_id.clone()),
+                form_type: None,
+            });
+        }
+        Some(form_type) => {
+            form_types.insert(form_type.clone());
+            match validators.get(form_type) {
+                Some(SchemaCompileState::Missing) | None => {}
+                Some(SchemaCompileState::CompileError(_)) => {}
+                Some(SchemaCompileState::Ok(validator)) => {
+                    for error in validator.iter_errors(&obs.data) {
+                        let path = error.instance_path.to_string();
+                        issues.push(ImportIssue {
+                            severity: "error",
+                            code: "schema_validation".to_string(),
+                            message: format!(
+                                "{}: {}",
+                                obs.observation_id,
+                                schema_error_message(&path, &error.to_string())
+                            ),
+                            file_name: Some(file_name.to_string()),
+                            observation_id: Some(obs.observation_id.clone()),
+                            form_type: Some(form_type.clone()),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    for name in referenced_attachment_names_for_observation(schema, &obs.data) {
+        referenced.insert(name);
+    }
+}
+
+/// Parse + validate import JSON paths in parallel against preloaded form schemas.
+pub fn parse_and_validate_paths(
+    paths: Vec<String>,
+    schemas_by_form_type: &HashMap<String, Value>,
+    staged_attachment_basenames: &[String],
+) -> ImportValidateBatchResult {
+    if paths.is_empty() {
+        return ImportValidateBatchResult {
+            files: Vec::new(),
+            issues: Vec::new(),
+            observation_count: 0,
+            form_type_count: 0,
+            referenced_attachment_names: Vec::new(),
+            missing_attachment_names: Vec::new(),
+            orphan_attachment_names: Vec::new(),
+        };
+    }
+
+    // Pass 1: parallel parse (ordered).
+    let mut parsed_index: Vec<(usize, ParsedImportFileResult)> = paths
+        .par_iter()
+        .enumerate()
+        .map(|(i, raw)| {
+            let p = Path::new(raw.trim());
+            (i, parse_import_json_file(p))
+        })
+        .collect();
+    parsed_index.sort_by_key(|(i, _)| *i);
+
+    let mut form_types = HashSet::new();
+    for (_, file) in &parsed_index {
+        if file.error.is_some() {
+            continue;
+        }
+        for obs in &file.observations {
+            if let Some(ft) = obs
+                .form_type
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                form_types.insert(ft.to_string());
+            }
+        }
+    }
+
+    let validators = compile_validators(&form_types, schemas_by_form_type);
+
+    // Pass 2: parallel schema + attachment checks on already-parsed files.
+    let mut outcomes: Vec<(usize, FileValidateOutcome)> = parsed_index
+        .into_par_iter()
+        .map(|(i, file)| {
+            let mut issues = Vec::new();
+            let mut referenced = HashSet::new();
+            let mut file_form_types = HashSet::new();
+            let mut observation_count = 0usize;
+
+            if let Some(err) = &file.error {
+                issues.push(ImportIssue {
+                    severity: "error",
+                    code: "parse_file".to_string(),
+                    message: format!("{}: {err}", file.file_name),
+                    file_name: Some(file.file_name.clone()),
+                    observation_id: None,
+                    form_type: None,
+                });
+                return (
+                    i,
+                    FileValidateOutcome {
+                        file,
+                        issues,
+                        referenced,
+                        form_types: file_form_types,
+                        observation_count,
+                    },
+                );
+            }
+
+            for obs in &file.observations {
+                observation_count += 1;
+                push_observation_issues(
+                    &file.file_name,
+                    obs,
+                    &validators,
+                    schemas_by_form_type,
+                    &mut issues,
+                    &mut referenced,
+                    &mut file_form_types,
+                );
+            }
+
+            (
+                i,
+                FileValidateOutcome {
+                    file,
+                    issues,
+                    referenced,
+                    form_types: file_form_types,
+                    observation_count,
+                },
+            )
+        })
+        .collect();
+    outcomes.sort_by_key(|(i, _)| *i);
+
+    let mut files = Vec::with_capacity(outcomes.len());
+    let mut issues = Vec::new();
+    let mut all_referenced = HashSet::new();
+    let mut all_form_types = HashSet::new();
+    let mut observation_count = 0usize;
+
+    for (_, outcome) in outcomes {
+        observation_count += outcome.observation_count;
+        all_form_types.extend(outcome.form_types);
+        all_referenced.extend(outcome.referenced);
+        issues.extend(outcome.issues);
+        files.push(outcome.file);
+    }
+
+    let mut missing_schema_types: Vec<String> = all_form_types
+        .iter()
+        .filter(|ft| {
+            matches!(
+                validators.get(*ft),
+                Some(SchemaCompileState::Missing) | None
+            )
+        })
+        .cloned()
+        .collect();
+    missing_schema_types.sort();
+    for ft in missing_schema_types {
+        issues.push(ImportIssue {
+            severity: "error",
+            code: "missing_form_schema".to_string(),
+            message: format!("No form schema in the active app bundle for form type \"{ft}\"."),
+            file_name: None,
+            observation_id: None,
+            form_type: Some(ft),
+        });
+    }
+
+    let mut compile_error_types: Vec<(String, String)> = Vec::new();
+    for ft in &all_form_types {
+        if let Some(SchemaCompileState::CompileError(msg)) = validators.get(ft) {
+            compile_error_types.push((ft.clone(), msg.clone()));
+        }
+    }
+    compile_error_types.sort_by(|a, b| a.0.cmp(&b.0));
+    for (ft, msg) in compile_error_types {
+        issues.push(ImportIssue {
+            severity: "error",
+            code: "invalid_form_schema".to_string(),
+            message: format!("Could not compile JSON Schema for form type \"{ft}\": {msg}"),
+            file_name: None,
+            observation_id: None,
+            form_type: Some(ft),
+        });
+    }
+
+    let staged_norm: HashMap<String, String> = {
+        let mut m = HashMap::new();
+        for b in staged_attachment_basenames {
+            let k = normalize_basename(b);
+            if !k.is_empty() {
+                m.entry(k).or_insert_with(|| b.clone());
+            }
+        }
+        m
+    };
+
+    let mut referenced_list: Vec<String> = all_referenced.into_iter().collect();
+    referenced_list.sort();
+
+    let mut missing = Vec::new();
+    for ref_name in &referenced_list {
+        let kn = normalize_basename(ref_name);
+        if !kn.is_empty() && !staged_norm.contains_key(&kn) {
+            missing.push(ref_name.clone());
+        }
+    }
+    missing.sort();
+
+    let referenced_norm: HashSet<String> = referenced_list
+        .iter()
+        .map(|r| normalize_basename(r))
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let mut orphan: Vec<String> = staged_norm
+        .iter()
+        .filter(|(norm, _)| !referenced_norm.contains(*norm))
+        .map(|(_, display)| display.clone())
+        .collect();
+    orphan.sort();
+
+    for m in &missing {
+        issues.push(ImportIssue {
+            severity: "error",
+            code: "missing_attachment".to_string(),
+            message: format!("Referenced attachment \"{m}\" is not in the staged attachment list."),
+            file_name: None,
+            observation_id: None,
+            form_type: None,
+        });
+    }
+    for o in &orphan {
+        issues.push(ImportIssue {
+            severity: "warning",
+            code: "orphan_attachment".to_string(),
+            message: format!(
+                "Staged attachment \"{o}\" is not referenced by any staged observation payload."
+            ),
+            file_name: None,
+            observation_id: None,
+            form_type: None,
+        });
+    }
+
+    ImportValidateBatchResult {
+        files,
+        issues,
+        observation_count,
+        form_type_count: all_form_types.len(),
+        referenced_attachment_names: referenced_list,
+        missing_attachment_names: missing,
+        orphan_attachment_names: orphan,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+
+    fn write_obs(dir: &std::path::Path, name: &str, body: &str) -> String {
+        let path = dir.join(name);
+        fs::write(&path, body).unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn schema_validation_flags_type_mismatch() {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "PhotoForm".to_string(),
+            json!({
+                "type": "object",
+                "properties": {
+                    "pic": { "type": "object", "format": "photo" }
+                }
+            }),
+        );
+
+        let base =
+            std::env::temp_dir().join(format!("ode_import_validate_schema_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        let path = write_obs(
+            &base,
+            "a.json",
+            r#"{
+              "observationId": "o1",
+              "formType": "PhotoForm",
+              "updatedAt": "2026-01-01T00:00:00Z",
+              "data": { "pic": "not-an-object" }
+            }"#,
+        );
+
+        let result = parse_and_validate_paths(vec![path], &schemas, &[]);
+        assert!(
+            result.issues.iter().any(|i| i.code == "schema_validation"),
+            "issues: {:?}",
+            result.issues
+        );
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn photo_format_does_not_fail_when_formats_disabled() {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "PhotoForm".to_string(),
+            json!({
+                "type": "object",
+                "properties": {
+                    "pic": { "type": "object", "format": "photo" }
+                }
+            }),
+        );
+
+        let base =
+            std::env::temp_dir().join(format!("ode_import_validate_format_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        let path = write_obs(
+            &base,
+            "a.json",
+            r#"{
+              "observationId": "o1",
+              "formType": "PhotoForm",
+              "updatedAt": "2026-01-01T00:00:00Z",
+              "data": { "pic": { "filename": "used.jpg" } }
+            }"#,
+        );
+
+        let result = parse_and_validate_paths(vec![path], &schemas, &["used.jpg".to_string()]);
+        assert!(
+            !result.issues.iter().any(|i| i.code == "schema_validation"),
+            "issues: {:?}",
+            result.issues
+        );
+        assert!(
+            result
+                .referenced_attachment_names
+                .contains(&"used.jpg".to_string())
+        );
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn missing_and_orphan_attachments() {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "PhotoForm".to_string(),
+            json!({
+                "type": "object",
+                "properties": {
+                    "pic": { "type": "object", "format": "photo" }
+                }
+            }),
+        );
+
+        let base =
+            std::env::temp_dir().join(format!("ode_import_validate_att_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        let path = write_obs(
+            &base,
+            "a.json",
+            r#"{
+              "observationId": "o1",
+              "formType": "PhotoForm",
+              "updatedAt": "2026-01-01T00:00:00Z",
+              "data": { "pic": { "filename": "missing.jpg" } }
+            }"#,
+        );
+
+        let result = parse_and_validate_paths(vec![path], &schemas, &["orphan.jpg".to_string()]);
+        assert!(
+            result
+                .missing_attachment_names
+                .contains(&"missing.jpg".to_string())
+        );
+        assert!(
+            result
+                .orphan_attachment_names
+                .contains(&"orphan.jpg".to_string())
+        );
+        let _ = fs::remove_dir_all(&base);
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -3920,7 +3920,7 @@ fn read_host_text_file_inner(path: &Path) -> Result<String, String> {
     fs::read_to_string(path).map_err(|e| e.to_string())
 }
 
-const MAX_HOST_TEXT_BATCH_PATHS: usize = 128;
+const MAX_HOST_TEXT_BATCH_PATHS: usize = 512;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -4173,6 +4173,194 @@ fn parse_import_observation_json_paths(
     let mut indexed = indexed;
     indexed.sort_by_key(|(i, _)| *i);
     Ok(indexed.into_iter().map(|(_, r)| r).collect())
+}
+
+/// Same floor as Formulus / Desktop TS (`1980-01-01`).
+const MIN_VALID_IMPORT_SYNCED_AT_MS: i64 = 315_532_800_000;
+
+fn parse_import_timestamp_ms(raw: &str) -> Option<i64> {
+    let t = raw.trim();
+    if t.is_empty() {
+        return None;
+    }
+    if let Ok(dt) = DateTime::parse_from_rfc3339(t) {
+        return Some(dt.timestamp_millis());
+    }
+    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(t, "%Y-%m-%dT%H:%M:%S%.f") {
+        return Some(dt.and_utc().timestamp_millis());
+    }
+    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(t, "%Y-%m-%dT%H:%M:%S") {
+        return Some(dt.and_utc().timestamp_millis());
+    }
+    None
+}
+
+fn import_observation_apparently_synced(obj: &serde_json::Map<String, Value>) -> bool {
+    let synced_raw = optional_import_str(obj, "synced_at", "syncedAt");
+    let Some(synced_ms) = synced_raw.as_deref().and_then(parse_import_timestamp_ms) else {
+        return false;
+    };
+    if synced_ms <= MIN_VALID_IMPORT_SYNCED_AT_MS {
+        return false;
+    }
+    let updated_raw = optional_import_str(obj, "updated_at", "updatedAt");
+    let Some(updated_ms) = updated_raw.as_deref().and_then(parse_import_timestamp_ms) else {
+        return true;
+    };
+    updated_ms <= synced_ms
+}
+
+fn import_json_root_observation_maps(root: &Value) -> Vec<&serde_json::Map<String, Value>> {
+    match root {
+        Value::Array(a) => a.iter().filter_map(|v| v.as_object()).collect(),
+        Value::Object(map) => {
+            if let Some(Value::Array(inner)) = map.get("observations") {
+                inner.iter().filter_map(|v| v.as_object()).collect()
+            } else {
+                vec![map]
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ImportSyncAppearanceScanResult {
+    /// JSON files scanned.
+    file_count: usize,
+    observation_count: usize,
+    apparently_synced_count: usize,
+    unsynced_count: usize,
+    parse_error_count: usize,
+    /// Absolute paths to keep when skipping already-synced rows (pending + parse errors).
+    unsynced_paths: Vec<String>,
+}
+
+#[derive(Debug)]
+struct ImportFileSyncScanRow {
+    path: String,
+    observation_count: usize,
+    apparently_synced_count: usize,
+    unsynced_count: usize,
+    parse_error: bool,
+}
+
+fn scan_one_import_json_sync_appearance(path: &Path) -> ImportFileSyncScanRow {
+    let path_str = path.to_string_lossy().to_string();
+    match read_host_text_file_inner(path) {
+        Err(_) => ImportFileSyncScanRow {
+            path: path_str,
+            observation_count: 0,
+            apparently_synced_count: 0,
+            unsynced_count: 0,
+            parse_error: true,
+        },
+        Ok(text) => match serde_json::from_str::<Value>(&text) {
+            Err(_) => ImportFileSyncScanRow {
+                path: path_str,
+                observation_count: 0,
+                apparently_synced_count: 0,
+                unsynced_count: 0,
+                parse_error: true,
+            },
+            Ok(root) => {
+                let maps = import_json_root_observation_maps(&root);
+                if maps.is_empty() {
+                    return ImportFileSyncScanRow {
+                        path: path_str,
+                        observation_count: 0,
+                        apparently_synced_count: 0,
+                        unsynced_count: 0,
+                        parse_error: true,
+                    };
+                }
+                let mut synced = 0usize;
+                let mut unsynced = 0usize;
+                for obj in maps {
+                    if observation_id_from_obj(obj).is_none() {
+                        unsynced += 1;
+                        continue;
+                    }
+                    if import_observation_apparently_synced(obj) {
+                        synced += 1;
+                    } else {
+                        unsynced += 1;
+                    }
+                }
+                ImportFileSyncScanRow {
+                    path: path_str,
+                    observation_count: synced + unsynced,
+                    apparently_synced_count: synced,
+                    unsynced_count: unsynced,
+                    parse_error: false,
+                }
+            }
+        },
+    }
+}
+
+/// Lightweight parallel scan of Formulus-style `syncedAt` / `updatedAt` without shipping payloads.
+#[tauri::command]
+fn scan_import_json_sync_appearance(
+    paths: Vec<String>,
+) -> Result<ImportSyncAppearanceScanResult, String> {
+    if paths.is_empty() {
+        return Ok(ImportSyncAppearanceScanResult {
+            file_count: 0,
+            observation_count: 0,
+            apparently_synced_count: 0,
+            unsynced_count: 0,
+            parse_error_count: 0,
+            unsynced_paths: Vec::new(),
+        });
+    }
+    if paths.len() > MAX_IMPORT_SCAN_ENTRIES {
+        return Err(format!(
+            "Too many JSON paths to scan (max {MAX_IMPORT_SCAN_ENTRIES})"
+        ));
+    }
+
+    let file_count = paths.len();
+    let rows: Vec<ImportFileSyncScanRow> = paths
+        .into_par_iter()
+        .map(|raw| {
+            let p = Path::new(raw.trim());
+            scan_one_import_json_sync_appearance(p)
+        })
+        .collect();
+
+    let mut observation_count = 0usize;
+    let mut apparently_synced_count = 0usize;
+    let mut unsynced_obs = 0usize;
+    let mut parse_error_count = 0usize;
+    let mut unsynced_paths = Vec::new();
+
+    for row in rows {
+        observation_count += row.observation_count;
+        apparently_synced_count += row.apparently_synced_count;
+        unsynced_obs += row.unsynced_count;
+        if row.parse_error {
+            parse_error_count += 1;
+            unsynced_paths.push(row.path);
+        } else if row.unsynced_count > 0 {
+            // Keep the file if any observation still needs import.
+            unsynced_paths.push(row.path);
+        } else if row.apparently_synced_count == 0 {
+            // Empty / unexpected — keep for validation to report.
+            unsynced_paths.push(row.path);
+        }
+        // else: all observations apparently synced → omit from unsynced_paths
+    }
+
+    Ok(ImportSyncAppearanceScanResult {
+        file_count,
+        observation_count,
+        apparently_synced_count,
+        unsynced_count: unsynced_obs + parse_error_count,
+        parse_error_count,
+        unsynced_paths,
+    })
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -5484,6 +5672,7 @@ pub fn run() {
             copy_workspace_attachment_from_path,
             expand_import_staging_paths,
             parse_import_observation_json_paths,
+            scan_import_json_sync_appearance,
             copy_workspace_attachments_batch,
             read_host_text_file,
             host_path_is_directory,
@@ -5533,9 +5722,10 @@ mod tests {
         ATTACHMENT_COPY_PROGRESS_MIN_INTERVAL, ApiObservation, CompressionMethod,
         ObservationExtras, SimpleFileOptions, ZipArchive, ZipWriter,
         apply_app_bundle_zip_at_workspace, attachment_copy_progress_step, bind_query_params,
-        build_observation_overview, extract_observations_from_json_value, init_db,
-        mirror_custom_app_dev_folder, parse_observation_extras, parse_time,
-        publish_bundle_zip_entry_allowed, resolve_attachment_path,
+        build_observation_overview, extract_observations_from_json_value,
+        import_observation_apparently_synced, init_db, mirror_custom_app_dev_folder,
+        parse_observation_extras, parse_time, publish_bundle_zip_entry_allowed,
+        resolve_attachment_path, scan_import_json_sync_appearance,
         should_emit_attachment_copy_progress, should_mark_conflict, strip_ode_desktop_injection,
         upsert_observation_from_local_import, validate_custom_app_dev_source_folder,
         zip_dev_mirror_bundle,
@@ -5781,6 +5971,79 @@ mod tests {
         assert_eq!(extras.author.as_deref(), Some("username:device02"));
         assert_eq!(extras.tags.as_deref(), Some(&["migrated".to_string()][..]));
         assert!(extras.geolocation.is_some());
+    }
+
+    #[test]
+    fn import_observation_apparently_synced_matches_formulus_rule() {
+        let synced: serde_json::Map<String, Value> = serde_json::from_value(serde_json::json!({
+            "observationId": "a",
+            "updatedAt": "2026-08-15T11:00:00.000Z",
+            "syncedAt": "2026-08-15T12:00:00.000Z",
+        }))
+        .unwrap();
+        assert!(import_observation_apparently_synced(&synced));
+
+        let pending: serde_json::Map<String, Value> = serde_json::from_value(serde_json::json!({
+            "observationId": "b",
+            "updatedAt": "2026-08-15T13:00:00.000Z",
+            "syncedAt": "2026-08-15T12:00:00.000Z",
+        }))
+        .unwrap();
+        assert!(!import_observation_apparently_synced(&pending));
+
+        let never: serde_json::Map<String, Value> = serde_json::from_value(serde_json::json!({
+            "observationId": "c",
+            "updatedAt": "2026-08-15T13:00:00.000Z",
+            "syncedAt": null,
+        }))
+        .unwrap();
+        assert!(!import_observation_apparently_synced(&never));
+    }
+
+    #[test]
+    fn scan_import_json_sync_appearance_keeps_unsynced_paths() {
+        let base = std::env::temp_dir().join(format!(
+            "ode_import_sync_scan_{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        let synced_path = base.join("synced.json");
+        let pending_path = base.join("pending.json");
+        fs::write(
+            &synced_path,
+            r#"{
+              "observationId": "s1",
+              "formType": "t",
+              "updatedAt": "2026-01-01T00:00:00.000Z",
+              "syncedAt": "2026-01-02T00:00:00.000Z",
+              "data": {}
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            &pending_path,
+            r#"{
+              "observationId": "p1",
+              "formType": "t",
+              "updatedAt": "2026-01-03T00:00:00.000Z",
+              "syncedAt": "2026-01-02T00:00:00.000Z",
+              "data": {}
+            }"#,
+        )
+        .unwrap();
+        let result = scan_import_json_sync_appearance(vec![
+            synced_path.to_string_lossy().to_string(),
+            pending_path.to_string_lossy().to_string(),
+        ])
+        .unwrap();
+        assert_eq!(result.file_count, 2);
+        assert_eq!(result.observation_count, 2);
+        assert_eq!(result.apparently_synced_count, 1);
+        assert_eq!(result.unsynced_count, 1);
+        assert_eq!(result.unsynced_paths.len(), 1);
+        assert!(result.unsynced_paths[0].ends_with("pending.json"));
+        let _ = fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipWriter};
 
 mod data_export;
+mod import_validate;
 mod observation_index;
 mod observation_query;
 mod sync_engine;
@@ -611,13 +612,13 @@ struct SaveObservationRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct ApiObservation {
-    observation_id: String,
-    data: Value,
-    form_type: Option<String>,
-    updated_at: Option<String>,
+pub(crate) struct ApiObservation {
+    pub(crate) observation_id: String,
+    pub(crate) data: Value,
+    pub(crate) form_type: Option<String>,
+    pub(crate) updated_at: Option<String>,
     #[serde(default)]
-    extras: Option<ObservationExtras>,
+    pub(crate) extras: Option<ObservationExtras>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -948,6 +949,24 @@ fn open_db(ctx: &AppCtxHandle) -> Result<ScopedDb<'_>, CustodianError> {
         _guard: guard,
         conn,
     })
+}
+
+/// Open SQLite for long-running background work (full index rebuild) without
+/// holding `workspace_sqlite_lock` for the entire job. Holding that mutex for a
+/// multi-minute rebuild blocks every other DB command (import refresh, list,
+/// health) and makes the UI look stuck on the last "Writing observations…" step.
+///
+/// Concurrent short writers still take the mutex; this connection uses a busy
+/// timeout so rebuild waits on them instead of starving the UI.
+fn open_db_for_background_index_rebuild(ctx: &AppCtxHandle) -> Result<Connection, CustodianError> {
+    let db_path = resolve_db_path(ctx)?;
+    if let Some(parent) = db_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let conn = Connection::open(&db_path)?;
+    conn.busy_timeout(std::time::Duration::from_secs(120))?;
+    init_db(&conn)?;
+    Ok(conn)
 }
 
 /// Caller must hold `workspace_sqlite_lock`. Opens the DB, checkpoints WAL, then closes.
@@ -1913,7 +1932,7 @@ fn spawn_observation_index_rebuild(app: tauri::AppHandle, ctx: AppCtxHandle, job
         if defs.is_empty() {
             return;
         }
-        let conn = match open_db(&ctx) {
+        let conn = match open_db_for_background_index_rebuild(&ctx) {
             Ok(c) => c,
             Err(err) => {
                 emit_bundle_index_rebuild_progress(
@@ -3980,11 +3999,11 @@ fn host_path_is_directory(path: String) -> bool {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ParsedImportFileResult {
-    file_name: String,
-    observations: Vec<ApiObservation>,
+pub(crate) struct ParsedImportFileResult {
+    pub(crate) file_name: String,
+    pub(crate) observations: Vec<ApiObservation>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
+    pub(crate) error: Option<String>,
 }
 
 fn observation_id_from_obj(obj: &serde_json::Map<String, Value>) -> Option<String> {
@@ -4110,7 +4129,7 @@ fn extract_observations_from_json_value(
     Ok(observations)
 }
 
-fn parse_import_json_file(path: &Path) -> ParsedImportFileResult {
+pub(crate) fn parse_import_json_file(path: &Path) -> ParsedImportFileResult {
     let file_name = path
         .file_name()
         .and_then(|n| n.to_str())
@@ -4142,6 +4161,68 @@ fn parse_import_json_file(path: &Path) -> ParsedImportFileResult {
             },
         },
     }
+}
+
+/// Load every `schema.json` under active/dev form roots (first-wins by form type).
+fn load_bundle_form_schemas_for_ctx(ctx: &AppCtxHandle) -> Result<HashMap<String, Value>, String> {
+    let roots = bundle_form_roots_for_ctx(ctx)?;
+    let mut out = HashMap::new();
+    for root in roots {
+        let rd = match fs::read_dir(&root) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        for entry in rd {
+            let entry = entry.map_err(|e| e.to_string())?;
+            let name = entry.file_name().to_string_lossy().to_string();
+            if !entry.file_type().map_err(|e| e.to_string())?.is_dir() {
+                continue;
+            }
+            if reserved_form_dir_name(&name) {
+                continue;
+            }
+            if out.contains_key(&name) {
+                continue;
+            }
+            let schema_path = entry.path().join("schema.json");
+            let ui_path = entry.path().join("ui.json");
+            if !(schema_path.is_file() && ui_path.is_file()) {
+                continue;
+            }
+            let form_schema: Value =
+                serde_json::from_str(&fs::read_to_string(&schema_path).map_err(|e| e.to_string())?)
+                    .map_err(|e| e.to_string())?;
+            out.insert(name, form_schema);
+        }
+    }
+    Ok(out)
+}
+
+/// Parse + schema-validate import JSON on the host (Rayon), loading form schemas from the active bundle.
+#[tauri::command]
+fn parse_and_validate_import_json_paths(
+    paths: Vec<String>,
+    staged_attachment_basenames: Vec<String>,
+    ctx: tauri::State<'_, AppCtxHandle>,
+) -> Result<import_validate::ImportValidateBatchResult, String> {
+    if paths.is_empty() {
+        return Ok(import_validate::parse_and_validate_paths(
+            paths,
+            &HashMap::new(),
+            &staged_attachment_basenames,
+        ));
+    }
+    if paths.len() > MAX_IMPORT_SCAN_ENTRIES {
+        return Err(format!(
+            "Too many JSON paths to validate (max {MAX_IMPORT_SCAN_ENTRIES})"
+        ));
+    }
+    let schemas = load_bundle_form_schemas_for_ctx(&ctx)?;
+    Ok(import_validate::parse_and_validate_paths(
+        paths,
+        &schemas,
+        &staged_attachment_basenames,
+    ))
 }
 
 /// Parse observation JSON files on the host (parallel) in import order.
@@ -5360,10 +5441,11 @@ fn import_observations_run(
                 conflicts += 1;
             }
         }
-        if !index_defs.is_empty() && !mark_pending {
-            // Sync pull: update indexes incrementally per page (no full rebuild follows).
-            // Local file import: skip here — `import_observations` schedules one background
-            // full rebuild after the batch commit (incremental work would be discarded).
+        if !index_defs.is_empty() {
+            // Sync pull and local file import both update the active generation
+            // incrementally. A full rebuild is reserved for bundle apply / empty
+            // index / explicit rebuild — not for adding a few hundred import rows
+            // on top of an already-indexed sync.
             let payload = serde_json::to_string(&observation.data).map_err(|e| e.to_string())?;
             let form_type = observation.form_type.as_deref().unwrap_or("");
             observation_index::incremental_reindex(
@@ -5406,7 +5488,9 @@ fn import_observations(
     let ctx_inner = ctx.inner().clone();
     let mark = mark_pending.unwrap_or(false);
     let mut result = import_observations_run(observations, mark, &ctx_inner)?;
-    let should_schedule = schedule_index_rebuild.unwrap_or(mark) && result.imported > 0;
+    // Full rebuild is optional and off by default — import/sync maintain indexes
+    // incrementally. Callers that need a snapshot rebuild (rare) pass true.
+    let should_schedule = schedule_index_rebuild.unwrap_or(false) && result.imported > 0;
     if should_schedule {
         result.index_rebuild_scheduled =
             schedule_observation_index_rebuild(&app, &ctx_inner).is_some();
@@ -5528,12 +5612,52 @@ fn get_app_health(ctx: tauri::State<'_, AppCtxHandle>) -> Result<AppHealth, Stri
 
 /// Clears local observations, backup history, attachment files, and generation archives; resets
 /// `sync_state` to fresh-install values. Does not modify `bundles/` or app auth.
+///
+/// When `pending_only` is true, only pending-push and conflict observations (and their
+/// index/history rows) are removed, plus the outbound `attachments/pending/` queue.
+/// Synced rows and sync offsets are preserved for a continued pull.
 #[tauri::command]
-fn reset_local_workspace_data(ctx: tauri::State<'_, AppCtxHandle>) -> Result<AppHealth, String> {
+fn reset_local_workspace_data(
+    pending_only: Option<bool>,
+    ctx: tauri::State<'_, AppCtxHandle>,
+) -> Result<AppHealth, String> {
+    let pending_only = pending_only.unwrap_or(false);
     with_workspace_fs_exclusive(&ctx, |ctx| {
         let db_path = resolve_db_path(ctx)?;
         let conn = Connection::open(&db_path)?;
         init_db(&conn)?;
+
+        if pending_only {
+            conn.execute(
+                "DELETE FROM observation_history WHERE observation_id IN (
+                    SELECT id FROM observations
+                    WHERE dirty = 1 OR sync_status IN ('dirty', 'conflict')
+                )",
+                [],
+            )?;
+            conn.execute(
+                "DELETE FROM observation_index WHERE observation_id IN (
+                    SELECT id FROM observations
+                    WHERE dirty = 1 OR sync_status IN ('dirty', 'conflict')
+                )",
+                [],
+            )?;
+            conn.execute(
+                "DELETE FROM observations WHERE dirty = 1 OR sync_status IN ('dirty', 'conflict')",
+                [],
+            )?;
+            conn.execute_batch("PRAGMA wal_checkpoint(FULL);")?;
+            drop(conn);
+
+            let ws = resolve_active_workspace_dir(ctx)?;
+            let pending_dir = attachments_root(&ws).join(ATTACH_SUBDIR_PENDING);
+            if pending_dir.exists() {
+                fs::remove_dir_all(&pending_dir)?;
+            }
+            ensure_workspace_layout(&ws)?;
+            return Ok(());
+        }
+
         conn.execute("DELETE FROM observation_history", [])?;
         conn.execute("DELETE FROM observations", [])?;
         conn.execute("DELETE FROM observation_index", [])?;
@@ -5672,6 +5796,7 @@ pub fn run() {
             copy_workspace_attachment_from_path,
             expand_import_staging_paths,
             parse_import_observation_json_paths,
+            parse_and_validate_import_json_paths,
             scan_import_json_sync_appearance,
             copy_workspace_attachments_batch,
             read_host_text_file,
@@ -6002,10 +6127,8 @@ mod tests {
 
     #[test]
     fn scan_import_json_sync_appearance_keeps_unsynced_paths() {
-        let base = std::env::temp_dir().join(format!(
-            "ode_import_sync_scan_{}",
-            std::process::id()
-        ));
+        let base =
+            std::env::temp_dir().join(format!("ode_import_sync_scan_{}", std::process::id()));
         let _ = fs::remove_dir_all(&base);
         fs::create_dir_all(&base).unwrap();
         let synced_path = base.join("synced.json");

--- a/desktop/src-tauri/src/observation_index.rs
+++ b/desktop/src-tauri/src/observation_index.rs
@@ -1,10 +1,14 @@
 //! Local observation_index EAV table (never synced) + snapshot generation rebuild.
 
+use rayon::prelude::*;
 use rusqlite::{Connection, params};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::path::Path;
+
+/// Observations loaded / parsed per parallel chunk during a full rebuild.
+const REBUILD_MAP_CHUNK_SIZE: usize = 512;
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -85,14 +89,74 @@ fn form_type_matches(form_type: &str, patterns: Option<&Vec<String>>) -> bool {
     false
 }
 
-fn json_path_to_key(path: &str) -> String {
-    path.strip_prefix("$.").unwrap_or(path).to_string()
+fn json_path_to_key(path: &str) -> &str {
+    path.strip_prefix("$.").unwrap_or(path)
 }
 
-fn extract_scalar(payload: &str, path: &str) -> Option<Value> {
-    let v: Value = serde_json::from_str(payload).ok()?;
-    let key = json_path_to_key(path);
-    v.get(&key).cloned()
+#[derive(Debug, Clone)]
+struct IndexRow {
+    observation_id: String,
+    index_key: String,
+    value_text: Option<String>,
+    value_num: Option<f64>,
+}
+
+/// Parse payload once and emit every matching EAV row (CPU-bound map step).
+fn extract_index_rows(
+    observation_id: &str,
+    form_type: &str,
+    payload: &str,
+    defs: &[ObservationIndexDef],
+) -> Vec<IndexRow> {
+    let Ok(v) = serde_json::from_str::<Value>(payload) else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(defs.len());
+    for def in defs {
+        if !form_type_matches(form_type, def.form_types.as_ref()) {
+            continue;
+        }
+        let Some(val) = v.get(json_path_to_key(&def.path)) else {
+            continue;
+        };
+        if val.is_null() {
+            continue;
+        }
+        let (value_text, value_num) = scalar_to_columns(val, def.value_type.as_deref());
+        out.push(IndexRow {
+            observation_id: observation_id.to_string(),
+            index_key: def.key.clone(),
+            value_text,
+            value_num,
+        });
+    }
+    out
+}
+
+fn insert_index_rows(
+    conn: &Connection,
+    generation: i64,
+    rows: &[IndexRow],
+) -> rusqlite::Result<()> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    // Full rebuild clears the target generation first; INSERT (not OR REPLACE) is fine
+    // and cheaper. Incremental reindex deletes the observation's rows first as well.
+    let mut stmt = conn.prepare(
+        "INSERT INTO observation_index (observation_id, index_key, index_generation, value_text, value_num)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+    )?;
+    for row in rows {
+        stmt.execute(params![
+            row.observation_id,
+            row.index_key,
+            generation,
+            row.value_text,
+            row.value_num,
+        ])?;
+    }
+    Ok(())
 }
 
 pub fn reindex_observation(
@@ -107,24 +171,8 @@ pub fn reindex_observation(
         "DELETE FROM observation_index WHERE observation_id = ?1 AND index_generation = ?2",
         params![observation_id, generation],
     )?;
-    for def in defs {
-        if !form_type_matches(form_type, def.form_types.as_ref()) {
-            continue;
-        }
-        let Some(val) = extract_scalar(payload, &def.path) else {
-            continue;
-        };
-        if val.is_null() {
-            continue;
-        }
-        let (value_text, value_num) = scalar_to_columns(&val, def.value_type.as_deref());
-        conn.execute(
-            "INSERT OR REPLACE INTO observation_index (observation_id, index_key, index_generation, value_text, value_num)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![observation_id, def.key, generation, value_text, value_num],
-        )?;
-    }
-    Ok(())
+    let rows = extract_index_rows(observation_id, form_type, payload, defs);
+    insert_index_rows(conn, generation, &rows)
 }
 
 fn scalar_to_columns(val: &Value, value_type: Option<&str>) -> (Option<String>, Option<f64>) {
@@ -174,15 +222,6 @@ pub fn rebuild_all_indexes(
         cb(0, total, Some("Indexing observations…"));
     }
 
-    let mut stmt = conn.prepare("SELECT id, form_type, payload FROM observations")?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, Option<String>>(1)?,
-            row.get::<_, String>(2)?,
-        ))
-    })?;
-
     let progress_interval = if total < 50 {
         1
     } else if total < 500 {
@@ -191,23 +230,59 @@ pub fn rebuild_all_indexes(
         50
     };
 
+    // Map-join rebuild:
+    // 1. Load observation triples (desktop-scale; typically tens of thousands).
+    // 2. Parallel map: parse each payload once and extract all EAV rows.
+    // 3. Join: batch INSERT in one transaction (avoids per-row autocommit).
+    let observations: Vec<(String, String, String)> = {
+        let mut stmt = conn.prepare("SELECT id, form_type, payload FROM observations")?;
+        let mapped = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                row.get::<_, String>(2)?,
+            ))
+        })?;
+        mapped.collect::<rusqlite::Result<Vec<_>>>()?
+    };
+
+    // Drop secondary indexes for the bulk load; recreate after commit.
+    conn.execute_batch(
+        r#"
+        DROP INDEX IF EXISTS idx_observation_index_lookup;
+        DROP INDEX IF EXISTS idx_observation_index_lookup_num;
+        "#,
+    )?;
+
+    let tx = conn.unchecked_transaction()?;
     let mut done = 0i64;
-    for row in rows {
-        let (id, form_type, payload) = row?;
-        let ft = form_type.unwrap_or_default();
-        reindex_observation(conn, &id, &ft, &payload, defs, new_gen)?;
-        done += 1;
+    for chunk in observations.chunks(REBUILD_MAP_CHUNK_SIZE) {
+        let mapped: Vec<IndexRow> = chunk
+            .par_iter()
+            .flat_map(|(id, ft, payload)| extract_index_rows(id, ft, payload, defs))
+            .collect();
+        insert_index_rows(&tx, new_gen, &mapped)?;
+        done += chunk.len() as i64;
         if let Some(ref mut cb) = progress
             && (total == 0 || done == total || done % progress_interval == 0)
         {
             cb(done, total, Some("Indexing observations…"));
         }
     }
+    tx.commit()?;
 
     if let Some(ref mut cb) = progress {
         cb(done, total, Some("Creating SQLite indexes…"));
     }
 
+    conn.execute_batch(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_observation_index_lookup
+            ON observation_index(index_generation, index_key, value_text, observation_id);
+        CREATE INDEX IF NOT EXISTS idx_observation_index_lookup_num
+            ON observation_index(index_generation, index_key, value_num, observation_id);
+        "#,
+    )?;
     recreate_sqlite_indexes(conn, defs)?;
 
     conn.execute(
@@ -468,6 +543,41 @@ mod tests {
             )
             .unwrap();
         assert_eq!(rows, 1);
+    }
+
+    #[test]
+    fn rebuild_map_join_indexes_many_observations() {
+        let conn = test_conn();
+        let defs = sample_defs();
+        for i in 0..1200 {
+            conn.execute(
+                "INSERT INTO observations (id, form_type, payload) VALUES (?1, 'person', ?2)",
+                params![
+                    format!("obs{i}"),
+                    format!(r#"{{"p_id":"P{i}","age":{}}}"#, i % 80)
+                ],
+            )
+            .unwrap();
+        }
+        let generation = rebuild_all_indexes(&conn, &defs, None).unwrap();
+        assert_eq!(generation, 2);
+        let rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM observation_index WHERE index_generation = 2",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        // Each person has p_id + age
+        assert_eq!(rows, 2400);
+        let lookup_ok: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_observation_index_lookup'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(lookup_ok, 1);
     }
 
     #[test]

--- a/desktop/src-tauri/src/observation_query.rs
+++ b/desktop/src-tauri/src/observation_query.rs
@@ -291,6 +291,23 @@ fn compile_json_extract(
         }
     };
     let p = push_param(params, value);
+
+    // A numeric comparison has to match the indexed path, which compares against
+    // `value_num` and therefore only ever considers values that are JSON numbers.
+    // SQLite orders by storage class rather than coercing, so `'abc' > 5` is true
+    // and every text value would otherwise satisfy a numeric filter here. This
+    // fallback is what `query_observations` switches to when the index is
+    // unusable, so the two paths have to return the same rows.
+    //
+    // json_type rather than typeof(json_extract(...)): JSON `true` extracts as
+    // the integer 1, so typeof would admit booleans that the index stores as text.
+    if value.is_number() {
+        let type_expr = format!("json_type(o.payload, '{json_path}')");
+        return Ok(format!(
+            "({type_expr} IN ('integer','real') AND {expr} {sql_op} {p})"
+        ));
+    }
+
     Ok(format!("{expr} {sql_op} {p}"))
 }
 

--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -1278,6 +1278,16 @@ textarea {
   flex-wrap: wrap;
 }
 
+.app-sync-banner-text {
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.app-sync-banner-save-report {
+  flex-shrink: 0;
+  align-self: center;
+}
+
 .activity-progress {
   flex: 1 1 100%;
   height: 4px;

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -60,6 +60,15 @@ vi.mock('./lib/tauriClient', () => ({
     writeWorkspaceAttachment: vi.fn(),
     copyWorkspaceAttachmentFromPath: vi.fn(),
     expandImportStagingPaths: vi.fn().mockResolvedValue([]),
+    parseImportObservationJsonPaths: vi.fn().mockResolvedValue([]),
+    scanImportJsonSyncAppearance: vi.fn().mockResolvedValue({
+      fileCount: 0,
+      observationCount: 0,
+      apparentlySyncedCount: 0,
+      unsyncedCount: 0,
+      parseErrorCount: 0,
+      unsyncedPaths: [],
+    }),
     readHostTextFile: vi.fn().mockResolvedValue('{}'),
     readHostTextFilesBatch: vi.fn().mockImplementation((paths: string[]) =>
       Promise.resolve(

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -61,6 +61,15 @@ vi.mock('./lib/tauriClient', () => ({
     copyWorkspaceAttachmentFromPath: vi.fn(),
     expandImportStagingPaths: vi.fn().mockResolvedValue([]),
     parseImportObservationJsonPaths: vi.fn().mockResolvedValue([]),
+    parseAndValidateImportJsonPaths: vi.fn().mockResolvedValue({
+      files: [],
+      issues: [],
+      observationCount: 0,
+      formTypeCount: 0,
+      referencedAttachmentNames: [],
+      missingAttachmentNames: [],
+      orphanAttachmentNames: [],
+    }),
     scanImportJsonSyncAppearance: vi.fn().mockResolvedValue({
       fileCount: 0,
       observationCount: 0,

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -40,6 +40,7 @@ import {
   ensureBundleApplyEventPipeline,
   installGlobalIndexRebuildListener,
 } from './lib/bundleTauriEvents';
+import { tauriClient } from './lib/tauriClient';
 import './App.css';
 
 const DATA_NAV = [
@@ -222,6 +223,7 @@ function Shell() {
   const isWorkbench = location.pathname.startsWith('/workbench');
   const navItems = isWorkbench ? WORKBENCH_NAV : DATA_NAV;
   const syncMessage = useCustodianStore(s => s.syncMessage);
+  const syncDetailReport = useCustodianStore(s => s.syncDetailReport);
   const clearSyncMessage = useCustodianStore(s => s.clearSyncMessage);
   const pushToast = useToastStore(s => s.pushToast);
   const syncActivity = useCustodianStore(selectSyncActivity);
@@ -276,13 +278,18 @@ function Shell() {
     if (!syncMessage) {
       return;
     }
-    const isLong = syncMessage.includes('\n') || syncMessage.length > 120;
-    if (isLong) {
+    // Keep the banner when a downloadable detail report is attached, or when
+    // the message is long (multi-line / verbose).
+    const keepBanner =
+      Boolean(syncDetailReport) ||
+      syncMessage.includes('\n') ||
+      syncMessage.length > 120;
+    if (keepBanner) {
       return;
     }
     pushToast({ message: syncMessage, variant: 'success' });
     clearSyncMessage();
-  }, [syncMessage, pushToast, clearSyncMessage]);
+  }, [syncMessage, syncDetailReport, pushToast, clearSyncMessage]);
 
   const showActivityBanner =
     Boolean(activityText) && activityPresent && !activityBannerDismissed;
@@ -290,7 +297,33 @@ function Shell() {
   const showSyncMessageBanner =
     Boolean(syncMessage) &&
     syncMessage !== null &&
-    (syncMessage.includes('\n') || syncMessage.length > 120);
+    (Boolean(syncDetailReport) ||
+      syncMessage.includes('\n') ||
+      syncMessage.length > 120);
+
+  async function saveSyncDetailReport() {
+    if (!syncDetailReport) {
+      return;
+    }
+    try {
+      const { save } = await import('@tauri-apps/plugin-dialog');
+      const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-');
+      const path = await save({
+        defaultPath: `ode-push-attachment-report-${stamp}.txt`,
+        filters: [{ name: 'Text', extensions: ['txt'] }],
+      });
+      if (path == null) {
+        return;
+      }
+      await tauriClient.writeTextFile(path, syncDetailReport);
+      pushToast({ message: 'Report saved.', variant: 'success' });
+    } catch (e) {
+      pushToast({
+        message: e instanceof Error ? e.message : String(e),
+        variant: 'error',
+      });
+    }
+  }
 
   return (
     <>
@@ -372,7 +405,20 @@ function Shell() {
             ) : null}
             {showSyncMessageBanner ? (
               <div className="notice success app-sync-banner app-sync-banner-with-dismiss">
-                <div className="app-sync-banner-body">{syncMessage}</div>
+                <div className="app-sync-banner-body">
+                  <span className="app-sync-banner-text">{syncMessage}</span>
+                  {syncDetailReport ? (
+                    <button
+                      type="button"
+                      className="secondary btn-icon app-sync-banner-save-report"
+                      onClick={() => void saveSyncDetailReport()}>
+                      <span className="material-symbols-outlined" aria-hidden>
+                        download
+                      </span>
+                      Save report
+                    </button>
+                  ) : null}
+                </div>
                 <button
                   type="button"
                   className="app-sync-banner-dismiss"

--- a/desktop/src/components/ForcePushMissingAttachmentsDialog.tsx
+++ b/desktop/src/components/ForcePushMissingAttachmentsDialog.tsx
@@ -24,9 +24,9 @@ export function ForcePushMissingAttachmentsDialog({
   }
 
   return (
-    <div className="modal-backdrop" role="presentation">
+    <div className="modal-overlay" role="presentation">
       <div
-        className="modal-card"
+        className="card modal-card"
         role="dialog"
         aria-modal="true"
         aria-labelledby="force-push-title">

--- a/desktop/src/components/ResetLocalDataDialog.tsx
+++ b/desktop/src/components/ResetLocalDataDialog.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+
+export type ResetLocalDataChoice = {
+  pendingOnly: boolean;
+};
+
+export function ResetLocalDataDialog({
+  open,
+  dirtyCount,
+  conflictCount,
+  onChoice,
+}: {
+  open: boolean;
+  dirtyCount: number;
+  conflictCount: number;
+  onChoice: (choice: ResetLocalDataChoice | null) => void;
+}) {
+  const [pendingOnly, setPendingOnly] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setPendingOnly(false);
+    }
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  const pendingLabel =
+    dirtyCount + conflictCount > 0
+      ? ` (${dirtyCount} pending push · ${conflictCount} conflict${conflictCount === 1 ? '' : 's'})`
+      : '';
+
+  return (
+    <div className="modal-overlay" role="presentation">
+      <div
+        className="card modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="reset-local-data-title">
+        <h3 id="reset-local-data-title">Reset local data</h3>
+        <p className="muted">
+          By default this removes <strong>all</strong> observations and
+          attachment files from this device and resets sync offsets.
+        </p>
+        <label className="field-row-checkbox">
+          <input
+            type="checkbox"
+            checked={pendingOnly}
+            onChange={e => setPendingOnly(e.target.checked)}
+          />
+          <span>Reset only pending observations{pendingLabel}</span>
+        </label>
+        {pendingOnly ? (
+          <p className="muted">
+            Deletes pending-push and conflict rows only. Synced observations and
+            sync offsets stay so the next pull can continue without
+            re-downloading everything.
+          </p>
+        ) : (
+          <p className="muted">
+            Full reset: clears the local repository and attachment files. The
+            next pull starts from empty offsets.
+          </p>
+        )}
+        <div className="button-row">
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => onChoice(null)}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="secondary danger"
+            onClick={() => onChoice({ pendingOnly })}>
+            Reset
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/hooks/useProfileAutoSynkAuth.ts
+++ b/desktop/src/hooks/useProfileAutoSynkAuth.ts
@@ -7,6 +7,9 @@ import {
 /**
  * Silent sign-in on profile change (refresh token or keyring password), matching Sync page behavior.
  * Uses {@link recoverActiveProfileAuth} so expired stored tokens are renewed, not reused blindly.
+ *
+ * `authBlocked` is true when recovery failed — even if a stale session remains in localStorage —
+ * so UI must not claim "Authenticated" from session presence alone.
  */
 export function useProfileAutoSynkAuth(activeProfileId: string | undefined) {
   const authSession = useCustodianStore(selectAuthSessionForActiveProfile);
@@ -14,22 +17,37 @@ export function useProfileAutoSynkAuth(activeProfileId: string | undefined) {
     s => s.recoverActiveProfileAuth,
   );
   const [authBlocked, setAuthBlocked] = useState(false);
+  /** False until the first recover attempt for the current profile finishes. */
+  const [authReady, setAuthReady] = useState(false);
 
   const refreshAuth = useCallback(async (): Promise<boolean> => {
+    setAuthReady(false);
     const ok = await recoverActiveProfileAuth();
-    setAuthBlocked(
-      !ok && !selectAuthSessionForActiveProfile(useCustodianStore.getState()),
-    );
+    setAuthBlocked(!ok);
+    setAuthReady(true);
     return ok;
   }, [recoverActiveProfileAuth]);
 
   useEffect(() => {
-    void refreshAuth();
-  }, [activeProfileId, refreshAuth]);
+    let cancelled = false;
+    setAuthReady(false);
+    setAuthBlocked(false);
+    void (async () => {
+      const ok = await recoverActiveProfileAuth();
+      if (cancelled) {
+        return;
+      }
+      setAuthBlocked(!ok);
+      setAuthReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeProfileId, recoverActiveProfileAuth]);
 
   const ensureAuth = useCallback(async (): Promise<boolean> => {
     return refreshAuth();
   }, [refreshAuth]);
 
-  return { authSession, authBlocked, ensureAuth, refreshAuth };
+  return { authSession, authBlocked, authReady, ensureAuth, refreshAuth };
 }

--- a/desktop/src/lib/importSummary.test.ts
+++ b/desktop/src/lib/importSummary.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   extractObservationsFromJson,
+  isImportObservationApparentlySynced,
+  partitionImportObservationsBySyncAppearance,
   summarizeImportFiles,
   type ParsedObservationFile,
 } from './importSummary';
+import type { ApiObservation } from '../types/domain';
 
 describe('extractObservationsFromJson', () => {
   it('parses Synkronus-style snake_case object', () => {
@@ -104,5 +107,89 @@ describe('summarizeImportFiles', () => {
     expect(s.observationCount).toBe(2);
     expect(s.formTypeCount).toBe(2);
     expect(s.attachmentHintCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('isImportObservationApparentlySynced', () => {
+  const base: ApiObservation = {
+    observationId: 'o1',
+    data: {},
+    updatedAt: '2026-08-15T12:00:00.000Z',
+  };
+
+  it('is false when syncedAt is missing or null', () => {
+    expect(isImportObservationApparentlySynced(base)).toBe(false);
+    expect(
+      isImportObservationApparentlySynced({
+        ...base,
+        extras: { syncedAt: null },
+      }),
+    ).toBe(false);
+  });
+
+  it('is true when updatedAt is at or before syncedAt', () => {
+    expect(
+      isImportObservationApparentlySynced({
+        ...base,
+        extras: { syncedAt: '2026-08-15T12:00:00.000Z' },
+      }),
+    ).toBe(true);
+    expect(
+      isImportObservationApparentlySynced({
+        ...base,
+        updatedAt: '2026-08-15T11:00:00.000Z',
+        extras: { syncedAt: '2026-08-15T12:00:00.000Z' },
+      }),
+    ).toBe(true);
+  });
+
+  it('is false when updated after syncedAt (pending local edit)', () => {
+    expect(
+      isImportObservationApparentlySynced({
+        ...base,
+        updatedAt: '2026-08-15T13:00:00.000Z',
+        extras: { syncedAt: '2026-08-15T12:00:00.000Z' },
+      }),
+    ).toBe(false);
+  });
+
+  it('ignores placeholder syncedAt before 1980', () => {
+    expect(
+      isImportObservationApparentlySynced({
+        ...base,
+        extras: { syncedAt: '1970-01-01T00:00:00.000Z' },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('partitionImportObservationsBySyncAppearance', () => {
+  it('splits synced vs unsynced rows', () => {
+    const rows: ApiObservation[] = [
+      {
+        observationId: 'synced',
+        data: {},
+        updatedAt: '2026-01-01T00:00:00Z',
+        extras: { syncedAt: '2026-01-02T00:00:00Z' },
+      },
+      {
+        observationId: 'pending',
+        data: {},
+        updatedAt: '2026-01-03T00:00:00Z',
+        extras: { syncedAt: '2026-01-02T00:00:00Z' },
+      },
+      {
+        observationId: 'never',
+        data: {},
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ];
+    const part = partitionImportObservationsBySyncAppearance(rows);
+    expect(part.total).toBe(3);
+    expect(part.apparentlySynced.map(o => o.observationId)).toEqual(['synced']);
+    expect(part.unsynced.map(o => o.observationId)).toEqual([
+      'pending',
+      'never',
+    ]);
   });
 });

--- a/desktop/src/lib/importSummary.ts
+++ b/desktop/src/lib/importSummary.ts
@@ -323,7 +323,9 @@ export async function parseObservationJsonFromPaths(
   return out;
 }
 
-const RUST_PARSE_CHUNK = 128;
+const RUST_PARSE_CHUNK = 512;
+/** Overlapping IPC batches while each batch still parses in parallel on the host. */
+const RUST_PARSE_CONCURRENCY = 3;
 
 /**
  * Read and parse observation JSON via Rust (parallel per chunk). Preserves file order.
@@ -336,27 +338,34 @@ export async function parseObservationJsonPathsViaRust(
   if (total === 0) {
     return [];
   }
-  const out: ParsedObservationFile[] = [];
+  const chunks: { name: string; nativePath: string }[][] = [];
   for (let i = 0; i < total; i += RUST_PARSE_CHUNK) {
-    const chunk = items.slice(i, i + RUST_PARSE_CHUNK);
-    const paths = chunk.map(c => c.nativePath);
-    const rows = await tauriClient.parseImportObservationJsonPaths(paths);
-    if (rows.length !== chunk.length) {
-      throw new Error(
-        `parseImportObservationJsonPaths returned ${rows.length} rows, expected ${chunk.length}`,
-      );
-    }
-    for (let j = 0; j < chunk.length; j++) {
-      const r = rows[j]!;
-      out.push({
+    chunks.push(items.slice(i, i + RUST_PARSE_CHUNK));
+  }
+
+  let done = 0;
+  const chunkResults = await mapPool(
+    chunks,
+    RUST_PARSE_CONCURRENCY,
+    async chunk => {
+      const paths = chunk.map(c => c.nativePath);
+      const rows = await tauriClient.parseImportObservationJsonPaths(paths);
+      if (rows.length !== chunk.length) {
+        throw new Error(
+          `parseImportObservationJsonPaths returned ${rows.length} rows, expected ${chunk.length}`,
+        );
+      }
+      done += chunk.length;
+      onBatchProgress?.(Math.min(done, total), total);
+      return rows.map(r => ({
         fileName: r.fileName,
         observations: r.observations,
         error: r.error,
-      });
-    }
-    onBatchProgress?.(Math.min(i + chunk.length, total), total);
-  }
-  return out;
+      }));
+    },
+  );
+
+  return chunkResults.flat();
 }
 
 export function flattenObservations(

--- a/desktop/src/lib/importSummary.ts
+++ b/desktop/src/lib/importSummary.ts
@@ -368,3 +368,62 @@ export function flattenObservations(
   }
   return out;
 }
+
+/**
+ * Ignore null / placeholder syncedAt values (same floor as Formulus
+ * `MIN_VALID_SYNCED_AT_MS` in observationSyncStatus.ts).
+ */
+export const MIN_VALID_IMPORT_SYNCED_AT_MS = new Date('1980-01-01').getTime();
+
+function parseImportTimestampMs(raw: string | null | undefined): number | null {
+  if (raw == null || !raw.trim()) {
+    return null;
+  }
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * True when Formulus-style export metadata says the observation was fully
+ * synced (`syncedAt` set and `updatedAt <= syncedAt`). Used to offer skipping
+ * already-synced rows during hail-mary device exports.
+ */
+export function isImportObservationApparentlySynced(
+  observation: ApiObservation,
+): boolean {
+  const syncedMs = parseImportTimestampMs(observation.extras?.syncedAt ?? null);
+  if (syncedMs == null || syncedMs <= MIN_VALID_IMPORT_SYNCED_AT_MS) {
+    return false;
+  }
+  const updatedMs = parseImportTimestampMs(observation.updatedAt ?? null);
+  if (updatedMs == null) {
+    return true;
+  }
+  return updatedMs <= syncedMs;
+}
+
+export interface ImportSyncAppearancePartition {
+  total: number;
+  apparentlySynced: ApiObservation[];
+  unsynced: ApiObservation[];
+}
+
+/** Split flattened import rows by Formulus sync appearance (`syncedAt`). */
+export function partitionImportObservationsBySyncAppearance(
+  observations: readonly ApiObservation[],
+): ImportSyncAppearancePartition {
+  const apparentlySynced: ApiObservation[] = [];
+  const unsynced: ApiObservation[] = [];
+  for (const obs of observations) {
+    if (isImportObservationApparentlySynced(obs)) {
+      apparentlySynced.push(obs);
+    } else {
+      unsynced.push(obs);
+    }
+  }
+  return {
+    total: observations.length,
+    apparentlySynced,
+    unsynced,
+  };
+}

--- a/desktop/src/lib/importSummary.ts
+++ b/desktop/src/lib/importSummary.ts
@@ -1,6 +1,7 @@
 import type {
   ApiObservation,
   HostTextReadResult,
+  ImportHostIssue,
   ObservationExtras,
 } from '../types/domain';
 import { tauriClient } from './tauriClient';
@@ -366,6 +367,41 @@ export async function parseObservationJsonPathsViaRust(
   );
 
   return chunkResults.flat();
+}
+
+/**
+ * Host-side parallel parse + schema/attachment validation for the full staged set.
+ * Prefer this over parse-then-AJV for large imports.
+ */
+export async function parseAndValidateImportJsonViaRust(
+  items: readonly { name: string; nativePath: string }[],
+  stagedAttachmentBasenames: readonly string[],
+): Promise<{
+  parsedFiles: ParsedObservationFile[];
+  issues: ImportHostIssue[];
+  observationCount: number;
+  formTypeCount: number;
+  referencedAttachmentNames: string[];
+  missingAttachmentNames: string[];
+  orphanAttachmentNames: string[];
+}> {
+  const paths = items.map(it => it.nativePath);
+  const result = await tauriClient.parseAndValidateImportJsonPaths(paths, [
+    ...stagedAttachmentBasenames,
+  ]);
+  return {
+    parsedFiles: result.files.map(r => ({
+      fileName: r.fileName,
+      observations: r.observations,
+      error: r.error,
+    })),
+    issues: result.issues,
+    observationCount: result.observationCount,
+    formTypeCount: result.formTypeCount,
+    referencedAttachmentNames: result.referencedAttachmentNames,
+    missingAttachmentNames: result.missingAttachmentNames,
+    orphanAttachmentNames: result.orphanAttachmentNames,
+  };
 }
 
 export function flattenObservations(

--- a/desktop/src/lib/pushAttachmentAudit.test.ts
+++ b/desktop/src/lib/pushAttachmentAudit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatMissingAttachmentHighlight,
+  formatMissingAttachmentReport,
+  type MissingAttachmentIssue,
+} from './pushAttachmentAudit';
+
+const sample: MissingAttachmentIssue[] = [
+  {
+    id: 'obs_1',
+    formType: 'p_consent',
+    missing: ['a.jpg', 'a'],
+  },
+  {
+    id: 'obs_2',
+    formType: 'p_consent',
+    missing: ['b.jpg'],
+  },
+];
+
+describe('formatMissingAttachmentHighlight', () => {
+  it('stays short for forced and skipped modes', () => {
+    const forced = formatMissingAttachmentHighlight(sample, 'forced');
+    const skipped = formatMissingAttachmentHighlight(sample, 'skipped');
+    expect(forced).toContain('Included 2 observations');
+    expect(forced).toContain('(forced)');
+    expect(forced).not.toContain('obs_1');
+    expect(skipped).toContain('Skipped 2 observations');
+    expect(skipped).not.toContain('a.jpg');
+    expect(forced.length).toBeLessThan(120);
+    expect(skipped.length).toBeLessThan(120);
+  });
+});
+
+describe('formatMissingAttachmentReport', () => {
+  it('includes full per-observation detail for download', () => {
+    const report = formatMissingAttachmentReport(sample, 'forced');
+    expect(report).toContain('forced inclusion');
+    expect(report).toContain('obs_1 (form: p_consent)');
+    expect(report).toContain('- a.jpg');
+    expect(report).toContain('obs_2 (form: p_consent)');
+  });
+});

--- a/desktop/src/lib/pushAttachmentAudit.ts
+++ b/desktop/src/lib/pushAttachmentAudit.ts
@@ -105,3 +105,51 @@ export function formatMissingAttachmentSummary(
     )
     .join('\n');
 }
+
+/** One-line UI highlight (no per-observation dump). */
+export function formatMissingAttachmentHighlight(
+  issues: MissingAttachmentIssue[],
+  mode: 'skipped' | 'forced',
+): string {
+  if (issues.length === 0) {
+    return '';
+  }
+  const n = issues.length;
+  const noun = n === 1 ? 'observation' : 'observations';
+  if (mode === 'forced') {
+    return ` Included ${n} ${noun} with missing attachment(s) (forced).`;
+  }
+  return ` Skipped ${n} ${noun} with missing attachment file(s).`;
+}
+
+/** Full multi-line report suitable for saving to a text file. */
+export function formatMissingAttachmentReport(
+  issues: MissingAttachmentIssue[],
+  mode: 'skipped' | 'forced',
+  meta?: { headline?: string },
+): string {
+  const lines: string[] = [];
+  lines.push('ODE Desktop — push attachment report');
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push(
+    `Mode: ${mode === 'forced' ? 'forced inclusion' : 'skipped from push'}`,
+  );
+  if (meta?.headline?.trim()) {
+    lines.push('');
+    lines.push(meta.headline.trim());
+  }
+  lines.push('');
+  lines.push(
+    `Summary: ${issues.length} observation(s) with missing attachment file(s).`,
+  );
+  lines.push('');
+  lines.push('Details:');
+  for (const issue of issues) {
+    lines.push(`${issue.id} (form: ${issue.formType})`);
+    for (const name of issue.missing) {
+      lines.push(`  - ${name}`);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}

--- a/desktop/src/lib/tauriClient.ts
+++ b/desktop/src/lib/tauriClient.ts
@@ -10,6 +10,7 @@ import type {
   ImportResult,
   ImportStagingScanEntry,
   ImportSyncAppearanceScanResult,
+  ImportValidateBatchResult,
   ParsedImportFileResult,
   AttachmentCopyBatchResult,
   HostTextReadResult,
@@ -156,6 +157,18 @@ export const tauriClient = {
       'parse_import_observation_json_paths',
       { paths },
     ),
+  /** Parallel host parse + JSON Schema / attachment validation (loads bundle schemas once). */
+  parseAndValidateImportJsonPaths: (
+    paths: string[],
+    stagedAttachmentBasenames: string[],
+  ) =>
+    invokeSafe<ImportValidateBatchResult>(
+      'parse_and_validate_import_json_paths',
+      {
+        paths,
+        stagedAttachmentBasenames,
+      },
+    ),
   scanImportJsonSyncAppearance: (paths: string[]) =>
     invokeSafe<ImportSyncAppearanceScanResult>(
       'scan_import_json_sync_appearance',
@@ -289,8 +302,8 @@ export const tauriClient = {
   /**
    * @param markPending When true (file import), observations are stored as pending push.
    *   When false/omitted, rows match server pull semantics (synced / conflict rules).
-   * @param scheduleIndexRebuild When false, skips the post-import full index rebuild (use on
-   *   intermediate write batches; default true for file import, false for server pull).
+   * @param scheduleIndexRebuild When true, schedules a full background index rebuild
+   *   after the write. Default false — import and sync update indexes incrementally.
    */
   importObservations: (
     observations: ApiObservation[],
@@ -304,8 +317,10 @@ export const tauriClient = {
   markObservationsPushed: (ids: string[]) =>
     invokeSafe<void>('mark_observations_pushed', { ids }),
   getAppHealth: () => invokeSafe<AppHealth>('get_app_health'),
-  resetLocalWorkspaceData: () =>
-    invokeSafe<AppHealth>('reset_local_workspace_data'),
+  resetLocalWorkspaceData: (options?: { pendingOnly?: boolean }) =>
+    invokeSafe<AppHealth>('reset_local_workspace_data', {
+      pendingOnly: options?.pendingOnly ?? false,
+    }),
   synkLogin: (req: SyncLoginRequest) =>
     invokeSafe<AuthSession>('synk_login', { req }),
 

--- a/desktop/src/lib/tauriClient.ts
+++ b/desktop/src/lib/tauriClient.ts
@@ -9,6 +9,7 @@ import type {
   CredentialSetResult,
   ImportResult,
   ImportStagingScanEntry,
+  ImportSyncAppearanceScanResult,
   ParsedImportFileResult,
   AttachmentCopyBatchResult,
   HostTextReadResult,
@@ -153,6 +154,11 @@ export const tauriClient = {
   parseImportObservationJsonPaths: (paths: string[]) =>
     invokeSafe<ParsedImportFileResult[]>(
       'parse_import_observation_json_paths',
+      { paths },
+    ),
+  scanImportJsonSyncAppearance: (paths: string[]) =>
+    invokeSafe<ImportSyncAppearanceScanResult>(
+      'scan_import_json_sync_appearance',
       { paths },
     ),
   copyWorkspaceAttachmentsBatch: (

--- a/desktop/src/pages/ImportPage.tsx
+++ b/desktop/src/pages/ImportPage.tsx
@@ -33,6 +33,9 @@ import {
 
 const MAX_INDIVIDUAL_FILES = 20;
 
+/** Cap DOM rows — rendering tens of thousands of staging rows freezes the UI. */
+const STAGING_LIST_PREVIEW = 50;
+
 /** Host copy batch size — keeps IPC payloads and UI updates manageable. */
 const ATTACHMENT_COPY_CHUNK_SIZE = 400;
 
@@ -216,6 +219,9 @@ export function ImportPage() {
   const busy = importActivity !== null;
 
   const addScanEntries = useImportStagingStore(s => s.addScanEntries);
+  const retainStagedJsonPaths = useImportStagingStore(
+    s => s.retainStagedJsonPaths,
+  );
   const removeStagedJson = useImportStagingStore(s => s.removeStagedJson);
   const removeStagedAttachment = useImportStagingStore(
     s => s.removeStagedAttachment,
@@ -226,6 +232,10 @@ export function ImportPage() {
   const setError = useImportStagingStore(s => s.setError);
   const setImportActivity = useImportStagingStore(s => s.setImportActivity);
 
+  /** After staging skip dialog: silently drop remaining synced rows at import. */
+  const [preferSkipSynced, setPreferSkipSynced] = useState(false);
+  const [skippedSyncedAtStaging, setSkippedSyncedAtStaging] = useState(0);
+
   const stagingSummary = useMemo(() => {
     const jsonCount = stagedJson.length;
     const attCount = stagedAttachments.length;
@@ -234,6 +244,69 @@ export function ImportPage() {
       stagedAttachments.reduce((a, s) => a + s.size, 0);
     return { jsonCount, attCount, bytes };
   }, [stagedJson, stagedAttachments]);
+
+  /**
+   * After JSON lands in staging, scan Formulus `syncedAt` metadata and optionally
+   * drop already-synced files before the heavy parse/validate pass.
+   */
+  const offerSkipAlreadySynced = useCallback(async () => {
+    const jsonPaths = useImportStagingStore
+      .getState()
+      .stagedJson.map(s => s.nativePath);
+    if (jsonPaths.length === 0) {
+      return;
+    }
+    setImportActivity({
+      statusText: `Checking sync status (${jsonPaths.length} JSON files)…`,
+    });
+    try {
+      const scan = await tauriClient.scanImportJsonSyncAppearance(jsonPaths);
+      if (scan.apparentlySyncedCount <= 0) {
+        return;
+      }
+      const skipSynced = await confirm(
+        `${scan.observationCount} observations were found. ${scan.apparentlySyncedCount} already appear to be synced — skip those and import only the ${scan.unsyncedCount} new observations?`,
+        {
+          title: 'Skip already-synced observations?',
+          kind: 'info',
+          okLabel: 'Skip synced',
+          cancelLabel: 'Keep all',
+        },
+      );
+      if (skipSynced) {
+        retainStagedJsonPaths(scan.unsyncedPaths);
+        setPreferSkipSynced(true);
+        setSkippedSyncedAtStaging(scan.apparentlySyncedCount);
+        setMessage(
+          `Staging updated — kept ${scan.unsyncedPaths.length} JSON file(s); skipped ${scan.apparentlySyncedCount} already-synced observation(s).`,
+        );
+      } else {
+        setPreferSkipSynced(false);
+        setSkippedSyncedAtStaging(0);
+      }
+    } catch (e) {
+      setError(
+        messageFromUnknown(e, 'Could not check already-synced observations'),
+      );
+    }
+  }, [retainStagedJsonPaths, setError, setImportActivity, setMessage]);
+
+  const stageExpandedEntries = useCallback(
+    async (
+      expanded: Awaited<
+        ReturnType<typeof tauriClient.expandImportStagingPaths>
+      >,
+    ) => {
+      if (!expanded.length) {
+        return;
+      }
+      addScanEntries(expanded);
+      if (expanded.some(e => e.isJson)) {
+        await offerSkipAlreadySynced();
+      }
+    },
+    [addScanEntries, offerSkipAlreadySynced],
+  );
 
   useEffect(() => {
     if (!isTauri()) {
@@ -267,9 +340,7 @@ export function ImportPage() {
                   paths,
                   MAX_INDIVIDUAL_FILES,
                 );
-                if (expanded.length) {
-                  addScanEntries(expanded);
-                }
+                await stageExpandedEntries(expanded);
               } catch (e) {
                 setError(
                   messageFromUnknown(e, 'Could not stage dropped files'),
@@ -288,7 +359,7 @@ export function ImportPage() {
       alive = false;
       unlisten?.();
     };
-  }, [addScanEntries, setError, setImportActivity]);
+  }, [setError, setImportActivity, stageExpandedEntries]);
 
   const pickImportFolder = useCallback(async () => {
     try {
@@ -307,15 +378,13 @@ export function ImportPage() {
         selected,
         null,
       );
-      if (expanded.length) {
-        addScanEntries(expanded);
-      }
+      await stageExpandedEntries(expanded);
     } catch (e) {
       setError(messageFromUnknown(e, 'Folder selection failed'));
     } finally {
       setImportActivity(null);
     }
-  }, [addScanEntries, setError, setImportActivity]);
+  }, [setError, setImportActivity, stageExpandedEntries]);
 
   const pickJsonFiles = useCallback(async () => {
     try {
@@ -333,15 +402,13 @@ export function ImportPage() {
         paths,
         MAX_INDIVIDUAL_FILES,
       );
-      if (expanded.length) {
-        addScanEntries(expanded);
-      }
+      await stageExpandedEntries(expanded);
     } catch (e) {
       setError(messageFromUnknown(e, 'File selection failed'));
     } finally {
       setImportActivity(null);
     }
-  }, [addScanEntries, setError, setImportActivity]);
+  }, [setError, setImportActivity, stageExpandedEntries]);
 
   const pickAttachmentFiles = useCallback(async () => {
     try {
@@ -422,8 +489,11 @@ export function ImportPage() {
         parsedFiles: parsed,
         formSpecsByType,
         stagedAttachmentBasenames: basenames,
-        onFileValidated: (fi, tot, name) =>
-          statusCtl.push(`Validating (${fi + 1}/${tot}) ${name}…`),
+        onFileValidated: (fi, tot, name) => {
+          if (tot <= 40 || fi === tot - 1 || (fi + 1) % 50 === 0) {
+            statusCtl.push(`Validating (${fi + 1}/${tot}) ${name}…`);
+          }
+        },
       });
 
       if (report.issues.length > 0) {
@@ -446,24 +516,17 @@ export function ImportPage() {
       const allObservations = flattenObservations(report.parsedFiles);
       const syncPartition =
         partitionImportObservationsBySyncAppearance(allObservations);
-      let observations = allObservations;
-      let skippedSyncedCount = 0;
-
-      if (syncPartition.apparentlySynced.length > 0) {
-        const skipSynced = await confirm(
-          `${syncPartition.total} observations were found. ${syncPartition.apparentlySynced.length} already appear to be synced — skip those and import only the ${syncPartition.unsynced.length} new observations?`,
-          {
-            title: 'Skip already-synced observations?',
-            kind: 'info',
-            okLabel: 'Skip synced',
-            cancelLabel: 'Import all',
-          },
-        );
-        if (skipSynced) {
-          observations = syncPartition.unsynced;
-          skippedSyncedCount = syncPartition.apparentlySynced.length;
-        }
-      }
+      // Staging already offered skip/keep; when skip was chosen, drop any
+      // remaining apparently-synced rows (e.g. mixed files) without re-prompting.
+      const observations = preferSkipSynced
+        ? syncPartition.unsynced
+        : allObservations;
+      const skippedSyncedCount = preferSkipSynced
+        ? Math.max(
+            skippedSyncedAtStaging,
+            syncPartition.apparentlySynced.length,
+          )
+        : 0;
 
       if (observations.length === 0) {
         setMessage(
@@ -607,6 +670,8 @@ export function ImportPage() {
           : '';
       setMessage(`${baseMsg}${indexMsg}${attMsg}`);
       clearStagedFiles();
+      setPreferSkipSynced(false);
+      setSkippedSyncedAtStaging(0);
       setPreviewReport(null);
     } catch (e) {
       setError(messageFromUnknown(e, 'Import failed'));
@@ -617,6 +682,8 @@ export function ImportPage() {
   }, [
     stagedJson,
     stagedAttachments,
+    preferSkipSynced,
+    skippedSyncedAtStaging,
     setMessage,
     setError,
     setImportActivity,
@@ -689,7 +756,11 @@ export function ImportPage() {
               type="button"
               className="linkish"
               disabled={busy}
-              onClick={() => clearStagingLists()}>
+              onClick={() => {
+                clearStagingLists();
+                setPreferSkipSynced(false);
+                setSkippedSyncedAtStaging(0);
+              }}>
               Clear staging
             </button>
           ) : null}
@@ -700,7 +771,7 @@ export function ImportPage() {
             {stagedJson.length > 0 ? (
               <div className="import-staging-section">
                 <h4>JSON ({stagedJson.length})</h4>
-                {stagedJson.map(s => (
+                {stagedJson.slice(0, STAGING_LIST_PREVIEW).map(s => (
                   <div key={s.nativePath} className="import-staging-row">
                     <button
                       type="button"
@@ -717,13 +788,19 @@ export function ImportPage() {
                     <span className="muted">{formatBytes(s.size)}</span>
                   </div>
                 ))}
+                {stagedJson.length > STAGING_LIST_PREVIEW ? (
+                  <p className="muted">
+                    … and {stagedJson.length - STAGING_LIST_PREVIEW} more (list
+                    truncated for performance)
+                  </p>
+                ) : null}
               </div>
             ) : null}
 
             {stagedAttachments.length > 0 ? (
               <div className="import-staging-section">
                 <h4>Attachments ({stagedAttachments.length})</h4>
-                {stagedAttachments.map(s => (
+                {stagedAttachments.slice(0, STAGING_LIST_PREVIEW).map(s => (
                   <div key={s.nativePath} className="import-staging-row">
                     <button
                       type="button"
@@ -740,6 +817,12 @@ export function ImportPage() {
                     <span className="muted">{formatBytes(s.size)}</span>
                   </div>
                 ))}
+                {stagedAttachments.length > STAGING_LIST_PREVIEW ? (
+                  <p className="muted">
+                    … and {stagedAttachments.length - STAGING_LIST_PREVIEW} more
+                    (list truncated for performance)
+                  </p>
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/desktop/src/pages/ImportPage.tsx
+++ b/desktop/src/pages/ImportPage.tsx
@@ -5,16 +5,18 @@ import { tauriClient } from '../lib/tauriClient';
 import {
   groupIssuesBySeverityAndCategory,
   normalizeBasename,
+  referencedNamesForObservation,
   runImportValidation,
   type ImportIssue,
   type ImportIssueCategory,
   type ImportValidationReport,
 } from '../lib/importValidation';
-import type { BundleFormSpec } from '../types/domain';
+import type { ApiObservation, BundleFormSpec } from '../types/domain';
 import {
   flattenObservations,
   mapPool,
   parseObservationJsonPathsViaRust,
+  partitionImportObservationsBySyncAppearance,
   summarizeImportFiles,
 } from '../lib/importSummary';
 import {
@@ -53,6 +55,22 @@ function formatBytes(n: number) {
     return `${(n / 1024).toFixed(1)} KB`;
   }
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Attachment basenames referenced by the observations actually being written. */
+function referencedAttachmentNamesForObservations(
+  observations: readonly ApiObservation[],
+  formSpecsByType: Map<string, BundleFormSpec>,
+): string[] {
+  const refs = new Set<string>();
+  for (const obs of observations) {
+    const ft = obs.formType?.trim();
+    const schema = ft ? formSpecsByType.get(ft)?.formSchema : undefined;
+    for (const name of referencedNamesForObservation(schema, obs.data)) {
+      refs.add(name);
+    }
+  }
+  return [...refs];
 }
 
 function normalizeDialogPaths(
@@ -425,7 +443,37 @@ export function ImportPage() {
         }
       }
 
-      const observations = flattenObservations(report.parsedFiles);
+      const allObservations = flattenObservations(report.parsedFiles);
+      const syncPartition =
+        partitionImportObservationsBySyncAppearance(allObservations);
+      let observations = allObservations;
+      let skippedSyncedCount = 0;
+
+      if (syncPartition.apparentlySynced.length > 0) {
+        const skipSynced = await confirm(
+          `${syncPartition.total} observations were found. ${syncPartition.apparentlySynced.length} already appear to be synced — skip those and import only the ${syncPartition.unsynced.length} new observations?`,
+          {
+            title: 'Skip already-synced observations?',
+            kind: 'info',
+            okLabel: 'Skip synced',
+            cancelLabel: 'Import all',
+          },
+        );
+        if (skipSynced) {
+          observations = syncPartition.unsynced;
+          skippedSyncedCount = syncPartition.apparentlySynced.length;
+        }
+      }
+
+      if (observations.length === 0) {
+        setMessage(
+          skippedSyncedCount > 0
+            ? `Nothing to import — all ${skippedSyncedCount} observations already appear to be synced.`
+            : 'Nothing to import — no observations found in staged JSON.',
+        );
+        return;
+      }
+
       const writeTotal = observations.length;
       let imported = 0;
       let conflicts = 0;
@@ -464,7 +512,7 @@ export function ImportPage() {
       }
 
       const refNorm = new Set(
-        report.referencedAttachmentNames
+        referencedAttachmentNamesForObservations(observations, formSpecsByType)
           .map(n => normalizeBasename(n))
           .filter(Boolean),
       );
@@ -545,7 +593,11 @@ export function ImportPage() {
       await loadObservations();
       await loadHealth();
 
-      const baseMsg = `Imported ${result.imported} observations (${result.conflicts} conflicts).`;
+      const skipMsg =
+        skippedSyncedCount > 0
+          ? ` Skipped ${skippedSyncedCount} already-synced observation(s).`
+          : '';
+      const baseMsg = `Imported ${result.imported} observations (${result.conflicts} conflicts).${skipMsg}`;
       const indexMsg = result.indexRebuildScheduled
         ? ' Rebuilding observation indexes in the background (see activity banner).'
         : '';

--- a/desktop/src/pages/ImportPage.tsx
+++ b/desktop/src/pages/ImportPage.tsx
@@ -6,7 +6,6 @@ import {
   groupIssuesBySeverityAndCategory,
   normalizeBasename,
   referencedNamesForObservation,
-  runImportValidation,
   type ImportIssue,
   type ImportIssueCategory,
   type ImportValidationReport,
@@ -15,7 +14,7 @@ import type { ApiObservation, BundleFormSpec } from '../types/domain';
 import {
   flattenObservations,
   mapPool,
-  parseObservationJsonPathsViaRust,
+  parseAndValidateImportJsonViaRust,
   partitionImportObservationsBySyncAppearance,
   summarizeImportFiles,
 } from '../lib/importSummary';
@@ -145,6 +144,8 @@ const CATEGORY_LABELS: Record<ImportIssueCategory, string> = {
 function ValidationAccordion({ issues }: { issues: ImportIssue[] }) {
   const grouped = groupIssuesBySeverityAndCategory(issues);
   const [openKeys, setOpenKeys] = useState<Set<string>>(new Set());
+  const errorCount = issues.filter(i => i.severity === 'error').length;
+  const warningCount = issues.filter(i => i.severity === 'warning').length;
 
   function toggle(key: string) {
     setOpenKeys(prev => {
@@ -169,38 +170,54 @@ function ValidationAccordion({ issues }: { issues: ImportIssue[] }) {
     }
   }
 
-  if (sections.length === 0) {
-    return <p className="notice success">No issues reported.</p>;
-  }
-
   return (
-    <div className="validation-accordion">
-      {sections.map(sec => (
-        <div key={sec.key} className="validation-accordion-item">
-          <button
-            type="button"
-            className="validation-accordion-header"
-            aria-expanded={openKeys.has(sec.key)}
-            onClick={() => toggle(sec.key)}>
-            <span className="material-symbols-outlined" aria-hidden>
-              {openKeys.has(sec.key) ? 'expand_more' : 'chevron_right'}
-            </span>
-            {sec.title}
-          </button>
-          {openKeys.has(sec.key) ? (
-            <div className="validation-accordion-body">
-              <ul>
-                {sec.items.slice(0, 30).map((issue, i) => (
-                  <li key={`${issue.code}-${i}`}>{issue.message}</li>
-                ))}
-              </ul>
-              {sec.items.length > 30 ? (
-                <p className="muted">… and {sec.items.length - 30} more</p>
+    <div className="validation-results">
+      {errorCount === 0 ? (
+        <p className="notice success">No validation errors were found.</p>
+      ) : (
+        <p className="notice warn">
+          {errorCount} validation error{errorCount === 1 ? '' : 's'}
+          {warningCount > 0
+            ? ` · ${warningCount} warning${warningCount === 1 ? '' : 's'}`
+            : ''}
+          . Review below — you can still import.
+        </p>
+      )}
+      {errorCount === 0 && warningCount > 0 ? (
+        <p className="muted">
+          {warningCount} warning{warningCount === 1 ? '' : 's'} reported.
+        </p>
+      ) : null}
+      {sections.length > 0 ? (
+        <div className="validation-accordion">
+          {sections.map(sec => (
+            <div key={sec.key} className="validation-accordion-item">
+              <button
+                type="button"
+                className="validation-accordion-header"
+                aria-expanded={openKeys.has(sec.key)}
+                onClick={() => toggle(sec.key)}>
+                <span className="material-symbols-outlined" aria-hidden>
+                  {openKeys.has(sec.key) ? 'expand_more' : 'chevron_right'}
+                </span>
+                {sec.title}
+              </button>
+              {openKeys.has(sec.key) ? (
+                <div className="validation-accordion-body">
+                  <ul>
+                    {sec.items.slice(0, 30).map((issue, i) => (
+                      <li key={`${issue.code}-${i}`}>{issue.message}</li>
+                    ))}
+                  </ul>
+                  {sec.items.length > 30 ? (
+                    <p className="muted">… and {sec.items.length - 30} more</p>
+                  ) : null}
+                </div>
               ) : null}
             </div>
-          ) : null}
+          ))}
         </div>
-      ))}
+      ) : null}
     </div>
   );
 }
@@ -300,6 +317,7 @@ export function ImportPage() {
       if (!expanded.length) {
         return;
       }
+      setPreviewReport(null);
       addScanEntries(expanded);
       if (expanded.some(e => e.isJson)) {
         await offerSkipAlreadySynced();
@@ -426,6 +444,7 @@ export function ImportPage() {
         MAX_INDIVIDUAL_FILES,
       );
       if (expanded.length) {
+        setPreviewReport(null);
         addScanEntries(expanded);
       }
     } catch (e) {
@@ -435,85 +454,64 @@ export function ImportPage() {
     }
   }, [addScanEntries, setError, setImportActivity]);
 
-  const runFullImport = useCallback(async () => {
+  const runValidate = useCallback(async () => {
     if (stagedJson.length === 0) {
       return;
     }
     const statusCtl = createThrottledImportStatus(setImportActivity);
-    setPreviewReport(null);
     setMessage(null);
     setError(null);
-    statusCtl.push('Reading observation JSON…');
 
     try {
       await ensureBundleApplyEventPipeline();
-      const parsed = await parseObservationJsonPathsViaRust(
+      statusCtl.push(
+        `Reading and validating JSON (${stagedJson.length} files)…`,
+      );
+      const hostReport = await parseAndValidateImportJsonViaRust(
         stagedJson.map(s => ({ name: s.name, nativePath: s.nativePath })),
-        (done, tot) => statusCtl.push(`Reading JSON (${done}/${tot})…`),
+        stagedAttachments.map(s => s.name),
       );
 
-      const formTypes = new Set<string>();
-      for (const p of parsed) {
-        if (p.error) {
-          continue;
-        }
-        for (const obs of p.observations) {
-          if (obs.formType?.trim()) {
-            formTypes.add(obs.formType.trim());
-          }
-        }
-      }
+      const issues: ImportIssue[] = hostReport.issues.map(i => ({
+        severity: i.severity === 'warning' ? 'warning' : 'error',
+        code: i.code,
+        message: i.message,
+        fileName: i.fileName,
+        observationId: i.observationId,
+        formType: i.formType ?? null,
+      }));
 
-      const formSpecsByType = new Map<string, BundleFormSpec>();
-      const ftArr = [...formTypes].sort();
-      if (ftArr.length > 0) {
-        let schemaDone = 0;
-        await mapPool(ftArr, 8, async ft => {
-          try {
-            const spec = await tauriClient.readBundleFormSpec(ft);
-            formSpecsByType.set(ft, spec);
-          } catch {
-            /* missing schema reported inside runImportValidation */
-          } finally {
-            schemaDone += 1;
-            statusCtl.push(
-              `Loading form schemas (${schemaDone}/${ftArr.length})…`,
-            );
-          }
-        });
-      }
-
-      statusCtl.push('Validating…');
-      const basenames = stagedAttachments.map(s => s.name);
-      const report = runImportValidation({
-        parsedFiles: parsed,
-        formSpecsByType,
-        stagedAttachmentBasenames: basenames,
-        onFileValidated: (fi, tot, name) => {
-          if (tot <= 40 || fi === tot - 1 || (fi + 1) % 50 === 0) {
-            statusCtl.push(`Validating (${fi + 1}/${tot}) ${name}…`);
-          }
-        },
+      setPreviewReport({
+        issues,
+        parsedFiles: hostReport.parsedFiles,
+        observationCount: hostReport.observationCount,
+        formTypeCount: hostReport.formTypeCount,
+        stagedAttachmentBasenames: stagedAttachments.map(s => s.name),
+        referencedAttachmentNames: hostReport.referencedAttachmentNames,
+        missingAttachmentNames: hostReport.missingAttachmentNames,
+        orphanAttachmentNames: hostReport.orphanAttachmentNames,
       });
+    } catch (e) {
+      setPreviewReport(null);
+      setError(messageFromUnknown(e, 'Validation failed'));
+    } finally {
+      statusCtl.dispose();
+      setImportActivity(null);
+    }
+  }, [stagedJson, stagedAttachments, setMessage, setError, setImportActivity]);
 
-      if (report.issues.length > 0) {
-        const errCount = report.issues.filter(
-          i => i.severity === 'error',
-        ).length;
-        const warnCount = report.issues.filter(
-          i => i.severity === 'warning',
-        ).length;
-        const ok = await confirm(
-          `${errCount} error(s), ${warnCount} warning(s). Import anyway?`,
-          { title: 'Validation issues', kind: 'warning' },
-        );
-        if (!ok) {
-          setPreviewReport(report);
-          return;
-        }
-      }
+  const runImportFromReport = useCallback(async () => {
+    if (!previewReport) {
+      return;
+    }
+    const statusCtl = createThrottledImportStatus(setImportActivity);
+    setMessage(null);
+    setError(null);
 
-      const allObservations = flattenObservations(report.parsedFiles);
+    try {
+      await ensureBundleApplyEventPipeline();
+
+      const allObservations = flattenObservations(previewReport.parsedFiles);
       const syncPartition =
         partitionImportObservationsBySyncAppearance(allObservations);
       // Staging already offered skip/keep; when skip was chosen, drop any
@@ -537,10 +535,35 @@ export function ImportPage() {
         return;
       }
 
+      // Form schemas only needed for attachment refs on the rows we actually write.
+      const formTypes = new Set<string>();
+      for (const obs of observations) {
+        if (obs.formType?.trim()) {
+          formTypes.add(obs.formType.trim());
+        }
+      }
+      const formSpecsByType = new Map<string, BundleFormSpec>();
+      const ftArr = [...formTypes].sort();
+      if (ftArr.length > 0 && stagedAttachments.length > 0) {
+        let schemaDone = 0;
+        await mapPool(ftArr, 8, async ft => {
+          try {
+            const spec = await tauriClient.readBundleFormSpec(ft);
+            formSpecsByType.set(ft, spec);
+          } catch {
+            /* attachment refs fall back to heuristics */
+          } finally {
+            schemaDone += 1;
+            statusCtl.push(
+              `Loading form schemas (${schemaDone}/${ftArr.length})…`,
+            );
+          }
+        });
+      }
+
       const writeTotal = observations.length;
       let imported = 0;
       let conflicts = 0;
-      let indexRebuildScheduled = false;
 
       for (
         let offset = 0;
@@ -552,103 +575,107 @@ export function ImportPage() {
           offset + IMPORT_WRITE_CHUNK_SIZE,
         );
         const written = Math.min(offset + chunk.length, writeTotal);
-        const isLast = written >= writeTotal;
         statusCtl.push(`Writing observations (${written}/${writeTotal})…`);
+        // Indexes are updated incrementally inside import (same as sync pull).
         const chunkResult = await tauriClient.importObservations(chunk, {
           markPending: true,
-          scheduleIndexRebuild: isLast,
+          scheduleIndexRebuild: false,
         });
         imported += chunkResult.imported;
         conflicts += chunkResult.conflicts;
-        indexRebuildScheduled =
-          indexRebuildScheduled || !!chunkResult.indexRebuildScheduled;
       }
 
-      const result = { imported, conflicts, indexRebuildScheduled };
-
-      const stagedNorm = new Map<string, string>();
-      for (const s of stagedAttachments) {
-        const k = normalizeBasename(s.name);
-        if (k && !stagedNorm.has(k)) {
-          stagedNorm.set(k, s.name);
-        }
-      }
-
-      const refNorm = new Set(
-        referencedAttachmentNamesForObservations(observations, formSpecsByType)
-          .map(n => normalizeBasename(n))
-          .filter(Boolean),
-      );
+      const result = { imported, conflicts };
 
       const copyItems: { sourcePath: string; attachmentId: string }[] = [];
-      for (const s of stagedAttachments) {
-        const kn = normalizeBasename(s.name);
-        if (!kn || !refNorm.has(kn)) {
-          continue;
-        }
-        const attachmentId = stagedNorm.get(kn) ?? s.name;
-        copyItems.push({
-          sourcePath: s.nativePath,
-          attachmentId,
-        });
-      }
-
       const copyErrors: string[] = [];
       let attachmentsCopied = 0;
-      if (copyItems.length > 0) {
-        const copyTotal = copyItems.length;
-        const copyStatusCtl = createThrottledImportStatus(
-          setImportActivity,
-          250,
+      if (stagedAttachments.length > 0) {
+        statusCtl.push('Resolving attachment references…');
+        const stagedNorm = new Map<string, string>();
+        for (const s of stagedAttachments) {
+          const k = normalizeBasename(s.name);
+          if (k && !stagedNorm.has(k)) {
+            stagedNorm.set(k, s.name);
+          }
+        }
+
+        const refNorm = new Set(
+          referencedAttachmentNamesForObservations(
+            observations,
+            formSpecsByType,
+          )
+            .map(n => normalizeBasename(n))
+            .filter(Boolean),
         );
-        copyStatusCtl.push(formatAttachmentCopyProgress(0, copyTotal));
-        const { listen } = await import('@tauri-apps/api/event');
-        let unlisten: (() => void) | undefined;
-        try {
-          for (
-            let offset = 0;
-            offset < copyItems.length;
-            offset += ATTACHMENT_COPY_CHUNK_SIZE
-          ) {
-            const chunk = copyItems.slice(
-              offset,
-              offset + ATTACHMENT_COPY_CHUNK_SIZE,
-            );
-            const chunkIndex =
-              Math.floor(offset / ATTACHMENT_COPY_CHUNK_SIZE) + 1;
-            const chunkCount = Math.ceil(
-              copyItems.length / ATTACHMENT_COPY_CHUNK_SIZE,
-            );
-            if (chunkCount > 1) {
+
+        for (const s of stagedAttachments) {
+          const kn = normalizeBasename(s.name);
+          if (!kn || !refNorm.has(kn)) {
+            continue;
+          }
+          const attachmentId = stagedNorm.get(kn) ?? s.name;
+          copyItems.push({
+            sourcePath: s.nativePath,
+            attachmentId,
+          });
+        }
+
+        if (copyItems.length > 0) {
+          const copyTotal = copyItems.length;
+          const copyStatusCtl = createThrottledImportStatus(
+            setImportActivity,
+            250,
+          );
+          copyStatusCtl.push(formatAttachmentCopyProgress(0, copyTotal));
+          const { listen } = await import('@tauri-apps/api/event');
+          let unlisten: (() => void) | undefined;
+          try {
+            for (
+              let offset = 0;
+              offset < copyItems.length;
+              offset += ATTACHMENT_COPY_CHUNK_SIZE
+            ) {
+              const chunk = copyItems.slice(
+                offset,
+                offset + ATTACHMENT_COPY_CHUNK_SIZE,
+              );
+              const chunkIndex =
+                Math.floor(offset / ATTACHMENT_COPY_CHUNK_SIZE) + 1;
+              const chunkCount = Math.ceil(
+                copyItems.length / ATTACHMENT_COPY_CHUNK_SIZE,
+              );
+              if (chunkCount > 1) {
+                copyStatusCtl.push(
+                  `Copying attachments batch ${chunkIndex}/${chunkCount}…`,
+                );
+              }
+              unlisten?.();
+              unlisten = await listen<{
+                done: number;
+                total: number;
+                attachmentId: string;
+              }>('import/attachment-copy-progress', e => {
+                const globalDone = offset + e.payload.done;
+                copyStatusCtl.push(
+                  formatAttachmentCopyProgress(globalDone, copyTotal),
+                );
+              });
+              const batchResult =
+                await tauriClient.copyWorkspaceAttachmentsBatch(chunk);
+              copyErrors.push(...batchResult.errors);
+              attachmentsCopied += batchResult.copied;
               copyStatusCtl.push(
-                `Copying attachments batch ${chunkIndex}/${chunkCount}…`,
+                formatAttachmentCopyProgress(
+                  Math.min(offset + chunk.length, copyTotal),
+                  copyTotal,
+                ),
               );
             }
+          } finally {
             unlisten?.();
-            unlisten = await listen<{
-              done: number;
-              total: number;
-              attachmentId: string;
-            }>('import/attachment-copy-progress', e => {
-              const globalDone = offset + e.payload.done;
-              copyStatusCtl.push(
-                formatAttachmentCopyProgress(globalDone, copyTotal),
-              );
-            });
-            const batchResult =
-              await tauriClient.copyWorkspaceAttachmentsBatch(chunk);
-            copyErrors.push(...batchResult.errors);
-            attachmentsCopied += batchResult.copied;
-            copyStatusCtl.push(
-              formatAttachmentCopyProgress(
-                Math.min(offset + chunk.length, copyTotal),
-                copyTotal,
-              ),
-            );
+            copyStatusCtl.dispose();
           }
-        } finally {
-          unlisten?.();
-          copyStatusCtl.dispose();
         }
       }
 
@@ -661,14 +688,11 @@ export function ImportPage() {
           ? ` Skipped ${skippedSyncedCount} already-synced observation(s).`
           : '';
       const baseMsg = `Imported ${result.imported} observations (${result.conflicts} conflicts).${skipMsg}`;
-      const indexMsg = result.indexRebuildScheduled
-        ? ' Rebuilding observation indexes in the background (see activity banner).'
-        : '';
       const attMsg =
         copyItems.length > 0
           ? ` Copied ${attachmentsCopied}/${copyItems.length} referenced attachment(s) to queue.${copyErrors.length ? ` Errors: ${copyErrors.slice(0, 5).join('; ')}${copyErrors.length > 5 ? '…' : ''}` : ''}`
           : '';
-      setMessage(`${baseMsg}${indexMsg}${attMsg}`);
+      setMessage(`${baseMsg}${attMsg}`);
       clearStagedFiles();
       setPreferSkipSynced(false);
       setSkippedSyncedAtStaging(0);
@@ -680,7 +704,7 @@ export function ImportPage() {
       setImportActivity(null);
     }
   }, [
-    stagedJson,
+    previewReport,
     stagedAttachments,
     preferSkipSynced,
     skippedSyncedAtStaging,
@@ -760,6 +784,7 @@ export function ImportPage() {
                 clearStagingLists();
                 setPreferSkipSynced(false);
                 setSkippedSyncedAtStaging(0);
+                setPreviewReport(null);
               }}>
               Clear staging
             </button>
@@ -778,7 +803,10 @@ export function ImportPage() {
                       className="import-staging-row-remove"
                       aria-label={`Remove ${s.name}`}
                       disabled={busy}
-                      onClick={() => removeStagedJson(s.nativePath)}>
+                      onClick={() => {
+                        removeStagedJson(s.nativePath);
+                        setPreviewReport(null);
+                      }}>
                       ×
                     </button>
                     <span className="material-symbols-outlined" aria-hidden>
@@ -807,7 +835,10 @@ export function ImportPage() {
                       className="import-staging-row-remove"
                       aria-label={`Remove ${s.name}`}
                       disabled={busy}
-                      onClick={() => removeStagedAttachment(s.nativePath)}>
+                      onClick={() => {
+                        removeStagedAttachment(s.nativePath);
+                        setPreviewReport(null);
+                      }}>
                       ×
                     </button>
                     <span className="material-symbols-outlined" aria-hidden>
@@ -833,23 +864,35 @@ export function ImportPage() {
             type="button"
             className="btn-icon"
             disabled={busy || stagedJson.length === 0}
-            onClick={() => void runFullImport()}>
+            onClick={() => void runValidate()}>
             <span className="material-symbols-outlined" aria-hidden>
-              download
+              fact_check
             </span>
-            {busy ? 'Working…' : 'Import into local store'}
+            {busy ? 'Working…' : 'Validate'}
           </button>
         </div>
       </div>
 
       {previewReport && preflightSummary ? (
         <div className="panel">
-          <h3>Validation summary</h3>
+          <h3>Validation results</h3>
           <p className="muted">
             {preflightSummary.observationCount} observations ·{' '}
             {preflightSummary.formTypeCount} form types
           </p>
           <ValidationAccordion issues={previewReport.issues} />
+          <div className="button-row" style={{ marginTop: 'var(--space-lg)' }}>
+            <button
+              type="button"
+              className="btn-icon"
+              disabled={busy || previewReport.observationCount === 0}
+              onClick={() => void runImportFromReport()}>
+              <span className="material-symbols-outlined" aria-hidden>
+                download
+              </span>
+              {busy ? 'Importing…' : 'Import into local store'}
+            </button>
+          </div>
         </div>
       ) : null}
 

--- a/desktop/src/pages/ProfilesPage.tsx
+++ b/desktop/src/pages/ProfilesPage.tsx
@@ -19,9 +19,9 @@ import {
 import type { ServerProfile } from '../types/domain';
 import {
   selectActiveProfileState,
-  selectAuthSessionForActiveProfile,
   useCustodianStore,
 } from '../store/useCustodianStore';
+import { useProfileAutoSynkAuth } from '../hooks/useProfileAutoSynkAuth';
 import { useProfileDraftGuardStore } from '../store/useProfileDraftGuardStore';
 import { confirmDestructiveAction } from '../lib/destructivePolicy';
 
@@ -89,7 +89,8 @@ export function ProfilesPage() {
     error,
   } = useCustodianStore();
   const active = useCustodianStore(selectActiveProfileState);
-  const authSession = useCustodianStore(selectAuthSessionForActiveProfile);
+  const { authSession, authBlocked, authReady, refreshAuth } =
+    useProfileAutoSynkAuth(active?.id);
 
   const [label, setLabel] = useState('');
   const [serverUrl, setServerUrl] = useState('');
@@ -406,6 +407,7 @@ export function ProfilesPage() {
         username: username.trim(),
         password: pwd,
       });
+      await refreshAuth();
     } catch {
       // synkLogin reports via store `error`
     }
@@ -415,8 +417,18 @@ export function ProfilesPage() {
   const derivedDb = ws ? workspaceSqlitePath(ws) : '';
   const derivedAttachments = ws ? workspaceAttachmentsDir(ws) : '';
 
-  const authIcon = authSession ? 'verified_user' : 'lock_open';
-  const authLabel = authSession ? 'Authenticated' : 'Authenticate';
+  const isAuthenticated = authReady && Boolean(authSession) && !authBlocked;
+  const authChecking = Boolean(active) && !authReady;
+  const authIcon = isAuthenticated
+    ? 'verified_user'
+    : authChecking
+      ? 'hourglass_empty'
+      : 'lock_open';
+  const authLabel = isAuthenticated
+    ? 'Authenticated'
+    : authChecking
+      ? 'Checking…'
+      : 'Authenticate';
 
   return (
     <section className="page">
@@ -524,8 +536,8 @@ export function ProfilesPage() {
                 <td colSpan={2} className="form-table-actions-cell">
                   <button
                     type="button"
-                    className={`btn-icon${authSession ? ' btn-success' : ' secondary'}`}
-                    disabled={Boolean(authSession)}
+                    className={`btn-icon${isAuthenticated ? ' btn-success' : ' secondary'}`}
+                    disabled={isAuthenticated || authChecking}
                     onClick={() => void authenticate()}>
                     <span className="material-symbols-outlined" aria-hidden>
                       {authIcon}

--- a/desktop/src/pages/SyncPage.tsx
+++ b/desktop/src/pages/SyncPage.tsx
@@ -27,9 +27,7 @@ function formatDate(value?: string | null) {
 
 export function SyncPage() {
   const activeProfile = useCustodianStore(selectActiveProfileState);
-  const { authSession, authBlocked, ensureAuth } = useProfileAutoSynkAuth(
-    activeProfile?.id,
-  );
+  const { authBlocked, ensureAuth } = useProfileAutoSynkAuth(activeProfile?.id);
   const syncActivity = useCustodianStore(selectSyncActivity);
   const syncPausedJob = useCustodianStore(selectPausedSyncJob);
   const bundleActivity = useCustodianStore(selectBundleActivity);
@@ -212,7 +210,7 @@ export function SyncPage() {
         <h2>Sync</h2>
       </header>
 
-      {authBlocked && !authSession ? (
+      {authBlocked ? (
         <p className="notice warn">
           Not authenticated. <Link to="/data/profiles">Open Profiles</Link> to
           sign in.

--- a/desktop/src/pages/SyncPage.tsx
+++ b/desktop/src/pages/SyncPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ForcePushMissingAttachmentsDialog } from '../components/ForcePushMissingAttachmentsDialog';
+import { ResetLocalDataDialog } from '../components/ResetLocalDataDialog';
 import { useProfileAutoSynkAuth } from '../hooks/useProfileAutoSynkAuth';
 import { tauriClient } from '../lib/tauriClient';
 import { confirmDestructiveAction } from '../lib/destructivePolicy';
@@ -56,6 +57,7 @@ export function SyncPage() {
   const [missingAttachmentIssues, setMissingAttachmentIssues] = useState<
     MissingAttachmentIssue[] | null
   >(null);
+  const [resetLocalOpen, setResetLocalOpen] = useState(false);
   const [indexStatus, setIndexStatus] = useState<{
     activeGeneration: number;
     lastRebuildAt?: string | null;
@@ -193,15 +195,8 @@ export function SyncPage() {
   }
 
   async function resetLocalData() {
-    if (
-      !(await confirmDestructiveAction(
-        'local_reset',
-        'Remove all observations and attachment files from this device and reset sync offsets.',
-      ))
-    ) {
-      return;
-    }
-    await resetLocalWorkspaceData();
+    await loadHealth();
+    setResetLocalOpen(true);
   }
 
   return (
@@ -363,6 +358,19 @@ export function SyncPage() {
             return;
           }
           void runPush(force);
+        }}
+      />
+
+      <ResetLocalDataDialog
+        open={resetLocalOpen}
+        dirtyCount={health?.dirtyCount ?? 0}
+        conflictCount={health?.conflictCount ?? 0}
+        onChoice={choice => {
+          setResetLocalOpen(false);
+          if (!choice) {
+            return;
+          }
+          void resetLocalWorkspaceData({ pendingOnly: choice.pendingOnly });
         }}
       />
     </section>

--- a/desktop/src/pages/WorkbenchCustomAppPage.tsx
+++ b/desktop/src/pages/WorkbenchCustomAppPage.tsx
@@ -25,9 +25,7 @@ import type { AppBundleState } from '../types/domain';
 export function WorkbenchCustomAppPage() {
   const navigate = useNavigate();
   const activeProfile = useCustodianStore(selectActiveProfileState);
-  const { authSession, authBlocked, ensureAuth } = useProfileAutoSynkAuth(
-    activeProfile?.id,
-  );
+  const { authBlocked, ensureAuth } = useProfileAutoSynkAuth(activeProfile?.id);
   const recoverActiveProfileAuth = useCustodianStore(
     s => s.recoverActiveProfileAuth,
   );
@@ -261,7 +259,7 @@ export function WorkbenchCustomAppPage() {
       {devError ? <p className="notice error">{devError}</p> : null}
       {bundleError ? <p className="notice error">{bundleError}</p> : null}
       {uploadError ? <p className="notice error">{uploadError}</p> : null}
-      {developerMode && baseUrl && authBlocked && !authSession ? (
+      {developerMode && baseUrl && authBlocked ? (
         <p className="notice warn">
           Not authenticated. <Link to="/data/profiles">Open Profiles</Link> to
           sign in.

--- a/desktop/src/store/useCustodianStore.ts
+++ b/desktop/src/store/useCustodianStore.ts
@@ -9,6 +9,7 @@ import {
 } from '../lib/syncTauriEvents';
 import { partitionPendingPushObservations } from '../lib/pushAttachmentAudit';
 import { getOrCreateClientId, syncGateway } from '../services/synk';
+import { isSyncHttpUnauthorized } from '../services/synk/syncErrors';
 import type {
   AppHealth,
   AuthSession,
@@ -117,7 +118,14 @@ async function reauthenticateActiveProfile(
       persistAuthMap(merged);
       set({ authSessionsByProfileId: merged });
       return;
-    } catch {
+    } catch (refreshError) {
+      const cred = await tauriClient.credentialGet(id);
+      const password = cred.password ?? '';
+      if (!password.trim()) {
+        // No password fallback: surface the refresh failure (401 clears session
+        // in recover; network errors keep the stored refresh token).
+        throw refreshError;
+      }
       // Fall through to password login.
     }
   }
@@ -137,6 +145,20 @@ async function reauthenticateActiveProfile(
   const merged = { ...get().authSessionsByProfileId, [id]: next };
   persistAuthMap(merged);
   set({ authSessionsByProfileId: merged });
+}
+
+function clearActiveProfileAuthSession(
+  set: (partial: Partial<CustodianState>) => void,
+  get: () => CustodianState,
+): void {
+  const id = get().activeProfileId;
+  if (!id || !get().authSessionsByProfileId[id]) {
+    return;
+  }
+  const auth = { ...get().authSessionsByProfileId };
+  delete auth[id];
+  persistAuthMap(auth);
+  set({ authSessionsByProfileId: auth });
 }
 
 async function awaitSyncJobTerminal(
@@ -389,13 +411,13 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
   clearExportActivity: () => set({ exportActivity: null }),
 
   ensureActiveProfileAuth: async () => {
-    if (selectAuthSessionForActiveProfile(get())?.token) {
-      return true;
-    }
     try {
       await reauthenticateActiveProfile(set, get);
       return true;
-    } catch {
+    } catch (e) {
+      if (isSyncHttpUnauthorized(e)) {
+        clearActiveProfileAuthSession(set, get);
+      }
       return false;
     }
   },
@@ -404,7 +426,10 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
     try {
       await reauthenticateActiveProfile(set, get);
       return true;
-    } catch {
+    } catch (e) {
+      if (isSyncHttpUnauthorized(e)) {
+        clearActiveProfileAuthSession(set, get);
+      }
       return false;
     }
   },

--- a/desktop/src/store/useCustodianStore.ts
+++ b/desktop/src/store/useCustodianStore.ts
@@ -7,7 +7,11 @@ import {
   setCustodianSyncProgressHandler,
   SyncPausedError,
 } from '../lib/syncTauriEvents';
-import { partitionPendingPushObservations } from '../lib/pushAttachmentAudit';
+import {
+  formatMissingAttachmentHighlight,
+  formatMissingAttachmentReport,
+  partitionPendingPushObservations,
+} from '../lib/pushAttachmentAudit';
 import { getOrCreateClientId, syncGateway } from '../services/synk';
 import { isSyncHttpUnauthorized } from '../services/synk/syncErrors';
 import type {
@@ -229,6 +233,8 @@ interface CustodianState {
   loading: boolean;
   error: string | null;
   syncMessage: string | null;
+  /** Full text for optional “Save report” (e.g. missing-attachment push details). */
+  syncDetailReport: string | null;
   syncActivity: {
     op: 'pull' | 'push' | 'reset';
     statusText: string;
@@ -295,7 +301,9 @@ interface CustodianState {
   syncPauseInFlight: () => Promise<void>;
   syncContinueInFlight: () => Promise<void>;
   syncCancelJob: (jobId?: string | null) => Promise<void>;
-  resetLocalWorkspaceData: () => Promise<void>;
+  resetLocalWorkspaceData: (options?: {
+    pendingOnly?: boolean;
+  }) => Promise<void>;
 }
 
 /** Tauri invoke often rejects with a string; preserve the real message for the UI. */
@@ -392,6 +400,7 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
   loading: false,
   error: null,
   syncMessage: null,
+  syncDetailReport: null,
   syncActivity: null,
   bundleActivity: null,
   exportActivity: null,
@@ -540,6 +549,7 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
         activeProfileId: s.activeProfileId,
         profiles: s.profiles,
         syncMessage: null,
+        syncDetailReport: null,
       });
       await reloadProfileScopedData(set, get);
       await get().refreshPausedSyncJob();
@@ -576,7 +586,7 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
   setSelectedObservationId: id => set({ selectedObservationId: id }),
   clearError: () => set({ error: null }),
 
-  clearSyncMessage: () => set({ syncMessage: null }),
+  clearSyncMessage: () => set({ syncMessage: null, syncDetailReport: null }),
 
   loadWorkspace: async () =>
     withErrorHandling(set, async () => {
@@ -649,7 +659,10 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
       await tauriClient.saveObservation(request);
       await get().loadObservations();
       await get().loadHealth();
-      set({ syncMessage: 'Saved locally. Observation is now pending push.' });
+      set({
+        syncMessage: 'Saved locally. Observation is now pending push.',
+        syncDetailReport: null,
+      });
     }),
 
   synkLogin: async request =>
@@ -661,6 +674,7 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
       set({
         authSessionsByProfileId: next,
         syncMessage: 'Authenticated with Synkronus.',
+        syncDetailReport: null,
       });
     }),
 
@@ -673,6 +687,7 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
       );
       set({
         syncMessage: null,
+        syncDetailReport: null,
         syncActivity: { op: 'pull', statusText: 'Pulling…' },
       });
       try {
@@ -703,6 +718,7 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
         await get().loadHealth();
         set({
           syncMessage: capture.current.trim() || 'Pull finished.',
+          syncDetailReport: null,
         });
       } finally {
         setCustodianSyncProgressHandler(null);
@@ -720,6 +736,7 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
       );
       set({
         syncMessage: null,
+        syncDetailReport: null,
         syncActivity: { op: 'push', statusText: 'Preparing push…' },
       });
       try {
@@ -733,7 +750,10 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
         const pendingPushObservations =
           await tauriClient.listDirtyObservations();
         if (pendingPushObservations.length === 0) {
-          set({ syncMessage: 'No pending observations to push.' });
+          set({
+            syncMessage: 'No pending observations to push.',
+            syncDetailReport: null,
+          });
           return 0;
         }
 
@@ -744,25 +764,21 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
             forceMissing,
           );
 
-        const skipSummary =
-          missingAttachmentIssues.length > 0 && !forceMissing
-            ? ` Skipped ${missingAttachmentIssues.length} observation(s) with missing attachment file(s): ${missingAttachmentIssues
-                .map(
-                  s =>
-                    `${s.id} (form: ${s.formType}; missing: ${s.missing.map(n => `"${n}"`).join(', ')})`,
-                )
-                .join('; ')}.`
+        const attachmentMode = forceMissing ? 'forced' : 'skipped';
+        const attachmentHighlight =
+          missingAttachmentIssues.length > 0
+            ? formatMissingAttachmentHighlight(
+                missingAttachmentIssues,
+                attachmentMode,
+              )
             : '';
-
-        const forceMissingSummary =
-          missingAttachmentIssues.length > 0 && forceMissing
-            ? ` Included ${missingAttachmentIssues.length} observation(s) with missing attachment(s) (forced): ${missingAttachmentIssues
-                .map(
-                  s =>
-                    `${s.id} (form: ${s.formType}; missing: ${s.missing.map(n => `"${n}"`).join(', ')})`,
-                )
-                .join('; ')}.`
-            : '';
+        const attachmentReport =
+          missingAttachmentIssues.length > 0
+            ? formatMissingAttachmentReport(
+                missingAttachmentIssues,
+                attachmentMode,
+              )
+            : null;
 
         if (
           missingAttachmentIssues.length > 0 &&
@@ -779,7 +795,8 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
 
         if (readyToPush.length === 0) {
           set({
-            syncMessage: `Nothing pushed.${skipSummary}`.trim(),
+            syncMessage: `Nothing pushed.${attachmentHighlight}`.trim(),
+            syncDetailReport: attachmentReport,
           });
           return 0;
         }
@@ -793,7 +810,9 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
           xOdeVersion: SYNKRONUS_CLIENT_VERSION,
           pushPrepare: {
             readyObservationIds: readyToPush.map(o => o.id),
-            skipSummary: skipSummary.trim() ? skipSummary : undefined,
+            skipSummary: attachmentHighlight.trim()
+              ? attachmentHighlight.trim()
+              : undefined,
           },
         });
         const resumePayloadBound = (): SyncResumeJobRequest => ({
@@ -812,8 +831,8 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
             ? Number(acceptedMatch[1])
             : readyToPush.length;
         set({
-          syncMessage:
-            `${capture.current.trim()}${skipSummary}${forceMissingSummary}`.trim(),
+          syncMessage: `${capture.current.trim()}${attachmentHighlight}`.trim(),
+          syncDetailReport: attachmentReport,
         });
         return accepted;
       } finally {
@@ -832,6 +851,7 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
       );
       set({
         syncMessage: null,
+        syncDetailReport: null,
         syncActivity: {
           op: 'reset',
           statusText: 'Resetting server repository…',
@@ -870,6 +890,7 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
           syncMessage:
             capture.current.trim() ||
             'Server repository reset and pull finished.',
+          syncDetailReport: null,
         });
       } finally {
         setCustodianSyncProgressHandler(null);
@@ -935,7 +956,10 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
         await get().loadObservations();
         await get().loadHealth();
         if (capture.current.trim()) {
-          set({ syncMessage: capture.current.trim() });
+          set({
+            syncMessage: capture.current.trim(),
+            syncDetailReport: null,
+          });
         }
       } finally {
         setCustodianSyncProgressHandler(null);
@@ -959,14 +983,17 @@ export const useCustodianStore = create<CustodianState>((set, get) => ({
     await get().loadHealth();
   },
 
-  resetLocalWorkspaceData: async () =>
+  resetLocalWorkspaceData: async options =>
     withErrorHandling(set, async () => {
-      await tauriClient.resetLocalWorkspaceData();
+      const pendingOnly = options?.pendingOnly === true;
+      await tauriClient.resetLocalWorkspaceData({ pendingOnly });
       await reloadProfileScopedData(set, get);
       set({
         selectedObservationId: null,
-        syncMessage:
-          'Local data reset: observations cleared, attachments removed, sync offsets reset.',
+        syncMessage: pendingOnly
+          ? 'Pending observations cleared. Synced data and sync offsets kept.'
+          : 'Local data reset: observations cleared, attachments removed, sync offsets reset.',
+        syncDetailReport: null,
       });
     }),
 }));

--- a/desktop/src/store/useImportStagingStore.ts
+++ b/desktop/src/store/useImportStagingStore.ts
@@ -18,6 +18,8 @@ interface ImportStagingState {
   error: string | null;
   importActivity: { statusText: string } | null;
   addScanEntries: (entries: ImportStagingScanEntry[]) => void;
+  /** Keep only JSON files whose absolute path is in `nativePaths`. */
+  retainStagedJsonPaths: (nativePaths: readonly string[]) => void;
   removeStagedJson: (nativePath: string) => void;
   removeStagedAttachment: (nativePath: string) => void;
   /** Clears staged JSON + attachment lists (keeps message/error). */
@@ -83,6 +85,14 @@ export const useImportStagingStore = create<ImportStagingState>(set => ({
         stagedAttachments: nextAtt,
         message: null,
         error: null,
+      };
+    }),
+
+  retainStagedJsonPaths: nativePaths =>
+    set(s => {
+      const keep = new Set(nativePaths);
+      return {
+        stagedJson: s.stagedJson.filter(f => keep.has(f.nativePath)),
       };
     }),
 

--- a/desktop/src/types/domain.ts
+++ b/desktop/src/types/domain.ts
@@ -84,6 +84,17 @@ export interface ParsedImportFileResult {
   error?: string;
 }
 
+/** Lightweight sync-appearance scan over staged Formulus export JSON. */
+export interface ImportSyncAppearanceScanResult {
+  fileCount: number;
+  observationCount: number;
+  apparentlySyncedCount: number;
+  unsyncedCount: number;
+  parseErrorCount: number;
+  /** Absolute paths to retain when skipping already-synced observations. */
+  unsyncedPaths: string[];
+}
+
 export interface AttachmentCopyBatchResult {
   copied: number;
   failed: number;

--- a/desktop/src/types/domain.ts
+++ b/desktop/src/types/domain.ts
@@ -95,6 +95,27 @@ export interface ImportSyncAppearanceScanResult {
   unsyncedPaths: string[];
 }
 
+/** One issue from host-side import validation ({@link parseAndValidateImportJsonPaths}). */
+export interface ImportHostIssue {
+  severity: 'error' | 'warning' | string;
+  code: string;
+  message: string;
+  fileName?: string;
+  observationId?: string;
+  formType?: string | null;
+}
+
+/** Result of parallel Rust parse + schema/attachment validation. */
+export interface ImportValidateBatchResult {
+  files: ParsedImportFileResult[];
+  issues: ImportHostIssue[];
+  observationCount: number;
+  formTypeCount: number;
+  referencedAttachmentNames: string[];
+  missingAttachmentNames: string[];
+  orphanAttachmentNames: string[];
+}
+
 export interface AttachmentCopyBatchResult {
   copied: number;
   failed: number;

--- a/formulus/src/api/synkronus/__tests__/pullCursor.test.ts
+++ b/formulus/src/api/synkronus/__tests__/pullCursor.test.ts
@@ -1,0 +1,104 @@
+import { pullPageOutcome } from '../pullCursor';
+
+describe('pullPageOutcome', () => {
+  it('finishes on the last page using current_version', () => {
+    expect(
+      pullPageOutcome(
+        { current_version: 420, change_cutoff: 410, has_more: false },
+        300,
+      ),
+    ).toEqual({ kind: 'done', version: 420 });
+  });
+
+  it('treats a missing has_more as the last page', () => {
+    expect(
+      pullPageOutcome({ current_version: 7, change_cutoff: 7 }, 0),
+    ).toEqual({ kind: 'done', version: 7 });
+  });
+
+  it('continues from change_cutoff while more pages follow', () => {
+    expect(
+      pullPageOutcome(
+        { current_version: 900, change_cutoff: 500, has_more: true },
+        300,
+      ),
+    ).toEqual({ kind: 'continue', nextSince: 500 });
+  });
+
+  it('accepts a first page starting from version 0', () => {
+    expect(
+      pullPageOutcome(
+        { current_version: 900, change_cutoff: 100, has_more: true },
+        0,
+      ),
+    ).toEqual({ kind: 'continue', nextSince: 100 });
+  });
+
+  it('refuses to loop when change_cutoff does not advance past since', () => {
+    const outcome = pullPageOutcome(
+      { current_version: 900, change_cutoff: 300, has_more: true },
+      300,
+    );
+    expect(outcome.kind).toBe('unusable');
+    expect(outcome).toMatchObject({
+      reason: expect.stringContaining('does not advance past since'),
+    });
+  });
+
+  it('refuses to loop when change_cutoff moves backwards', () => {
+    expect(
+      pullPageOutcome(
+        { current_version: 900, change_cutoff: 120, has_more: true },
+        300,
+      ).kind,
+    ).toBe('unusable');
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['null', null],
+    ['negative', -1],
+    ['not finite', Number.NaN],
+  ])('rejects a %s change_cutoff when more pages follow', (_label, cutoff) => {
+    expect(
+      pullPageOutcome(
+        {
+          current_version: 900,
+          change_cutoff: cutoff as number | null | undefined,
+          has_more: true,
+        },
+        10,
+      ).kind,
+    ).toBe('unusable');
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['null', null],
+    ['negative', -5],
+    ['not finite', Number.NaN],
+  ])(
+    'rejects a %s current_version on the final page',
+    (_label, currentVersion) => {
+      expect(
+        pullPageOutcome(
+          {
+            current_version: currentVersion as number | null | undefined,
+            change_cutoff: 10,
+            has_more: false,
+          },
+          10,
+        ).kind,
+      ).toBe('unusable');
+    },
+  );
+
+  it('allows a repository that is still empty to finish at version 0', () => {
+    expect(
+      pullPageOutcome(
+        { current_version: 0, change_cutoff: 0, has_more: false },
+        0,
+      ),
+    ).toEqual({ kind: 'done', version: 0 });
+  });
+});

--- a/formulus/src/api/synkronus/index.ts
+++ b/formulus/src/api/synkronus/index.ts
@@ -31,6 +31,7 @@ import {
 } from '../../errors/RepositoryResetRequiredError';
 import type { AxiosError, AxiosResponse } from 'axios';
 import { effectiveRepositoryGenerationForRequest } from './repositoryGenerationRequest';
+import { pullPageOutcome } from './pullCursor';
 import {
   formatCountProgress,
   type SynkronusSyncOptions,
@@ -1097,6 +1098,8 @@ class SynkronusApi {
     let currentSince = since;
     let totalServerRecordsThisPull = 0;
     let pullPage = 0;
+    let hasMorePages = true;
+    let finalVersion = since;
 
     reportSyncProgress(report, {
       phase: 'pull_observations',
@@ -1148,7 +1151,11 @@ class SynkronusApi {
         note: 'repository_generation = server epoch (resets); current_version = observation stream cursor — a 4 and a 1 here are not a mismatch.',
       });
 
-      console.debug('Pull response: ', res.data);
+      console.debug(
+        `Pull response: page ${pullPage}, ${
+          res.data.records?.length ?? 0
+        } record(s), has_more=${String(res.data.has_more)}`,
+      );
 
       this.ensureRepoGenResponseMatchesSent(
         'syncPull',
@@ -1186,35 +1193,40 @@ class SynkronusApi {
               : i18n.t('sync.progress.downloading'),
       });
 
-      console.debug('Pulled observations: ', domainObservations);
-
-      // Update since version for next iteration using change_cutoff
-      if (res.data.has_more && res.data.change_cutoff) {
-        currentSince = res.data.change_cutoff;
-        console.debug(`Continuing pagination from version ${currentSince}`);
+      // 3. Advance the cursor and persist it before fetching the next page, so
+      //    an interrupted pull resumes here instead of restarting from zero.
+      //    See pullCursor.ts for why this cannot skip records.
+      const pageOutcome = pullPageOutcome(res.data, currentSince);
+      if (pageOutcome.kind === 'unusable') {
+        throw new Error(
+          `Sync pull stopped after page ${pullPage}: ${pageOutcome.reason}`,
+        );
       }
-    } while (res.data.has_more);
 
-    if (includeAttachments) {
-      await this.processAttachmentManifest(options);
-    }
+      hasMorePages = pageOutcome.kind === 'continue';
+      const cursor =
+        pageOutcome.kind === 'continue'
+          ? pageOutcome.nextSince
+          : pageOutcome.version;
+      if (pageOutcome.kind === 'continue') {
+        currentSince = cursor;
+      } else {
+        finalVersion = cursor;
+      }
 
-    reportSyncProgress(report, {
-      phase: 'pull_observations',
-      current: 1,
-      total: 1,
-      details:
-        totalServerRecordsThisPull > 0
-          ? i18n.t('sync.progress.recordsSummary', {
-              count: totalServerRecordsThisPull,
-            })
-          : i18n.t('sync.progress.upToDate'),
-    });
+      await AsyncStorage.setItem('@last_seen_version', String(cursor));
+      console.debug(
+        `Pull cursor persisted at version ${cursor}${
+          hasMorePages ? ' (more pages follow)' : ''
+        }`,
+      );
+    } while (hasMorePages);
 
     logRepositoryGenerationSync('syncPull all pages done', {
       totalServerRecordsReceived: totalServerRecordsThisPull,
       finalBodyCurrentVersion: res.data.current_version,
       finalBodyRepositoryGeneration: res.data.repository_generation,
+      persistedObservationCursor: finalVersion,
     });
 
     if (totalServerRecordsThisPull === 0) {
@@ -1231,12 +1243,26 @@ class SynkronusApi {
       }
     }
 
-    // Only when all observations are pulled and ingested by WatermelonDB, update the last seen version
-    await AsyncStorage.setItem(
-      '@last_seen_version',
-      res.data.current_version.toString(),
-    );
-    return res.data.current_version;
+    // The observation cursor is already persisted (per page, above). Attachments
+    // carry their own cursor, so a failure here no longer forces a full
+    // re-pull of every observation on the next attempt.
+    if (includeAttachments) {
+      await this.processAttachmentManifest(options);
+    }
+
+    reportSyncProgress(report, {
+      phase: 'pull_observations',
+      current: 1,
+      total: 1,
+      details:
+        totalServerRecordsThisPull > 0
+          ? i18n.t('sync.progress.recordsSummary', {
+              count: totalServerRecordsThisPull,
+            })
+          : i18n.t('sync.progress.upToDate'),
+    });
+
+    return finalVersion;
   }
 
   /**

--- a/formulus/src/api/synkronus/index.ts
+++ b/formulus/src/api/synkronus/index.ts
@@ -1175,7 +1175,31 @@ class SynkronusApi {
 
       // 2. Apply to local db (local dirty records will not be applied = last update wins).
       //    Skipped rows get a `last_write_won` tag (see syncConstants / WatermelonDBRepo).
-      const pulledChanges = await repo.applyServerChanges(domainObservations); // ingest observations into WatermelonDB
+      //    Report before and during this step: on a first-time pull the page
+      //    can be thousands of rows, and indexing them used to leave the
+      //    progress card sitting on "Connecting…" until the flush returned.
+      if (domainObservations.length > 0) {
+        reportSyncProgress(report, {
+          phase: 'pull_observations',
+          current: pullPage,
+          total: 0,
+          indeterminate: true,
+          details: i18n.t('sync.progress.savingRecords', {
+            count: domainObservations.length,
+          }),
+        });
+      }
+      const pulledChanges = await repo.applyServerChanges(domainObservations, {
+        onIndexProgress: ({ current, total }) => {
+          if (total <= 0) return;
+          reportSyncProgress(report, {
+            phase: 'index_rebuild',
+            current,
+            total,
+            details: formatCountProgress(current, total),
+          });
+        },
+      });
       console.debug(`Applied ${pulledChanges} changes to local database`);
 
       reportSyncProgress(report, {

--- a/formulus/src/api/synkronus/pullCursor.ts
+++ b/formulus/src/api/synkronus/pullCursor.ts
@@ -1,0 +1,75 @@
+/**
+ * Decides how the observation pull loop proceeds after a page has been applied
+ * to the local database.
+ *
+ * The pull cursor (`@last_seen_version`) is persisted **per page** rather than
+ * once at the end of the whole pull. That is what makes an interrupted pull
+ * resumable: without it, losing the connection on the last page of a large
+ * repository throws away every page before it and the next attempt starts from
+ * zero again, which on a field connection can mean sync never completes at all.
+ *
+ * Persisting `change_cutoff` cannot skip records. It is the same watermark the
+ * loop already uses to request the next page, so a resumed run asks the server
+ * exactly what this run would have asked for next, and `applyServerChanges`
+ * upserts — re-applying a page that was already applied changes nothing.
+ */
+
+export type PullPageOutcome =
+  /** More pages follow. Request the next one from `nextSince` and persist it. */
+  | { kind: 'continue'; nextSince: number }
+  /** Final page. Persist `version` as the observation stream cursor. */
+  | { kind: 'done'; version: number }
+  /**
+   * The response cannot be used to make progress. Continuing would re-request
+   * the same page forever, so the caller must fail loudly instead of looping.
+   */
+  | { kind: 'unusable'; reason: string };
+
+export interface PullPageCursorFields {
+  current_version?: number | null;
+  change_cutoff?: number | null;
+  has_more?: boolean;
+}
+
+function asVersion(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+export function pullPageOutcome(
+  page: PullPageCursorFields,
+  since: number,
+): PullPageOutcome {
+  if (!page.has_more) {
+    const version = asVersion(page.current_version);
+    if (version == null) {
+      return {
+        kind: 'unusable',
+        reason: `final page reported current_version=${JSON.stringify(
+          page.current_version,
+        )}, which is not a usable version number`,
+      };
+    }
+    return { kind: 'done', version };
+  }
+
+  const cutoff = asVersion(page.change_cutoff);
+  if (cutoff == null) {
+    return {
+      kind: 'unusable',
+      reason: `server reported more pages but change_cutoff=${JSON.stringify(
+        page.change_cutoff,
+      )}, which is not a usable version number`,
+    };
+  }
+  if (cutoff <= since) {
+    return {
+      kind: 'unusable',
+      reason: `server reported more pages but change_cutoff (${cutoff}) does not advance past since (${since})`,
+    };
+  }
+
+  return { kind: 'continue', nextSince: cutoff };
+}

--- a/formulus/src/database/__tests__/observationIndexGuards.test.ts
+++ b/formulus/src/database/__tests__/observationIndexGuards.test.ts
@@ -38,6 +38,7 @@ jest.mock('../../services/AppConfigService', () => ({
 
 import ObservationIndexService, {
   computeDefsSignature,
+  INDEX_WRITE_BATCH_SIZE,
 } from '../../services/ObservationIndexService';
 
 const EMPTY_SIGNATURE = computeDefsSignature([]);
@@ -174,6 +175,39 @@ describe('ObservationIndexService guards', () => {
 
       service.reset();
       await expect(service.isIndexUsable()).resolves.toBe(false);
+    });
+  });
+
+  describe('incrementalReindexMany', () => {
+    it('flushes in bounded writes instead of one statement list for the whole page', async () => {
+      configIndexes.push({ key: 'hh_id', path: '$.hh_id' });
+      const rows = Array.from(
+        { length: INDEX_WRITE_BATCH_SIZE + 50 },
+        (_, i) => ({
+          observationId: `obs-${i}`,
+          formType: 'household',
+          dataJson: JSON.stringify({ hh_id: `HH-${i}` }),
+        }),
+      );
+      rawResults.push([{ active_generation: 1 }], [{ active_generation: 1 }]);
+      mockDb.write.mockClear();
+      const onProgress = jest.fn();
+
+      await service.incrementalReindexMany(rows, onProgress);
+
+      expect(mockDb.write).toHaveBeenCalledTimes(2);
+      expect(onProgress).toHaveBeenCalledWith({
+        current: 0,
+        total: INDEX_WRITE_BATCH_SIZE + 50,
+      });
+      expect(onProgress).toHaveBeenCalledWith({
+        current: INDEX_WRITE_BATCH_SIZE,
+        total: INDEX_WRITE_BATCH_SIZE + 50,
+      });
+      expect(onProgress).toHaveBeenLastCalledWith({
+        current: INDEX_WRITE_BATCH_SIZE + 50,
+        total: INDEX_WRITE_BATCH_SIZE + 50,
+      });
     });
   });
 });

--- a/formulus/src/database/__tests__/observationIndexGuards.test.ts
+++ b/formulus/src/database/__tests__/observationIndexGuards.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Guards that keep an unusable index from silently answering queries.
+ *
+ * The failure this protects against is not an error but an empty result set:
+ * a declared key routes a query into `observation_index`, and if the index was
+ * never built, was emptied by a database wipe, or cannot represent the value,
+ * every predicate simply matches nothing.
+ */
+const configIndexes: Array<Record<string, unknown>> = [];
+
+jest.mock('../../database/database', () => ({
+  database: {
+    write: jest.fn(async (fn: () => Promise<void>) => fn()),
+    adapter: { unsafeExecute: jest.fn(async () => undefined) },
+    get: jest.fn(() => ({
+      query: jest.fn(() => ({ unsafeFetchRaw: jest.fn(async () => []) })),
+    })),
+  },
+}));
+
+jest.mock('../../webview/FormulusMessageHandlers', () => ({
+  appEvents: {
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    emit: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/AppConfigService', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn(() => ({
+      loadConfig: jest.fn(async () => undefined),
+      getConfig: jest.fn(() => ({ observationIndexes: configIndexes })),
+    })),
+  },
+}));
+
+import ObservationIndexService, {
+  computeDefsSignature,
+} from '../../services/ObservationIndexService';
+
+const EMPTY_SIGNATURE = computeDefsSignature([]);
+
+/** Rows handed to successive `unsafeFetchRaw` calls, in order. */
+const rawResults: unknown[][] = [];
+
+const mockDb = {
+  write: jest.fn(async (fn: () => Promise<void>) => fn()),
+  adapter: { unsafeExecute: jest.fn(async () => undefined) },
+  get: jest.fn(() => ({
+    query: jest.fn(() => ({
+      unsafeFetchRaw: jest.fn(async () => rawResults.shift() ?? []),
+    })),
+  })),
+};
+
+describe('ObservationIndexService guards', () => {
+  let service: ObservationIndexService;
+  let warn: jest.SpyInstance;
+
+  beforeAll(async () => {
+    service = ObservationIndexService.getInstance(mockDb as never);
+    // The constructor kicks off a bootstrap rebuild; let it settle so it does
+    // not consume the rows queued by individual tests.
+    await service.ensureInitialRebuild();
+  });
+
+  beforeEach(() => {
+    rawResults.length = 0;
+    configIndexes.length = 0;
+    service.reset();
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  describe('getIndexDefs', () => {
+    it('keeps definitions with a top-level key and path', () => {
+      configIndexes.push({ key: 'hh_id', path: '$.hh_id' });
+      expect(service.getIndexDefs()).toEqual([
+        { key: 'hh_id', path: '$.hh_id' },
+      ]);
+    });
+
+    it('drops definitions missing a key or a path', () => {
+      configIndexes.push(
+        { key: '', path: '$.skip' },
+        { key: 'hh_id', path: '' },
+      );
+      expect(service.getIndexDefs()).toEqual([]);
+    });
+
+    it('drops a nested path, which the extractor cannot read', () => {
+      // Extraction reads data['a.b'] rather than data.a.b, so a nested
+      // definition writes no rows while still routing queries to the index.
+      configIndexes.push({ key: 'a.b', path: '$.a.b' });
+      expect(service.getIndexDefs()).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('declares nested path'),
+      );
+    });
+
+    it('warns about a nested path only once', () => {
+      configIndexes.push({ key: 'a.b', path: '$.a.b' });
+      service.getIndexDefs();
+      service.getIndexDefs();
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('isIndexUsable', () => {
+    function queueUsableIndex(): void {
+      rawResults.push(
+        [{ active_generation: 1 }],
+        [{ present: 1 }],
+        [
+          {
+            active_generation: 1,
+            last_rebuild_at: '2026-01-01',
+            defs_signature: EMPTY_SIGNATURE,
+          },
+        ],
+      );
+    }
+
+    it('reports true when rows exist and the stored signature matches', async () => {
+      queueUsableIndex();
+      await expect(service.isIndexUsable()).resolves.toBe(true);
+    });
+
+    it('reports false when the active generation is empty', async () => {
+      rawResults.push([{ active_generation: 1 }], [{ present: 0 }]);
+      await expect(service.isIndexUsable()).resolves.toBe(false);
+    });
+
+    it('reports false when rows exist but were built from different definitions', async () => {
+      rawResults.push(
+        [{ active_generation: 1 }],
+        [{ present: 1 }],
+        [
+          {
+            active_generation: 1,
+            last_rebuild_at: '2026-01-01',
+            defs_signature: 'stale-bundle',
+          },
+        ],
+      );
+      await expect(service.isIndexUsable()).resolves.toBe(false);
+    });
+
+    it('re-checks after a negative answer so recovery is picked up', async () => {
+      rawResults.push([{ active_generation: 1 }], [{ present: 0 }]);
+      await expect(service.isIndexUsable()).resolves.toBe(false);
+
+      queueUsableIndex();
+      await expect(service.isIndexUsable()).resolves.toBe(true);
+    });
+
+    it('caches a positive answer instead of querying on every call', async () => {
+      queueUsableIndex();
+      await expect(service.isIndexUsable()).resolves.toBe(true);
+
+      // No rows queued: a second query would read the empty queue and report
+      // false, so answering true proves the result was cached.
+      await expect(service.isIndexUsable()).resolves.toBe(true);
+    });
+
+    it('forgets the cached answer after reset, which follows a database wipe', async () => {
+      queueUsableIndex();
+      await expect(service.isIndexUsable()).resolves.toBe(true);
+
+      service.reset();
+      await expect(service.isIndexUsable()).resolves.toBe(false);
+    });
+  });
+});

--- a/formulus/src/database/database.ts
+++ b/formulus/src/database/database.ts
@@ -87,6 +87,18 @@ const migrations = schemaMigrations({
         `),
       ],
     },
+    {
+      toVersion: 7,
+      steps: [
+        // Records which index definitions the current rows were built from, so
+        // an interrupted rebuild is detected on the next launch instead of
+        // looking complete forever. Left NULL for existing installs, which
+        // forces exactly one rebuild after upgrading.
+        unsafeExecuteSql(`
+          ALTER TABLE observation_index_meta ADD COLUMN defs_signature TEXT;
+        `),
+      ],
+    },
   ],
 });
 

--- a/formulus/src/database/repositories/LocalRepoInterface.ts
+++ b/formulus/src/database/repositories/LocalRepoInterface.ts
@@ -70,7 +70,12 @@ export interface LocalRepoInterface {
    * @param changes Array of changes to apply
    * @returns Promise resolving to the number of changes applied
    */
-  applyServerChanges(changes: Observation[]): Promise<number>;
+  applyServerChanges(
+    changes: Observation[],
+    options?: {
+      onIndexProgress?: (progress: { current: number; total: number }) => void;
+    },
+  ): Promise<number>;
 
   /**
    * Get pending changes from the local database

--- a/formulus/src/database/repositories/WatermelonDBRepo.ts
+++ b/formulus/src/database/repositories/WatermelonDBRepo.ts
@@ -257,7 +257,17 @@ export class WatermelonDBRepo implements LocalRepoInterface {
       const indexService = ObservationIndexService.getInstance(this.database);
       await indexService.ensureInitialRebuild();
 
-      const indexKeys = indexKeysFromConfig(indexService.getIndexDefs());
+      let indexKeys = indexKeysFromConfig(indexService.getIndexDefs());
+      if (indexKeys.size > 0 && !(await indexService.isIndexUsable())) {
+        // ensureInitialRebuild() reports success even when it gave up, so this
+        // is the last point at which an unusable index can be caught. Querying
+        // an empty index returns no rows, and one built from a previous
+        // bundle's definitions returns wrong ones — neither raises an error.
+        console.warn(
+          '[queryObservations] observation_index is empty or stale for the active generation; using json_extract so results stay correct',
+        );
+        indexKeys = new Set<string>();
+      }
       const compiled = compileObservationQuery({
         dialect: 'formulus',
         jsonColumn: 'data',
@@ -522,6 +532,12 @@ export class WatermelonDBRepo implements LocalRepoInterface {
       return 0;
     }
 
+    // Only the changes whose data actually landed in the database may be
+    // indexed. A locally dirty record keeps its local data and is merely tagged,
+    // so indexing the server payload for it would leave the index describing
+    // values the stored record does not have — invisible until a full rebuild.
+    const applied: Observation[] = [];
+
     const count = await this.database.write(async () => {
       const existingRecords = await this.observationsCollection
         .query(
@@ -549,6 +565,7 @@ export class WatermelonDBRepo implements LocalRepoInterface {
                 record.tags = serializeTagsColumn(merged);
               });
             }
+            applied.push(change);
             return existing.prepareUpdate(record => {
               record.formType = change.formType || record.formType;
               record.formVersion = change.formVersion || record.formVersion;
@@ -576,6 +593,7 @@ export class WatermelonDBRepo implements LocalRepoInterface {
           console.debug(
             `Preparing create for new observation: ${change.observationId}`,
           );
+          applied.push(change);
           return this.observationsCollection.prepareCreate(record => {
             record._raw.id = change.observationId;
             record.observationId = change.observationId;
@@ -603,7 +621,7 @@ export class WatermelonDBRepo implements LocalRepoInterface {
     });
 
     const indexService = ObservationIndexService.getInstance(this.database);
-    const indexRows = changes.map(change => ({
+    const indexRows = applied.map(change => ({
       observationId: change.observationId,
       formType: change.formType,
       dataJson:

--- a/formulus/src/database/repositories/WatermelonDBRepo.ts
+++ b/formulus/src/database/repositories/WatermelonDBRepo.ts
@@ -527,7 +527,12 @@ export class WatermelonDBRepo implements LocalRepoInterface {
    * Apply changes from the server to the local database
    * @param changes Array of changes to apply
    */
-  async applyServerChanges(changes: Observation[]): Promise<number> {
+  async applyServerChanges(
+    changes: Observation[],
+    options?: {
+      onIndexProgress?: (progress: { current: number; total: number }) => void;
+    },
+  ): Promise<number> {
     if (!changes.length) {
       return 0;
     }
@@ -629,7 +634,10 @@ export class WatermelonDBRepo implements LocalRepoInterface {
           ? change.data
           : JSON.stringify(change.data),
     }));
-    await indexService.incrementalReindexMany(indexRows);
+    await indexService.incrementalReindexMany(
+      indexRows,
+      options?.onIndexProgress,
+    );
 
     return count;
   }

--- a/formulus/src/database/repositories/__tests__/WatermelonDBRepo.test.ts
+++ b/formulus/src/database/repositories/__tests__/WatermelonDBRepo.test.ts
@@ -20,6 +20,7 @@ jest.mock('../../../services/ObservationIndexService', () => {
   const incrementalReindexMany = jest.fn(async () => undefined);
   const getIndexDefs = jest.fn(() => []);
   const ensureInitialRebuild = jest.fn(async () => undefined);
+  const isIndexUsable = jest.fn(async () => true);
   const rebuildAllIndexes = jest.fn(async () => ({
     generation: 1,
     lastRebuildAt: null,
@@ -32,6 +33,7 @@ jest.mock('../../../services/ObservationIndexService', () => {
         incrementalReindexMany,
         getIndexDefs,
         ensureInitialRebuild,
+        isIndexUsable,
         rebuildAllIndexes,
       })),
     },
@@ -48,6 +50,7 @@ import { Observation } from '../LocalRepoInterface';
 import { ObservationMapper } from '../../../mappers/ObservationMapper';
 import { LAST_WRITE_WON_TAG } from '../../../sync/syncConstants';
 import { Q } from '@nozbe/watermelondb';
+import ObservationIndexService from '../../../services/ObservationIndexService';
 
 // Create a test database with in-memory LokiJS adapter
 function createTestDatabase() {
@@ -719,5 +722,50 @@ describe('WatermelonDBRepo', () => {
 
     const appliedAgain = await repo.applyServerChanges([serverObservation]);
     expect(appliedAgain).toBe(0);
+  });
+
+  /**
+   * A locally dirty row keeps its local data and is only tagged, so feeding the
+   * server payload to the index would leave the index describing values the
+   * stored record does not have. Nothing surfaces that divergence until a full
+   * rebuild, and in the meantime an indexed query matches on the wrong values.
+   */
+  test('applyServerChanges only indexes the changes it actually stored', async () => {
+    const localId = await repo.saveObservation({
+      formType: 'form_lww',
+      data: { source: 'local' },
+    });
+
+    const conflicting: Observation = {
+      observationId: localId,
+      formType: 'form_lww',
+      formVersion: '1.0',
+      createdAt: new Date('2025-01-02T10:00:00.000Z'),
+      updatedAt: new Date('2025-01-02T12:00:00.000Z'),
+      syncedAt: null,
+      deleted: false,
+      data: { source: 'server' },
+      geolocation: null,
+    };
+    const fresh: Observation = {
+      ...conflicting,
+      observationId: 'obs_server_only_3003',
+    };
+
+    const indexService = ObservationIndexService.getInstance(
+      database,
+    ) as unknown as {
+      incrementalReindexMany: jest.Mock;
+    };
+    indexService.incrementalReindexMany.mockClear();
+
+    await repo.applyServerChanges([conflicting, fresh]);
+
+    const indexed = indexService.incrementalReindexMany.mock.calls[0][0] as
+      | Array<{ observationId: string }>
+      | undefined;
+    expect(indexed?.map(row => row.observationId)).toEqual([
+      'obs_server_only_3003',
+    ]);
   });
 });

--- a/formulus/src/database/schema.ts
+++ b/formulus/src/database/schema.ts
@@ -2,7 +2,7 @@ import { appSchema, tableSchema } from '@nozbe/watermelondb';
 
 // Define the database schema
 export const schemas = appSchema({
-  version: 6,
+  version: 7,
   tables: [
     tableSchema({
       name: 'observations',
@@ -27,6 +27,11 @@ export const schemas = appSchema({
         { name: 'active_generation', type: 'number' },
         { name: 'building_generation', type: 'number', isOptional: true },
         { name: 'last_rebuild_at', type: 'string', isOptional: true },
+        // Identifies the index definitions the current rows were built from.
+        // `last_rebuild_at` only records that some rebuild happened; without
+        // this, a rebuild interrupted by a crash is indistinguishable from a
+        // completed one and never reruns.
+        { name: 'defs_signature', type: 'string', isOptional: true },
       ],
     }),
     tableSchema({

--- a/formulus/src/locales/en.json
+++ b/formulus/src/locales/en.json
@@ -135,6 +135,7 @@
   "sync.progress.phase.push_attachments": "Uploading attachments",
   "sync.progress.phase.push_observations": "Uploading changes",
   "sync.progress.phase.app_bundle": "Updating forms",
+  "sync.progress.phase.index_rebuild": "Preparing data for search",
   "sync.progress.phase.default": "Syncing",
   "sync.progress.syncingAndUpdatingForms": "Syncing & updating forms",
   "sync.progress.syncingAndUpdating": "Syncing & updating",

--- a/formulus/src/locales/en.json
+++ b/formulus/src/locales/en.json
@@ -149,6 +149,8 @@
   "sync.progress.downloadingPage": "Downloading (page {{page}})…",
   "sync.progress.recordsDownloaded_one": "{{count}} observation downloaded",
   "sync.progress.recordsDownloaded_other": "{{count}} observations downloaded",
+  "sync.progress.savingRecords_one": "Saving {{count}} observation…",
+  "sync.progress.savingRecords_other": "Saving {{count}} observations…",
   "sync.progress.recordsSummary_one": "{{count}} observation",
   "sync.progress.recordsSummary_other": "{{count}} observations",
   "sync.progress.nothingToUpload": "Nothing to upload",

--- a/formulus/src/locales/fr.json
+++ b/formulus/src/locales/fr.json
@@ -135,6 +135,7 @@
   "sync.progress.phase.push_attachments": "Envoi des pièces jointes",
   "sync.progress.phase.push_observations": "Envoi des modifications",
   "sync.progress.phase.app_bundle": "Mise à jour des formulaires",
+  "sync.progress.phase.index_rebuild": "Préparation des données pour la recherche",
   "sync.progress.phase.default": "Synchronisation",
   "sync.progress.syncingAndUpdatingForms": "Synchronisation et mise à jour des formulaires",
   "sync.progress.syncingAndUpdating": "Synchronisation et mise à jour",

--- a/formulus/src/locales/fr.json
+++ b/formulus/src/locales/fr.json
@@ -149,6 +149,8 @@
   "sync.progress.downloadingPage": "Téléchargement (page {{page}})…",
   "sync.progress.recordsDownloaded_one": "{{count}} observation téléchargée",
   "sync.progress.recordsDownloaded_other": "{{count}} observations téléchargées",
+  "sync.progress.savingRecords_one": "Enregistrement de {{count}} observation…",
+  "sync.progress.savingRecords_other": "Enregistrement de {{count}} observations…",
   "sync.progress.recordsSummary_one": "{{count}} observation",
   "sync.progress.recordsSummary_other": "{{count}} observations",
   "sync.progress.nothingToUpload": "Rien à envoyer",

--- a/formulus/src/locales/pt.json
+++ b/formulus/src/locales/pt.json
@@ -149,6 +149,8 @@
   "sync.progress.downloadingPage": "A descarregar (página {{page}})…",
   "sync.progress.recordsDownloaded_one": "{{count}} observação descarregada",
   "sync.progress.recordsDownloaded_other": "{{count}} observações descarregadas",
+  "sync.progress.savingRecords_one": "A guardar {{count}} observação…",
+  "sync.progress.savingRecords_other": "A guardar {{count}} observações…",
   "sync.progress.recordsSummary_one": "{{count}} observação",
   "sync.progress.recordsSummary_other": "{{count}} observações",
   "sync.progress.nothingToUpload": "Nada para enviar",

--- a/formulus/src/locales/pt.json
+++ b/formulus/src/locales/pt.json
@@ -135,6 +135,7 @@
   "sync.progress.phase.push_attachments": "A enviar anexos",
   "sync.progress.phase.push_observations": "A enviar alterações",
   "sync.progress.phase.app_bundle": "A atualizar formulários",
+  "sync.progress.phase.index_rebuild": "A preparar dados para pesquisa",
   "sync.progress.phase.default": "A sincronizar",
   "sync.progress.syncingAndUpdatingForms": "A sincronizar e atualizar formulários",
   "sync.progress.syncingAndUpdating": "A sincronizar e atualizar",

--- a/formulus/src/services/AppConfigService.ts
+++ b/formulus/src/services/AppConfigService.ts
@@ -94,21 +94,26 @@ class AppConfigService {
       const raw = await RNFS.readFile(APP_CONFIG_PATH, 'utf8');
       const parsed: AppConfig = JSON.parse(raw);
 
-      // Basic validation
+      // A missing or malformed theme only disables theming. It used to discard
+      // the whole config, which also silently dropped observationIndexes and
+      // left every declared query unindexed for no visible reason.
       if (!parsed.theme?.light || !parsed.theme?.dark) {
         console.warn(
-          '[AppConfigService] app.config.json is missing theme.light or theme.dark — ignoring.',
-        );
-        this.config = null;
-      } else {
-        this.config = parsed;
-        console.log(
-          `[AppConfigService] Loaded config for "${parsed.name}" v${parsed.version}`,
+          '[AppConfigService] app.config.json is missing theme.light or theme.dark — falling back to ODE colors.',
         );
       }
+
+      this.config = parsed;
+      console.log(
+        `[AppConfigService] Loaded config for "${parsed.name}" v${parsed.version}`,
+      );
     } catch (err) {
+      // Deliberately not latching `loaded` here. A read that throws mid-bundle
+      // extraction is transient, and latching would pin the config to null —
+      // and with it the index definitions — for the rest of the process.
       console.warn('[AppConfigService] Failed to load app.config.json:', err);
       this.config = null;
+      return;
     }
 
     this.loaded = true;
@@ -134,10 +139,7 @@ class AppConfigService {
    * Returns the custom app colors if available, otherwise ODE defaults.
    */
   getThemeColors(mode: 'light' | 'dark'): ThemeColors {
-    if (this.config) {
-      return this.config.theme[mode];
-    }
-    return getOdeFallbackColors(mode);
+    return this.config?.theme?.[mode] ?? getOdeFallbackColors(mode);
   }
 
   /**

--- a/formulus/src/services/ObservationIndexService.ts
+++ b/formulus/src/services/ObservationIndexService.ts
@@ -3,10 +3,14 @@
  * Rebuild uses snapshot generation swap; incremental updates on save/sync.
  *
  * Implementation notes:
- *  - All write paths collect SQL into an array and flush once via
+ *  - Incremental write paths collect SQL into an array and flush once via
  *    `db.adapter.unsafeExecute({ sqls })` inside a single `db.write(...)`
  *    block. This avoids nested `db.write` calls, which deadlock under
  *    WatermelonDB's serial WorkQueue.
+ *  - A full rebuild writes in bounded batches so the INSERT list cannot grow
+ *    with the whole repository. The signature is cleared first and stamped
+ *    last, so a crash mid-rebuild is indistinguishable from "not current"
+ *    and the next launch reruns.
  *  - `ensureInitialRebuild()` runs on first instantiation to populate the
  *    index for users who already have synced rows from before indexing
  *    landed.
@@ -109,8 +113,18 @@ function yieldToUi(): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, 0));
 }
 
-/** Observations read per batch between yields. */
-const REBUILD_BATCH_SIZE = 200;
+/**
+ * Observations processed per index write.
+ *
+ * Used by a full rebuild and by `incrementalReindexMany` (sync pull). Each
+ * observation produces a DELETE plus one INSERT per matching definition, and
+ * none of that is released until `unsafeExecute` returns. Two hundred rows
+ * keeps the statement list in the low thousands even with a generous
+ * `observationIndexes` config — small enough for a Blackview-class tablet,
+ * large enough that a first-time pull of a few thousand observations is
+ * tens of writes rather than one giant flush.
+ */
+export const INDEX_WRITE_BATCH_SIZE = 200;
 
 export interface IndexRebuildProgress {
   /** Observations processed so far. */
@@ -368,63 +382,82 @@ export class ObservationIndexService {
     // The rebuild empties the table before refilling it, and may legitimately
     // end with no rows at all, so any cached "index is healthy" answer is void.
     this.indexUsable = false;
-    return this.db.write(async () => {
+
+    // Invalidate the signature *before* touching rows. A crash after this
+    // point leaves `isIndexUsable` false even if some batches have landed,
+    // and `ensureInitialRebuild` will rerun instead of treating the partial
+    // table as current. OFFSET pagination is unsafe once we release the
+    // write lock between batches (a concurrent insert shifts the window),
+    // so the scan walks `id > cursor` instead.
+    await this.db.write(async () => {
       await this.db.adapter.unsafeExecute({
         sqls: [
           [
             `INSERT OR IGNORE INTO observation_index_meta(id, active_generation) VALUES (?, ?)`,
             ['meta', gen],
           ],
+          [
+            `UPDATE observation_index_meta
+             SET defs_signature = NULL, building_generation = ?
+             WHERE id = ?`,
+            [gen, 'meta'],
+          ],
+          ['DELETE FROM observation_index', []],
         ],
       });
+    });
 
-      const totalRows = await this.query<{ cnt: number }>(
-        'SELECT COUNT(*) AS cnt FROM observations',
+    const totalRows = await this.query<{ cnt: number }>(
+      'SELECT COUNT(*) AS cnt FROM observations',
+    );
+    const total = totalRows[0]?.cnt ?? 0;
+
+    let processed = 0;
+    let cursor: string | null = null;
+    options?.onProgress?.({ current: 0, total });
+
+    while (true) {
+      const batch = await this.query<{
+        id: string;
+        form_type: string;
+        data: string;
+      }>(
+        cursor == null
+          ? 'SELECT id, form_type, data FROM observations ORDER BY id LIMIT ?'
+          : 'SELECT id, form_type, data FROM observations WHERE id > ? ORDER BY id LIMIT ?',
+        cursor == null
+          ? [INDEX_WRITE_BATCH_SIZE]
+          : [cursor, INDEX_WRITE_BATCH_SIZE],
       );
-      const total = totalRows[0]?.cnt ?? 0;
+      if (!batch.length) break;
 
       const sqls: SqlStatement[] = [];
-      sqls.push(['DELETE FROM observation_index', []]);
-
-      // Read in batches and yield between them. The scan parses each
-      // observation's JSON once per definition, which on a full repository is
-      // long enough to freeze the UI if run as a single loop.
-      let processed = 0;
-      options?.onProgress?.({ current: 0, total });
-      for (let offset = 0; offset < total; offset += REBUILD_BATCH_SIZE) {
-        const batch = await this.query<{
-          id: string;
-          form_type: string;
-          data: string;
-        }>(
-          'SELECT id, form_type, data FROM observations ORDER BY id LIMIT ? OFFSET ?',
-          [REBUILD_BATCH_SIZE, offset],
+      for (const obs of batch) {
+        this.collectReindexStatements(
+          obs.id,
+          obs.form_type ?? '',
+          obs.data,
+          defs,
+          gen,
+          sqls,
         );
-        if (!batch.length) break;
-
-        for (const obs of batch) {
-          this.collectReindexStatements(
-            obs.id,
-            obs.form_type ?? '',
-            obs.data,
-            defs,
-            gen,
-            sqls,
-          );
-        }
-
-        processed += batch.length;
-        options?.onProgress?.({ current: processed, total });
-        await yieldToUi();
       }
+      await this.db.write(async () => {
+        await this.flush(sqls);
+      });
 
-      this.collectSqliteIndexStatements(defs, sqls);
+      cursor = batch[batch.length - 1].id;
+      processed += batch.length;
+      options?.onProgress?.({ current: processed, total });
+      await yieldToUi();
+    }
 
-      await this.flush(sqls);
-
-      // Stamp meta in a separate execute; batched meta UPDATE was not sticking.
-      // Written only after the rows land, so a rebuild interrupted before this
-      // point leaves a signature that no longer matches and reruns next launch.
+    const indexSqls: SqlStatement[] = [];
+    this.collectSqliteIndexStatements(defs, indexSqls);
+    await this.db.write(async () => {
+      await this.flush(indexSqls);
+      // Stamp only after every batch has landed. Batched meta UPDATE was not
+      // sticking on device, so this stays a separate execute.
       await this.db.adapter.unsafeExecute({
         sqls: [
           [
@@ -435,14 +468,13 @@ export class ObservationIndexService {
           ],
         ],
       });
-
-      const metaAfter = await this.getStatus();
-
-      return {
-        generation: gen,
-        lastRebuildAt: metaAfter.lastRebuildAt,
-      };
     });
+
+    const metaAfter = await this.getStatus();
+    return {
+      generation: gen,
+      lastRebuildAt: metaAfter.lastRebuildAt,
+    };
   }
 
   async incrementalReindex(
@@ -468,29 +500,54 @@ export class ObservationIndexService {
   }
 
   /**
-   * Reindex many observations in a single batched write. Used by sync paths
-   * that ingest large numbers of rows.
+   * Reindex many observations in bounded writes. Used by sync pull, where the
+   * first page on a new device can be thousands of rows — not a full rebuild,
+   * but the same shape of OOM if every INSERT is held until one flush.
+   *
+   * The signature is left alone: this is additive work against the current
+   * definitions. A crash mid-loop is safe because the pull cursor is persisted
+   * only after this returns, so the page is re-applied and these statements
+   * are INSERT OR REPLACE.
    */
   async incrementalReindexMany(
     rows: Array<{ observationId: string; formType: string; dataJson: string }>,
+    onProgress?: (progress: IndexRebuildProgress) => void,
   ): Promise<void> {
     const defs = this.getIndexDefs();
     if (!defs.length || rows.length === 0) return;
-    await this.db.write(async () => {
-      const generation = await this.readActiveGeneration();
-      const sqls: SqlStatement[] = [];
-      for (const r of rows) {
-        this.collectReindexStatements(
-          r.observationId,
-          r.formType,
-          r.dataJson,
-          defs,
-          generation,
-          sqls,
-        );
+
+    const total = rows.length;
+    onProgress?.({ current: 0, total });
+
+    for (
+      let offset = 0;
+      offset < rows.length;
+      offset += INDEX_WRITE_BATCH_SIZE
+    ) {
+      const batch = rows.slice(offset, offset + INDEX_WRITE_BATCH_SIZE);
+      await this.db.write(async () => {
+        const generation = await this.readActiveGeneration();
+        const sqls: SqlStatement[] = [];
+        for (const r of batch) {
+          this.collectReindexStatements(
+            r.observationId,
+            r.formType,
+            r.dataJson,
+            defs,
+            generation,
+            sqls,
+          );
+        }
+        await this.flush(sqls);
+      });
+      onProgress?.({
+        current: Math.min(offset + batch.length, total),
+        total,
+      });
+      if (offset + INDEX_WRITE_BATCH_SIZE < rows.length) {
+        await yieldToUi();
       }
-      await this.flush(sqls);
-    });
+    }
   }
 
   /**

--- a/formulus/src/services/ObservationIndexService.ts
+++ b/formulus/src/services/ObservationIndexService.ts
@@ -15,7 +15,6 @@ import { Database, Q } from '@nozbe/watermelondb';
 import { database } from '../database/database';
 import { ObservationModel } from '../database/models/ObservationModel';
 import AppConfigService from './AppConfigService';
-import { appEvents } from '../webview/FormulusMessageHandlers';
 import type { ObservationIndexDef } from '../types/AppConfig';
 
 type SqlArg = string | number | boolean | null;
@@ -33,11 +32,23 @@ function jsonPathToKey(path: string): string {
   return path.startsWith('$.') ? path.slice(2) : path;
 }
 
+/**
+ * Map a JSON scalar onto the index columns, or null when it should not be
+ * indexed at all.
+ *
+ * Numbers go to `value_num` and other scalars to `value_text`; the query
+ * compiler encodes the same split, so changing it here silently changes query
+ * results. Arrays and objects are deliberately excluded: stringifying them
+ * produced rows like `"[object Object],[object Object]"` that no query could
+ * ever match, since a scalar filter compares against the whole blob and an
+ * `any` filter goes through `json_each` instead. The row was pure write cost
+ * with a misleading appearance of coverage.
+ */
 function scalarToColumns(
   val: unknown,
   valueType?: string,
-): { valueText: string | null; valueNum: number | null } {
-  if (val == null) return { valueText: null, valueNum: null };
+): { valueText: string | null; valueNum: number | null } | null {
+  if (val == null) return null;
   if (valueType === 'number' || typeof val === 'number') {
     const n = Number(val);
     if (!Number.isNaN(n)) return { valueText: null, valueNum: n };
@@ -45,7 +56,67 @@ function scalarToColumns(
   if (typeof val === 'string') return { valueText: val, valueNum: null };
   if (typeof val === 'boolean')
     return { valueText: String(val), valueNum: null };
-  return { valueText: String(val), valueNum: null };
+  return null;
+}
+
+/**
+ * Only top-level keys can be indexed.
+ *
+ * Extraction reads `data[key]`, so a nested path yields undefined and writes no
+ * rows — while the declared key still routes queries to the index, where they
+ * match nothing. Rejecting the definition instead keeps those queries on the
+ * json_extract path, which handles nesting correctly.
+ */
+function isSupportedIndexPath(path: string): boolean {
+  const key = jsonPathToKey(path);
+  return key.length > 0 && !key.includes('.') && !key.includes('[');
+}
+
+/**
+ * A stable fingerprint of the index definitions a rebuild was run against.
+ *
+ * Stored alongside the rows so `last_rebuild_at` stops being the only evidence
+ * that the index is current. A timestamp records that *a* rebuild happened; it
+ * cannot distinguish an index built from today's definitions from one built
+ * from the previous bundle's, nor a completed rebuild from one the app died
+ * halfway through. Comparing signatures makes both cases self-correcting: the
+ * next launch sees a mismatch and rebuilds.
+ *
+ * Order-independent, so merely reordering entries in app.config.json does not
+ * trigger a rebuild of every observation on every device.
+ */
+export function computeDefsSignature(defs: ObservationIndexDef[]): string {
+  const normalized = defs
+    .map(def => ({
+      key: def.key,
+      path: def.path,
+      formTypes: [...(def.formTypes ?? [])].sort(),
+      valueType: def.valueType ?? null,
+      expressionIndex: def.enableExpressionIndex !== false,
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+  return JSON.stringify(normalized);
+}
+
+/**
+ * Yield to the event loop so React Native can paint.
+ *
+ * A rebuild walks every observation and parses its JSON once per definition.
+ * Left as one uninterrupted loop that work blocks the JS thread, which freezes
+ * the UI — including whatever spinner is meant to show the rebuild running.
+ */
+function yieldToUi(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+/** Observations read per batch between yields. */
+const REBUILD_BATCH_SIZE = 200;
+
+export interface IndexRebuildProgress {
+  /** Observations processed so far. */
+  current: number;
+  /** Total observations to process. */
+  total: number;
 }
 
 function extractScalar(dataJson: string, path: string): unknown {
@@ -62,22 +133,17 @@ export class ObservationIndexService {
   private readonly db: Database;
   private initialRebuildPromise: Promise<void> | null = null;
   private initialRebuildFinished = false;
+  private indexUsable = false;
+  private readonly warnedOnce = new Set<string>();
 
   private constructor(db: Database) {
     this.db = db;
-    appEvents.addListener('bundleUpdated', () => {
-      void (async () => {
-        try {
-          await AppConfigService.getInstance().loadConfig(/* force */ true);
-          await this.rebuildAllIndexes();
-        } catch (err) {
-          console.warn(
-            '[ObservationIndexService] rebuild after bundle failed:',
-            err,
-          );
-        }
-      })();
-    });
+    // The rebuild that follows a bundle update is driven by SyncService via
+    // `rebuildForBundleUpdate`, which awaits it and reports progress. It used
+    // to be a fire-and-forget listener here: the sync reported "complete" while
+    // the rebuild was still running, and any failure went to a console warning
+    // that nothing acted on. `bundleUpdated` still fires for the other
+    // listeners; it just no longer owns the rebuild.
     void this.ensureInitialRebuild();
   }
 
@@ -90,7 +156,83 @@ export class ObservationIndexService {
 
   getIndexDefs(): ObservationIndexDef[] {
     const cfg = AppConfigService.getInstance().getConfig();
-    return (cfg?.observationIndexes ?? []).filter(d => d.key && d.path);
+    return (cfg?.observationIndexes ?? []).filter(d => {
+      if (!d.key || !d.path) return false;
+      if (!isSupportedIndexPath(d.path)) {
+        this.warnOnce(
+          `path:${d.key}`,
+          `[ObservationIndexService] index "${d.key}" declares nested path "${d.path}"; only top-level keys can be indexed, so queries on it will use json_extract`,
+        );
+        return false;
+      }
+      return true;
+    });
+  }
+
+  /**
+   * Whether queries may trust `observation_index` for the active generation.
+   *
+   * A declared key routes a query through the index, so an index that cannot be
+   * trusted turns every predicate on it into a silent wrong answer rather than
+   * an error. Two ways that happens:
+   *
+   * - **No rows.** Never built, emptied by a database wipe, or abandoned by a
+   *   failed rebuild. Every indexed predicate matches nothing.
+   * - **Rows built from different definitions.** A bundle changed the declared
+   *   indexes and the rebuild did not finish. The rows look healthy and are
+   *   quietly answering for the previous bundle's schema.
+   *
+   * Either way the caller drops back to json_extract, which is slower but reads
+   * the observation JSON directly and is therefore always right.
+   *
+   * Only the negative answer is re-checked. A usable index stays usable until a
+   * rebuild or a wipe, and both clear this flag.
+   */
+  async isIndexUsable(): Promise<boolean> {
+    if (this.indexUsable) return true;
+
+    const generation = await this.readActiveGeneration();
+    const rows = await this.query<{ present: number }>(
+      'SELECT EXISTS(SELECT 1 FROM observation_index WHERE index_generation = ?) AS present',
+      [generation],
+    );
+    if ((rows[0]?.present ?? 0) !== 1) {
+      this.indexUsable = false;
+      return false;
+    }
+
+    const expected = computeDefsSignature(this.getIndexDefs());
+    const stored = (await this.getStatus()).defsSignature;
+    if (stored !== expected) {
+      this.warnOnce(
+        'signature-mismatch',
+        '[ObservationIndexService] index rows were built from different index definitions — falling back to json_extract until a rebuild completes',
+      );
+      this.indexUsable = false;
+      return false;
+    }
+
+    this.indexUsable = true;
+    return true;
+  }
+
+  /**
+   * Forget everything cached about the index.
+   *
+   * `unsafeResetDatabase` recreates the index tables empty, but this singleton
+   * survives it and would otherwise report a rebuild it no longer has.
+   */
+  reset(): void {
+    this.initialRebuildPromise = null;
+    this.initialRebuildFinished = false;
+    this.indexUsable = false;
+    this.warnedOnce.clear();
+  }
+
+  private warnOnce(token: string, message: string): void {
+    if (this.warnedOnce.has(token)) return;
+    this.warnedOnce.add(token);
+    console.warn(message);
   }
 
   getInitialRebuildFinished(): boolean {
@@ -100,18 +242,21 @@ export class ObservationIndexService {
   async getStatus(): Promise<{
     activeGeneration: number;
     lastRebuildAt: string | null;
+    defsSignature: string | null;
   }> {
     const rows = await this.query<{
       active_generation: number;
       last_rebuild_at: string | null;
+      defs_signature: string | null;
     }>(
-      'SELECT active_generation, last_rebuild_at FROM observation_index_meta WHERE id = ?',
+      'SELECT active_generation, last_rebuild_at, defs_signature FROM observation_index_meta WHERE id = ?',
       ['meta'],
     );
     const row = rows[0];
     return {
       activeGeneration: row?.active_generation ?? 1,
       lastRebuildAt: row?.last_rebuild_at ?? null,
+      defsSignature: row?.defs_signature ?? null,
     };
   }
 
@@ -145,10 +290,19 @@ export class ObservationIndexService {
         );
         const observationCount = obsCountRows[0]?.cnt ?? 0;
 
+        // A populated table is not evidence that it is *current*. If the stored
+        // signature does not match the definitions in force, the rows were
+        // built from a previous bundle or by a rebuild that never finished, and
+        // skipping here would leave that state in place permanently.
+        const signatureMatches =
+          status.defsSignature === computeDefsSignature(this.getIndexDefs());
+
         const skipBecausePopulated =
-          Boolean(status.lastRebuildAt) && indexCount > 0;
+          Boolean(status.lastRebuildAt) && indexCount > 0 && signatureMatches;
         const skipBecauseEmptyInstall =
-          observationCount === 0 && Boolean(status.lastRebuildAt);
+          observationCount === 0 &&
+          Boolean(status.lastRebuildAt) &&
+          signatureMatches;
 
         if (skipBecausePopulated) {
           this.initialRebuildFinished = true;
@@ -158,6 +312,12 @@ export class ObservationIndexService {
         if (skipBecauseEmptyInstall) {
           this.initialRebuildFinished = true;
           return;
+        }
+
+        if (!signatureMatches && Boolean(status.lastRebuildAt)) {
+          console.log(
+            '[ObservationIndexService] index definitions changed or a previous rebuild did not complete — rebuilding',
+          );
         }
 
         await this.rebuildAllIndexes();
@@ -171,15 +331,43 @@ export class ObservationIndexService {
     return this.initialRebuildPromise;
   }
 
-  async rebuildAllIndexes(): Promise<{
+  /**
+   * Reload the app config and rebuild the index against the definitions the
+   * newly installed bundle declares.
+   *
+   * Callers are expected to await this and show progress. A bundle can add,
+   * remove or retarget index definitions, and until the rebuild finishes every
+   * query on a changed key falls back to json_extract.
+   */
+  async rebuildForBundleUpdate(
+    onProgress?: (progress: IndexRebuildProgress) => void,
+  ): Promise<void> {
+    await AppConfigService.getInstance().loadConfig(/* force */ true);
+    try {
+      await this.rebuildAllIndexes({ onProgress });
+    } catch (err) {
+      // Leave no memoised "rebuild finished" behind: the next query re-runs
+      // the check, sees the signature mismatch, and tries again.
+      this.reset();
+      throw err;
+    }
+  }
+
+  async rebuildAllIndexes(options?: {
+    onProgress?: (progress: IndexRebuildProgress) => void;
+  }): Promise<{
     generation: number;
     lastRebuildAt: string | null;
   }> {
     const defs = this.getIndexDefs();
+    const signature = computeDefsSignature(defs);
     // Always rebuild in-place on generation 1. The previous 1↔2 swap wrote
     // index rows to the new generation but the meta active_generation UPDATE
     // did not persist on device (runtime logs: gen-2 rows, activeGeneration=1).
     const gen = 1;
+    // The rebuild empties the table before refilling it, and may legitimately
+    // end with no rows at all, so any cached "index is healthy" answer is void.
+    this.indexUsable = false;
     return this.db.write(async () => {
       await this.db.adapter.unsafeExecute({
         sqls: [
@@ -190,24 +378,44 @@ export class ObservationIndexService {
         ],
       });
 
-      const observations = await this.query<{
-        id: string;
-        form_type: string;
-        data: string;
-      }>('SELECT id, form_type, data FROM observations');
+      const totalRows = await this.query<{ cnt: number }>(
+        'SELECT COUNT(*) AS cnt FROM observations',
+      );
+      const total = totalRows[0]?.cnt ?? 0;
 
       const sqls: SqlStatement[] = [];
       sqls.push(['DELETE FROM observation_index', []]);
 
-      for (const obs of observations) {
-        this.collectReindexStatements(
-          obs.id,
-          obs.form_type ?? '',
-          obs.data,
-          defs,
-          gen,
-          sqls,
+      // Read in batches and yield between them. The scan parses each
+      // observation's JSON once per definition, which on a full repository is
+      // long enough to freeze the UI if run as a single loop.
+      let processed = 0;
+      options?.onProgress?.({ current: 0, total });
+      for (let offset = 0; offset < total; offset += REBUILD_BATCH_SIZE) {
+        const batch = await this.query<{
+          id: string;
+          form_type: string;
+          data: string;
+        }>(
+          'SELECT id, form_type, data FROM observations ORDER BY id LIMIT ? OFFSET ?',
+          [REBUILD_BATCH_SIZE, offset],
         );
+        if (!batch.length) break;
+
+        for (const obs of batch) {
+          this.collectReindexStatements(
+            obs.id,
+            obs.form_type ?? '',
+            obs.data,
+            defs,
+            gen,
+            sqls,
+          );
+        }
+
+        processed += batch.length;
+        options?.onProgress?.({ current: processed, total });
+        await yieldToUi();
       }
 
       this.collectSqliteIndexStatements(defs, sqls);
@@ -215,13 +423,15 @@ export class ObservationIndexService {
       await this.flush(sqls);
 
       // Stamp meta in a separate execute; batched meta UPDATE was not sticking.
+      // Written only after the rows land, so a rebuild interrupted before this
+      // point leaves a signature that no longer matches and reruns next launch.
       await this.db.adapter.unsafeExecute({
         sqls: [
           [
             `UPDATE observation_index_meta
-             SET active_generation = ?, building_generation = NULL, last_rebuild_at = datetime('now')
+             SET active_generation = ?, building_generation = NULL, last_rebuild_at = datetime('now'), defs_signature = ?
              WHERE id = ?`,
-            [gen, 'meta'],
+            [gen, signature, 'meta'],
           ],
         ],
       });
@@ -312,7 +522,15 @@ export class ObservationIndexService {
       if (!formTypeMatches(formType, def.formTypes)) continue;
       const val = extractScalar(dataJson, def.path);
       if (val == null) continue;
-      const { valueText, valueNum } = scalarToColumns(val, def.valueType);
+      const columns = scalarToColumns(val, def.valueType);
+      if (!columns) {
+        this.warnOnce(
+          `nonscalar:${def.key}`,
+          `[ObservationIndexService] index "${def.key}" holds a non-scalar value; it is not indexed, so only any() filters can match it`,
+        );
+        continue;
+      }
+      const { valueText, valueNum } = columns;
       const rowId = `${observationId}:${def.key}:${generation}`;
       out.push([
         `INSERT OR REPLACE INTO observation_index

--- a/formulus/src/services/RepositoryRecoveryService.ts
+++ b/formulus/src/services/RepositoryRecoveryService.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import RNFS from 'react-native-fs';
 import { database } from '../database/database';
 import { synkronusApi } from '../api/synkronus';
+import ObservationIndexService from './ObservationIndexService';
 
 const REPOSITORY_GENERATION_KEY = '@repository_generation';
 
@@ -33,6 +34,10 @@ class RepositoryRecoveryService {
     await database.write(async () => {
       await database.unsafeResetDatabase();
     });
+
+    // The index tables come back empty, but the service is a singleton and
+    // still believes it has a completed rebuild behind it.
+    ObservationIndexService.getInstance(database).reset();
 
     await AsyncStorage.multiRemove([
       '@last_seen_version',

--- a/formulus/src/services/ServerSwitchService.ts
+++ b/formulus/src/services/ServerSwitchService.ts
@@ -6,6 +6,7 @@ import { synkronusApi } from '../api/synkronus';
 import { logout } from '../api/synkronus/Auth';
 import { serverConfigService } from './ServerConfigService';
 import { invalidateSettingsHydrationCache } from './SettingsHydrationCache';
+import ObservationIndexService from './ObservationIndexService';
 
 /**
  * Handles cleanup when switching Synkronus servers to avoid cross-server data.
@@ -52,6 +53,10 @@ class ServerSwitchService {
     await database.write(async () => {
       await database.unsafeResetDatabase();
     });
+
+    // The index tables come back empty, but the service is a singleton and
+    // still believes it has a completed rebuild behind it.
+    ObservationIndexService.getInstance(database).reset();
 
     // 4) Clear sync/app metadata + tokens
     await AsyncStorage.multiRemove([

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -1,12 +1,16 @@
 import { synkronusApi } from '../api/synkronus';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { appEvents } from '../webview/FormulusMessageHandlers';
-import type { SyncProgress } from '../sync/syncProgress';
-import type { SynkronusSyncOptions } from '../sync/syncProgress';
+import {
+  formatCountProgress,
+  type SyncProgress,
+  type SynkronusSyncOptions,
+} from '../sync/syncProgress';
 import { notificationService } from './NotificationService';
 import { getUserFacingAppBundleUpdateErrorMessage } from './appBundleUpdateErrors';
 import { FormService } from './FormService';
 import { formLocaleIndexService } from './FormLocaleIndexService';
+import ObservationIndexService from './ObservationIndexService';
 import {
   autoLogin,
   getUserFacingSyncErrorMessage,
@@ -399,6 +403,29 @@ export class SyncService {
       await formService.invalidateCache();
 
       await formLocaleIndexService.refreshIndex();
+
+      // The bundle is the only way new index definitions arrive. Await the
+      // rebuild here rather than firing it from `bundleUpdated`: that event
+      // used to start a fire-and-forget rebuild, so sync reported "complete"
+      // while the index was still being written, and a crash left rows built
+      // from the previous bundle with no record that they were stale.
+      this.updateStatus(i18n.t('sync.progress.phase.index_rebuild'));
+      this.updateProgress({
+        current: 0,
+        total: 0,
+        phase: 'index_rebuild',
+        indeterminate: true,
+      });
+      await ObservationIndexService.getInstance().rebuildForBundleUpdate(
+        ({ current, total }) => {
+          this.updateProgress({
+            current,
+            total,
+            phase: 'index_rebuild',
+            details: formatCountProgress(current, total),
+          });
+        },
+      );
 
       const syncTime = new Date().toLocaleTimeString();
       await AsyncStorage.setItem('@lastSync', syncTime);

--- a/formulus/src/services/__tests__/ServerSwitchService.test.ts
+++ b/formulus/src/services/__tests__/ServerSwitchService.test.ts
@@ -56,6 +56,12 @@ jest.mock('../ServerConfigService', () => ({
   serverConfigService: mockServerConfigService,
 }));
 
+const mockIndexReset = jest.fn();
+jest.mock('../ObservationIndexService', () => ({
+  __esModule: true,
+  default: { getInstance: jest.fn(() => ({ reset: mockIndexReset })) },
+}));
+
 const { serverSwitchService } = require('../ServerSwitchService');
 
 describe('ServerSwitchService', () => {
@@ -81,6 +87,10 @@ describe('ServerSwitchService', () => {
 
     expect(mockDatabase.write).toHaveBeenCalled();
     expect(mockDatabase.unsafeResetDatabase).toHaveBeenCalled();
+
+    // The index service is a singleton and survives the database reset, so it
+    // has to be told that the rebuild it remembers is gone.
+    expect(mockIndexReset).toHaveBeenCalled();
 
     expect(mockAsyncStorage.multiRemove).toHaveBeenCalledWith([
       '@last_seen_version',

--- a/formulus/src/services/__tests__/SyncService.autoLogin.test.ts
+++ b/formulus/src/services/__tests__/SyncService.autoLogin.test.ts
@@ -118,6 +118,14 @@ jest.mock('../FormLocaleIndexService', () => ({
     refreshIndex: jest.fn().mockResolvedValue([]),
   },
 }));
+jest.mock('../ObservationIndexService', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn(() => ({
+      rebuildForBundleUpdate: jest.fn().mockResolvedValue(undefined),
+    })),
+  },
+}));
 
 import {
   jest,

--- a/formulus/src/sync/__tests__/syncProgressUi.test.ts
+++ b/formulus/src/sync/__tests__/syncProgressUi.test.ts
@@ -1,4 +1,5 @@
 import {
+  getSyncProgressCardTitle,
   getSyncProgressDetailsForDisplay,
   shouldShowSyncProgressCurrentItem,
   shouldShowSyncProgressPercent,
@@ -53,5 +54,32 @@ describe('syncProgressUi', () => {
         total: 100,
       }),
     ).toBe(false);
+  });
+
+  it('uses the index-rebuild title even during a bundle update', () => {
+    expect(
+      getSyncProgressCardTitle(
+        {
+          phase: 'index_rebuild',
+          current: 200,
+          total: 1500,
+          details: '200 of 1500',
+        },
+        'update',
+      ),
+    ).toBe('Preparing data for search');
+  });
+
+  it('uses the index-rebuild title during an observation pull', () => {
+    expect(
+      getSyncProgressCardTitle(
+        {
+          phase: 'index_rebuild',
+          current: 200,
+          total: 800,
+        },
+        'sync',
+      ),
+    ).toBe('Preparing data for search');
   });
 });

--- a/formulus/src/sync/syncProgress.ts
+++ b/formulus/src/sync/syncProgress.ts
@@ -10,7 +10,9 @@ export type SyncProgressPhase =
   | 'push_attachments'
   | 'push_observations'
   /** Form definitions / custom app ZIP (not observation attachments). */
-  | 'app_bundle';
+  | 'app_bundle'
+  /** Rebuilding local query indexes after a bundle changed their definitions. */
+  | 'index_rebuild';
 
 export interface SyncProgress {
   current: number;
@@ -62,6 +64,8 @@ export function syncProgressPhaseTitle(phase: SyncProgressPhase): string {
       return i18n.t('sync.progress.phase.push_observations');
     case 'app_bundle':
       return i18n.t('sync.progress.phase.app_bundle');
+    case 'index_rebuild':
+      return i18n.t('sync.progress.phase.index_rebuild');
     default:
       return i18n.t('sync.progress.phase.default');
   }

--- a/formulus/src/sync/syncProgressUi.ts
+++ b/formulus/src/sync/syncProgressUi.ts
@@ -45,6 +45,12 @@ export function getSyncProgressCardTitle(
   progress: SyncProgress,
   activeOperation: 'sync' | 'update' | 'sync_then_update' | null,
 ): string {
+  // Index work is its own phase and can run after a bundle download or
+  // during a first-time pull. The operation wrapper would otherwise keep
+  // saying "Updating forms" / "Syncing observations" while the bar moves.
+  if (progress.phase === 'index_rebuild') {
+    return syncProgressPhaseTitle('index_rebuild');
+  }
   if (activeOperation === 'sync_then_update') {
     if (progress.phase === 'app_bundle') {
       return i18n.t('sync.progress.syncingAndUpdatingForms');

--- a/packages/observation-query/fixtures/undeclared_numeric_fallback_guard.json
+++ b/packages/observation-query/fixtures/undeclared_numeric_fallback_guard.json
@@ -1,0 +1,20 @@
+{
+  "name": "undeclared_numeric_fallback_guard",
+  "jsonColumn": "payload",
+  "formType": "hh_person",
+  "includeDeleted": false,
+  "indexKeys": ["hh_id"],
+  "filter": {
+    "field": "data.age_years",
+    "op": "gte",
+    "value": 18
+  },
+  "expectedSqlFragmentsByDialect": {
+    "desktop": ["json_type(o.payload, '$.age_years') IN ('integer','real')"],
+    "formulus": [
+      "json_type(observations.data, '$.age_years') IN ('integer','real')"
+    ]
+  },
+  "expectWarning": true,
+  "expectError": false
+}

--- a/packages/observation-query/package.json
+++ b/packages/observation-query/package.json
@@ -9,7 +9,11 @@
     ".": "./src/index.ts",
     "./fixtures/*": "./fixtures/*"
   },
-  "files": ["src", "fixtures", "schema"],
+  "files": [
+    "src",
+    "fixtures",
+    "schema"
+  ],
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "build": "tsc"
@@ -20,7 +24,10 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
+    "@types/node": "^26.2.0",
+    "@types/sql.js": "^1.4.11",
     "jest": "^29.7.0",
+    "sql.js": "^1.14.2",
     "ts-jest": "^29.2.0",
     "typescript": "^5.0.4"
   }

--- a/packages/observation-query/pnpm-lock.yaml
+++ b/packages/observation-query/pnpm-lock.yaml
@@ -15,12 +15,21 @@ importers:
       '@types/jest':
         specifier: ^29.5.0
         version: 29.5.14
+      '@types/node':
+        specifier: ^26.2.0
+        version: 26.2.0
+      '@types/sql.js':
+        specifier: ^1.4.11
+        version: 1.4.11
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)
+        version: 29.7.0(@types/node@26.2.0)
+      sql.js:
+        specifier: ^1.14.2
+        version: 1.14.2
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.8.0))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.2.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.4
         version: 5.9.3
@@ -307,6 +316,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/emscripten@1.41.5':
+    resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
@@ -322,8 +334,11 @@ packages:
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
-  '@types/node@25.8.0':
-    resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+
+  '@types/sql.js@1.4.11':
+    resolution: {integrity: sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -1029,6 +1044,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sql.js@1.14.2:
+    resolution: {integrity: sha512-3ZGPovObMFrdw79zrUHbfdE/DLIsy8jdNdssmMSQuRAymedU6q84asPt0kgiqrdMYlPegDItiIMfmIXzZnYFcw==}
+
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -1129,8 +1147,8 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1389,7 +1407,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -1402,14 +1420,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.8.0)
+      jest-config: 29.7.0(@types/node@26.2.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -1434,7 +1452,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -1452,7 +1470,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -1474,7 +1492,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -1544,7 +1562,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -1598,9 +1616,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/emscripten@1.41.5': {}
+
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -1617,9 +1637,14 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
-  '@types/node@25.8.0':
+  '@types/node@26.2.0':
     dependencies:
-      undici-types: 7.24.6
+      undici-types: 8.3.0
+
+  '@types/sql.js@1.4.11':
+    dependencies:
+      '@types/emscripten': 1.41.5
+      '@types/node': 26.2.0
 
   '@types/stack-utils@2.0.3': {}
 
@@ -1775,13 +1800,13 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  create-jest@29.7.0(@types/node@25.8.0):
+  create-jest@29.7.0(@types/node@26.2.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.8.0)
+      jest-config: 29.7.0(@types/node@26.2.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -1991,7 +2016,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -2011,16 +2036,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@25.8.0):
+  jest-cli@29.7.0(@types/node@26.2.0):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.8.0)
+      create-jest: 29.7.0(@types/node@26.2.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.8.0)
+      jest-config: 29.7.0(@types/node@26.2.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -2030,7 +2055,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@25.8.0):
+  jest-config@29.7.0(@types/node@26.2.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -2055,7 +2080,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -2084,7 +2109,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -2094,7 +2119,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -2133,7 +2158,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -2168,7 +2193,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -2196,7 +2221,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -2242,7 +2267,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -2261,7 +2286,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -2270,17 +2295,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 26.2.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@25.8.0):
+  jest@29.7.0(@types/node@26.2.0):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.8.0)
+      jest-cli: 29.7.0(@types/node@26.2.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -2461,6 +2486,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sql.js@1.14.2: {}
+
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
@@ -2508,12 +2535,12 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.8.0))(typescript@5.9.3):
+  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.2.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@25.8.0)
+      jest: 29.7.0(@types/node@26.2.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -2539,7 +2566,7 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
-  undici-types@7.24.6: {}
+  undici-types@8.3.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:

--- a/packages/observation-query/src/compiler.ts
+++ b/packages/observation-query/src/compiler.ts
@@ -60,6 +60,24 @@ function pushParam(params: Array<string | number | null>, value: unknown): strin
   return '?';
 }
 
+/**
+ * Whether an operand should be compared numerically.
+ *
+ * This mirrors how the index stores values — numbers in `value_num`,
+ * everything else in `value_text` — so both compilation paths have to consult
+ * it to stay in agreement. `eq` is excluded deliberately, which keeps equality
+ * type-strict: `eq "42"` matches the string and `eq 42` matches the number.
+ */
+function isNumericOperand(value: unknown, op: string): boolean {
+  if (typeof value === 'number') return true;
+  return (
+    typeof value === 'string' &&
+    value !== '' &&
+    !Number.isNaN(Number(value)) &&
+    op !== 'eq'
+  );
+}
+
 export function compileFilter(
   filter: ObservationFilter,
   options: CompileOptions,
@@ -168,9 +186,7 @@ function compileCondition(
   }
 
   const val = cond.value;
-  const isNum =
-    typeof val === 'number' ||
-    (typeof val === 'string' && val !== '' && !Number.isNaN(Number(val)) && cond.op !== 'eq');
+  const isNum = isNumericOperand(val, cond.op);
 
   if (isNum && ['gt', 'gte', 'lt', 'lte', 'eq', 'neq'].includes(cond.op)) {
     const p = pushParam(params, Number(val));
@@ -246,6 +262,24 @@ function compileJsonExtractCondition(
   if (!(cond.op in opMap)) {
     return { code: 'UNSUPPORTED_OP', message: `Unsupported op ${cond.op}` };
   }
+
+  // A numeric comparison has to match the indexed path, which compares against
+  // `value_num` and therefore only ever considers values that are JSON numbers.
+  // SQLite orders by storage class rather than coercing, so an unguarded
+  // json_extract comparison disagrees in both directions: `18 >= '18'` is false,
+  // so a numeric-looking string operand matches nothing, and `'abc' > 5` is
+  // true, so every text value matches a numeric filter. This fallback runs
+  // precisely when the index is unusable, and a safety net that quietly returns
+  // different rows is worse than no safety net at all.
+  //
+  // json_type rather than typeof(json_extract(...)): JSON `true` extracts as
+  // the integer 1, so typeof would admit booleans that the index stores as text.
+  if (isNumericOperand(cond.value, cond.op)) {
+    const p = pushParam(params, Number(cond.value));
+    const typeExpr = `json_type(${tableAlias}.${jsonCol}, '${jsonPath}')`;
+    return `(${typeExpr} IN ('integer','real') AND ${expr} ${opMap[cond.op]} ${p})`;
+  }
+
   const p = pushParam(params, cond.value as string | number | null);
   return `${expr} ${opMap[cond.op]} ${p}`;
 }

--- a/packages/observation-query/src/compilerDifferential.test.ts
+++ b/packages/observation-query/src/compilerDifferential.test.ts
@@ -1,0 +1,214 @@
+/**
+ * The indexed path and the json_extract fallback must return the same rows.
+ *
+ * Callers drop to json_extract whenever a key is undeclared, and Formulus and
+ * Desktop both drop to it wholesale when the index turns out to be unusable.
+ * That safety net is only worth having if the two paths agree: a fallback that
+ * quietly returns a different result set is worse than one that fails loudly.
+ *
+ * SQLite makes agreement easy to get wrong, because it orders values by storage
+ * class instead of coercing them. `18 >= '18'` is false, so a numeric-looking
+ * string operand used to match nothing on the fallback while matching on the
+ * index; and `'abc' > 5` is true, so every text value used to match a numeric
+ * filter on the fallback while matching none on the index.
+ *
+ * Each case below runs twice against the same database — once with the key
+ * declared (indexed EXISTS) and once undeclared (json_extract) — and the two
+ * result sets have to be identical.
+ */
+import * as path from 'path';
+import initSqlJs, { type Database } from 'sql.js';
+import { compileObservationQuery } from './compiler';
+import type { ObservationFilter } from './types';
+
+/**
+ * Mirrors `ObservationIndexService.scalarToColumns` in Formulus and the Rust
+ * indexer in Desktop: JSON numbers go to `value_num`, other scalars to
+ * `value_text`, and absent, null and non-scalar values are not indexed at all.
+ */
+function indexColumns(value: unknown): {
+  valueText: string | null;
+  valueNum: number | null;
+} | null {
+  if (value == null) return null;
+  if (typeof value === 'number') return { valueText: null, valueNum: value };
+  if (typeof value === 'string') return { valueText: value, valueNum: null };
+  if (typeof value === 'boolean')
+    return { valueText: String(value), valueNum: null };
+  return null;
+}
+
+const INDEX_KEYS = ['age', 'name'];
+
+const OBSERVATIONS: Array<{ id: string; data: Record<string, unknown> }> = [
+  { id: 'p01', data: { age: 18, name: 'ann' } },
+  { id: 'p02', data: { age: 20, name: 'bob' } },
+  { id: 'p03', data: { age: 5, name: 'cid' } },
+  { id: 'p04', data: { age: '18', name: 'dee' } }, // numeric string
+  { id: 'p05', data: { age: 'abc', name: 'eve' } }, // text sorts above numbers
+  { id: 'p06', data: { name: 'fay' } }, // key absent
+  { id: 'p07', data: { age: null, name: 'gil' } }, // explicit null
+  { id: 'p08', data: { age: 18.5, name: 'hal' } }, // real
+  { id: 'p09', data: { age: true, name: 'ivy' } }, // extracts as integer 1
+  { id: 'p10', data: { age: [1, 2], name: 'jan' } }, // non-scalar
+];
+
+async function buildDatabase(): Promise<Database> {
+  const SQL = await initSqlJs({
+    locateFile: file => path.join(path.dirname(require.resolve('sql.js')), file),
+  });
+  const db = new SQL.Database();
+
+  db.run(`
+    CREATE TABLE observations (
+      id TEXT PRIMARY KEY NOT NULL,
+      observation_id TEXT NOT NULL,
+      form_type TEXT NOT NULL,
+      data TEXT NOT NULL,
+      deleted INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE observation_index (
+      observation_id TEXT NOT NULL,
+      index_key TEXT NOT NULL,
+      index_generation INTEGER NOT NULL,
+      value_text TEXT,
+      value_num REAL
+    );
+    CREATE TABLE observation_index_meta (
+      id TEXT PRIMARY KEY NOT NULL,
+      active_generation INTEGER NOT NULL
+    );
+    INSERT INTO observation_index_meta(id, active_generation) VALUES ('meta', 1);
+  `);
+
+  for (const obs of OBSERVATIONS) {
+    db.run(
+      'INSERT INTO observations(id, observation_id, form_type, data, deleted) VALUES (?, ?, ?, ?, 0)',
+      [obs.id, obs.id, 'person', JSON.stringify(obs.data)],
+    );
+    for (const key of INDEX_KEYS) {
+      const columns = indexColumns(obs.data[key]);
+      if (!columns) continue;
+      db.run(
+        `INSERT INTO observation_index
+           (observation_id, index_key, index_generation, value_text, value_num)
+         VALUES (?, ?, 1, ?, ?)`,
+        [obs.id, key, columns.valueText, columns.valueNum],
+      );
+    }
+  }
+
+  return db;
+}
+
+function run(
+  db: Database,
+  filter: ObservationFilter,
+  declaredKeys: string[],
+): string[] {
+  const compiled = compileObservationQuery({
+    dialect: 'formulus',
+    jsonColumn: 'data',
+    tableAlias: 'observations',
+    observationsTable: 'observations',
+    formType: 'person',
+    includeDeleted: false,
+    indexKeys: new Set(declaredKeys),
+    filter,
+  });
+  if ('code' in compiled) {
+    throw new Error(`${compiled.code}: ${compiled.message}`);
+  }
+
+  const statement = db.prepare(compiled.sql);
+  statement.bind(compiled.params as (string | number | null)[]);
+  const ids: string[] = [];
+  while (statement.step()) {
+    ids.push(statement.getAsObject().id as string);
+  }
+  statement.free();
+  return ids.sort();
+}
+
+describe('indexed and json_extract paths agree', () => {
+  let db: Database;
+
+  beforeAll(async () => {
+    db = await buildDatabase();
+  });
+
+  afterAll(() => {
+    db?.close();
+  });
+
+  const cases: Array<[string, ObservationFilter]> = [
+    ['eq on a string', { field: 'data.name', op: 'eq', value: 'bob' }],
+    ['eq on a number', { field: 'data.age', op: 'eq', value: 18 }],
+    ['eq on a numeric string', { field: 'data.age', op: 'eq', value: '18' }],
+    ['gte with a number operand', { field: 'data.age', op: 'gte', value: 18 }],
+    [
+      'gte with a numeric string operand',
+      { field: 'data.age', op: 'gte', value: '18' },
+    ],
+    ['gt with a number operand', { field: 'data.age', op: 'gt', value: 5 }],
+    ['gt with a low bound', { field: 'data.age', op: 'gt', value: 0 }],
+    ['lt with a number operand', { field: 'data.age', op: 'lt', value: 19 }],
+    ['lte with a numeric string', { field: 'data.age', op: 'lte', value: '18' }],
+    ['neq with a number operand', { field: 'data.age', op: 'neq', value: 18 }],
+    [
+      'neq with a numeric string operand',
+      { field: 'data.age', op: 'neq', value: '18' },
+    ],
+    ['in with numbers', { field: 'data.age', op: 'in', value: [18, 20] }],
+    ['in with strings', { field: 'data.age', op: 'in', value: ['18', 'abc'] }],
+    [
+      'and across two fields',
+      {
+        op: 'and',
+        conditions: [
+          { field: 'data.age', op: 'gte', value: '18' },
+          { field: 'data.name', op: 'neq', value: 'hal' },
+        ],
+      },
+    ],
+    [
+      'or across two fields',
+      {
+        op: 'or',
+        conditions: [
+          { field: 'data.age', op: 'lt', value: 10 },
+          { field: 'data.name', op: 'eq', value: 'bob' },
+        ],
+      },
+    ],
+  ];
+
+  it.each(cases)('%s', (_name, filter) => {
+    expect(run(db, filter, INDEX_KEYS)).toEqual(run(db, filter, []));
+  });
+
+  it('matches numbers when the operand arrives as a string', () => {
+    // The regression that motivated the guard: an age range typed into a
+    // whereClause reaches the compiler as a string, and the fallback used to
+    // return nothing at all for it.
+    const filter: ObservationFilter = {
+      field: 'data.age',
+      op: 'gte',
+      value: '18',
+    };
+    expect(run(db, filter, [])).toEqual(['p01', 'p02', 'p08']);
+  });
+
+  it('does not let text values satisfy a numeric comparison', () => {
+    // 'abc' > 5 is true in SQLite, so p05 would match without the type guard.
+    const filter: ObservationFilter = { field: 'data.age', op: 'gt', value: 5 };
+    expect(run(db, filter, [])).not.toContain('p05');
+  });
+
+  it('does not let booleans satisfy a numeric comparison', () => {
+    // JSON true extracts as the integer 1, so p09 would match `gt 0` under a
+    // typeof() guard; json_type() reports it as 'true' and excludes it.
+    const filter: ObservationFilter = { field: 'data.age', op: 'gt', value: 0 };
+    expect(run(db, filter, [])).not.toContain('p09');
+  });
+});


### PR DESCRIPTION
# More robust index rebuild + sync handling

## Description

This PR addresses various race conditions that can lead to incomplete indexes after a sync / app bundle update. The rebuild is made idempotent by creating a hashed key of the index generation to better detect changes or half-built indexes (e.g. if the app crashed during sync for some reason, e.g. out of battery).

## Type of Change

- [x] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [x] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [x] **Desktop** <!-- Please specify -->

---

**Thank you for contributing to Open Data Ensemble (ODE)!**
