### PR TITLE
fix(formulus): Include bundled sqlite package (jsi)

### DIFF
--- a/formulus/android/app/src/main/java/org/opendataensemble/formulus/MainApplication.kt
+++ b/formulus/android/app/src/main/java/org/opendataensemble/formulus/MainApplication.kt
@@ -7,6 +7,7 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage
 import org.opendataensemble.formulus.UserAppPackage
 
 class MainApplication : Application(), ReactApplication {
@@ -17,6 +18,9 @@ class MainApplication : Application(), ReactApplication {
       packageList = PackageList(this).packages.apply {
         // Packages that cannot be autolinked yet can be added manually here
         add(UserAppPackage())
+        // JSI is a separate Gradle project from Watermelon's autolinked Java
+        // adapter. Without this, jsi: true silently falls back to system SQLite.
+        add(WatermelonDBJSIPackage())
       },
     )
   }

--- a/formulus/src/contexts/SyncContext.tsx
+++ b/formulus/src/contexts/SyncContext.tsx
@@ -6,6 +6,7 @@ import React, {
   ReactNode,
 } from 'react';
 import { syncService as syncServiceInstance } from '../services/SyncService';
+import { i18n } from '../i18n/instance';
 
 export type { SyncProgress, SyncProgressPhase } from '../sync/syncProgress';
 export type { SyncProgressReporter } from '../sync/syncProgress';
@@ -69,12 +70,19 @@ export const SyncProvider: React.FC<SyncProviderProps> = ({ children }) => {
 
   const cancelSync = useCallback(() => {
     syncServiceInstance.cancelSync();
+    // Keep isActive until the in-flight syncObservations/updateAppBundle
+    // finally-block clears isSyncing. Flipping it here re-enabled the Sync
+    // button while the service was still busy, and the next tap threw
+    // "Sync already in progress".
     setSyncState(prev => ({
       ...prev,
-      isActive: false,
       canCancel: false,
-      error: 'Sync cancelled by user',
-      progress: undefined,
+      progress: prev.progress
+        ? {
+            ...prev.progress,
+            details: i18n.t('sync.progress.cancelling'),
+          }
+        : prev.progress,
     }));
   }, []);
 

--- a/formulus/src/database/__tests__/installWatermelonLogBridge.test.ts
+++ b/formulus/src/database/__tests__/installWatermelonLogBridge.test.ts
@@ -1,0 +1,57 @@
+import watermelonLogger from '@nozbe/watermelondb/utils/common/logger';
+import {
+  configureDiagnosticLog,
+  readRecentEvents,
+} from '../../diagnostics/DiagnosticLog';
+import { configureLogger, resetLoggerForTests } from '../../diagnostics/logger';
+import { createMemoryFs } from '../../diagnostics/memoryFs';
+import {
+  installWatermelonLogBridge,
+  resetWatermelonLogBridgeForTests,
+} from '../installWatermelonLogBridge';
+
+describe('installWatermelonLogBridge', () => {
+  beforeEach(() => {
+    resetWatermelonLogBridgeForTests();
+    resetLoggerForTests();
+    configureLogger({ persist: true });
+    configureDiagnosticLog({
+      fs: createMemoryFs(),
+      documentDirectoryPath: '/docs',
+    });
+  });
+
+  afterEach(() => {
+    resetWatermelonLogBridgeForTests();
+  });
+
+  it('persists Watermelon warn and error into the diagnostic log', async () => {
+    installWatermelonLogBridge();
+    watermelonLogger.warn('JSI SQLiteAdapter not available… falling back');
+    watermelonLogger.error(new Error('Failed to initialize JSI'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const events = await readRecentEvents(10);
+    expect(
+      events.some(
+        e =>
+          e.tag === 'watermelon' &&
+          e.level === 'warn' &&
+          e.message.includes('JSI SQLiteAdapter not available'),
+      ),
+    ).toBe(true);
+    expect(
+      events.some(
+        e =>
+          e.tag === 'watermelon' &&
+          e.level === 'error' &&
+          e.message.includes('Failed to initialize JSI'),
+      ),
+    ).toBe(true);
+  });
+
+  it('is idempotent', () => {
+    installWatermelonLogBridge();
+    installWatermelonLogBridge();
+    expect(() => watermelonLogger.warn('once')).not.toThrow();
+  });
+});

--- a/formulus/src/database/__tests__/probeSqliteEngine.test.ts
+++ b/formulus/src/database/__tests__/probeSqliteEngine.test.ts
@@ -1,0 +1,117 @@
+import {
+  describeSqliteEngine,
+  probeSqliteEngine,
+  sqliteEngineLogLevel,
+} from '../probeSqliteEngine';
+
+function mockDb(options: {
+  dispatcher?: string;
+  versionRows?: Record<string, unknown>[];
+  jsonRows?: Record<string, unknown>[] | Error;
+  jsiBinding?: boolean;
+}) {
+  let queryCount = 0;
+  const unsafeFetchRaw = jest.fn(async () => {
+    queryCount += 1;
+    if (queryCount === 1) {
+      return options.versionRows ?? [{ sqlite_version: '3.46.0' }];
+    }
+    if (options.jsonRows instanceof Error) {
+      throw options.jsonRows;
+    }
+    return options.jsonRows ?? [{ json_ok: '1' }];
+  });
+  const db = {
+    adapter: {
+      underlyingAdapter: {
+        _dispatcherType: options.dispatcher ?? 'jsi',
+        initializingPromise: Promise.resolve(),
+      },
+    },
+    get: jest.fn(() => ({
+      query: jest.fn(() => ({ unsafeFetchRaw })),
+    })),
+  };
+  if (options.jsiBinding) {
+    (
+      globalThis as { nativeWatermelonCreateAdapter?: () => unknown }
+    ).nativeWatermelonCreateAdapter = () => ({});
+  } else {
+    delete (globalThis as { nativeWatermelonCreateAdapter?: () => unknown })
+      .nativeWatermelonCreateAdapter;
+  }
+  return db;
+}
+
+describe('probeSqliteEngine', () => {
+  afterEach(() => {
+    delete (globalThis as { nativeWatermelonCreateAdapter?: () => unknown })
+      .nativeWatermelonCreateAdapter;
+  });
+
+  it('describes a healthy bundled engine', () => {
+    const report = {
+      dispatcher: 'jsi',
+      sqliteVersion: '3.46.0',
+      jsonExtract: true,
+      jsiBinding: true,
+    };
+    expect(describeSqliteEngine(report)).toBe(
+      'sqlite engine dispatcher=jsi version=3.46.0 json_extract=ok jsiBinding=yes',
+    );
+    expect(sqliteEngineLogLevel(report)).toBe('info');
+  });
+
+  it('treats a system-sqlite fallback as a warning even when JSON1 exists', () => {
+    expect(
+      sqliteEngineLogLevel({
+        dispatcher: 'asynchronous',
+        sqliteVersion: '3.32.2',
+        jsonExtract: true,
+        jsiBinding: false,
+      }),
+    ).toBe('warn');
+  });
+
+  it('treats missing json_extract as an error', () => {
+    expect(
+      sqliteEngineLogLevel({
+        dispatcher: 'asynchronous',
+        sqliteVersion: '3.22.0',
+        jsonExtract: false,
+        jsiBinding: false,
+      }),
+    ).toBe('error');
+    expect(
+      describeSqliteEngine({
+        dispatcher: 'asynchronous',
+        sqliteVersion: '3.22.0',
+        jsonExtract: false,
+        jsiBinding: false,
+      }),
+    ).toContain('json_extract=missing');
+  });
+
+  it('probes dispatcher, version, json_extract, and JSI binding', async () => {
+    const db = mockDb({ dispatcher: 'jsi', jsiBinding: true });
+    const report = await probeSqliteEngine(db as never);
+    expect(report).toEqual({
+      dispatcher: 'jsi',
+      sqliteVersion: '3.46.0',
+      jsonExtract: true,
+      jsiBinding: true,
+    });
+  });
+
+  it('records json_extract as missing when the probe query fails', async () => {
+    const db = mockDb({
+      dispatcher: 'asynchronous',
+      jsonRows: new Error('no such function: json_extract'),
+      jsiBinding: false,
+    });
+    const report = await probeSqliteEngine(db as never);
+    expect(report.jsonExtract).toBe(false);
+    expect(report.dispatcher).toBe('asynchronous');
+    expect(report.jsiBinding).toBe(false);
+  });
+});

--- a/formulus/src/database/database.ts
+++ b/formulus/src/database/database.ts
@@ -6,6 +6,12 @@ import {
   schemaMigrations,
   unsafeExecuteSql,
 } from '@nozbe/watermelondb/Schema/migrations';
+import { logger } from '../diagnostics/logger';
+import { installWatermelonLogBridge } from './installWatermelonLogBridge';
+import { logSqliteEngine } from './probeSqliteEngine';
+
+// Capture Watermelon's JSI-fallback warn before SQLiteAdapter runs initializeJSI.
+installWatermelonLogBridge();
 
 // Define migrations
 const migrations = schemaMigrations({
@@ -109,11 +115,14 @@ const adapter = new SQLiteAdapter({
   dbName: 'formulus',
   // Configure migrations
   migrations: migrations,
-  // Optional synchronous mode for development
+  // Requests the bundled JSI SQLite. Confirm with logSqliteEngine — Android
+  // still falls back to system SQLite if WatermelonDBJSIPackage is missing.
   jsi: true,
-  // Optional onSetUpError callback
   onSetUpError: error => {
-    console.error('Database setup error:', error);
+    logger.error(
+      'db',
+      error instanceof Error ? error.message : 'Database setup error',
+    );
   },
 });
 
@@ -124,4 +133,11 @@ export const database = new Database({
     ObservationModel,
     // Add more models as needed
   ],
+});
+
+void logSqliteEngine(database).catch(error => {
+  logger.warn(
+    'db',
+    error instanceof Error ? error.message : 'sqlite engine probe failed',
+  );
 });

--- a/formulus/src/database/installWatermelonLogBridge.ts
+++ b/formulus/src/database/installWatermelonLogBridge.ts
@@ -1,0 +1,72 @@
+import watermelonLogger from '@nozbe/watermelondb/utils/common/logger';
+import { joinLogArgs } from '../diagnostics/redact';
+import { logger } from '../diagnostics/logger';
+
+type WatermelonLogger = {
+  silent: boolean;
+  warn: (...messages: unknown[]) => void;
+  error: (...messages: unknown[]) => void;
+};
+
+const wmLogger = watermelonLogger as WatermelonLogger;
+
+let installed = false;
+let originalWarn: WatermelonLogger['warn'] | undefined;
+let originalError: WatermelonLogger['error'] | undefined;
+
+function formatWatermelonArgs(messages: unknown[]): string {
+  const normalized = messages.map(message =>
+    message instanceof Error ? message.message || String(message) : message,
+  );
+  return joinLogArgs(normalized);
+}
+
+function persist(level: 'warn' | 'error', messages: unknown[]): void {
+  if (wmLogger.silent) {
+    return;
+  }
+  const text = formatWatermelonArgs(messages);
+  if (!text) {
+    return;
+  }
+  logger[level]('watermelon', text);
+}
+
+/**
+ * WatermelonDB logs JSI fallback and native errors to console only. Mirror
+ * warn/error into the Formulus diagnostic log so field exports include them.
+ *
+ * Must run before `new SQLiteAdapter({ jsi: true })`, which is when the
+ * fallback warning is emitted.
+ */
+export function installWatermelonLogBridge(): void {
+  if (installed) {
+    return;
+  }
+  originalWarn = wmLogger.warn.bind(wmLogger);
+  originalError = wmLogger.error.bind(wmLogger);
+  wmLogger.warn = (...messages: unknown[]) => {
+    originalWarn?.(...messages);
+    persist('warn', messages);
+  };
+  wmLogger.error = (...messages: unknown[]) => {
+    originalError?.(...messages);
+    persist('error', messages);
+  };
+  installed = true;
+}
+
+export function resetWatermelonLogBridgeForTests(): void {
+  if (!installed) {
+    return;
+  }
+  if (originalWarn) {
+    wmLogger.warn = originalWarn;
+  }
+  if (originalError) {
+    wmLogger.error = originalError;
+  }
+  originalWarn = undefined;
+  originalError = undefined;
+  installed = false;
+}

--- a/formulus/src/database/probeSqliteEngine.ts
+++ b/formulus/src/database/probeSqliteEngine.ts
@@ -1,0 +1,118 @@
+import { Database, Q } from '@nozbe/watermelondb';
+import { logger } from '../diagnostics/logger';
+
+export type SqliteEngineReport = {
+  dispatcher: string;
+  sqliteVersion: string | null;
+  jsonExtract: boolean;
+  jsiBinding: boolean;
+};
+
+type SqliteAdapterLike = {
+  _dispatcherType?: string;
+  initializingPromise?: Promise<void>;
+};
+
+function getUnderlyingAdapter(db: Database): SqliteAdapterLike | undefined {
+  return (db.adapter as { underlyingAdapter?: SqliteAdapterLike })
+    .underlyingAdapter;
+}
+
+function hasJsiBinding(): boolean {
+  return (
+    typeof (globalThis as { nativeWatermelonCreateAdapter?: unknown })
+      .nativeWatermelonCreateAdapter === 'function'
+  );
+}
+
+async function rawQuery(
+  db: Database,
+  sql: string,
+): Promise<Record<string, unknown>[]> {
+  return (await db
+    .get('observations')
+    .query(Q.unsafeSqlQuery(sql))
+    .unsafeFetchRaw()) as Record<string, unknown>[];
+}
+
+function readText(
+  row: Record<string, unknown> | undefined,
+  key: string,
+): string | null {
+  const value = row?.[key];
+  if (value == null) {
+    return null;
+  }
+  return String(value);
+}
+
+export function describeSqliteEngine(report: SqliteEngineReport): string {
+  return `sqlite engine dispatcher=${report.dispatcher} version=${
+    report.sqliteVersion ?? 'unknown'
+  } json_extract=${report.jsonExtract ? 'ok' : 'missing'} jsiBinding=${
+    report.jsiBinding ? 'yes' : 'no'
+  }`;
+}
+
+export function sqliteEngineLogLevel(
+  report: SqliteEngineReport,
+): 'info' | 'warn' | 'error' {
+  if (!report.jsonExtract) {
+    return 'error';
+  }
+  if (report.dispatcher !== 'jsi') {
+    return 'warn';
+  }
+  return 'info';
+}
+
+export async function probeSqliteEngine(
+  db: Database,
+): Promise<SqliteEngineReport> {
+  const adapter = getUnderlyingAdapter(db);
+  if (adapter?.initializingPromise) {
+    await adapter.initializingPromise;
+  }
+
+  const dispatcher = adapter?._dispatcherType ?? 'unknown';
+  const jsiBinding = hasJsiBinding();
+  let sqliteVersion: string | null = null;
+  let jsonExtract = false;
+
+  try {
+    const rows = await rawQuery(
+      db,
+      'SELECT sqlite_version() AS sqlite_version',
+    );
+    sqliteVersion = readText(rows[0], 'sqlite_version');
+  } catch (error) {
+    logger.warn(
+      'db',
+      error instanceof Error ? error.message : 'sqlite_version() probe failed',
+    );
+  }
+
+  try {
+    const rows = await rawQuery(
+      db,
+      `SELECT json_extract('{"a":1}', '$.a') AS json_ok`,
+    );
+    jsonExtract = readText(rows[0], 'json_ok') === '1';
+  } catch {
+    jsonExtract = false;
+  }
+
+  return { dispatcher, sqliteVersion, jsonExtract, jsiBinding };
+}
+
+export async function logSqliteEngine(
+  db: Database,
+): Promise<SqliteEngineReport> {
+  const report = await probeSqliteEngine(db);
+  const level = sqliteEngineLogLevel(report);
+  logger[level]('db', describeSqliteEngine(report), {
+    phase: 'sqlite_probe',
+    success: report.jsonExtract && report.dispatcher === 'jsi',
+  });
+  return report;
+}

--- a/formulus/src/locales/en.json
+++ b/formulus/src/locales/en.json
@@ -170,6 +170,7 @@
   "sync.progress.uploadComplete": "Upload complete",
   "sync.progress.countOf": "{{current}} of {{total}}",
   "sync.progress.inProgress": "In progress…",
+  "sync.progress.cancelling": "Cancelling…",
   "settings.switchServerTitle": "Switch server?",
   "settings.switchServerWipeMessage": "Switching servers will wipe all local data for the previous server.",
   "settings.switchServerPendingMessage": "Unsynced observations: {{observations}}\nUnsynced attachments: {{attachments}}\n\nSync is recommended before switching.",

--- a/formulus/src/locales/fr.json
+++ b/formulus/src/locales/fr.json
@@ -170,6 +170,7 @@
   "sync.progress.uploadComplete": "Envoi terminé",
   "sync.progress.countOf": "{{current}} sur {{total}}",
   "sync.progress.inProgress": "En cours…",
+  "sync.progress.cancelling": "Annulation…",
   "settings.switchServerTitle": "Changer de serveur ?",
   "settings.switchServerWipeMessage": "Changer de serveur effacera toutes les données locales de l'ancien serveur.",
   "settings.switchServerPendingMessage": "Observations non synchronisées : {{observations}}\nPièces jointes non synchronisées : {{attachments}}\n\nIl est recommandé de synchroniser avant de changer.",

--- a/formulus/src/locales/pt.json
+++ b/formulus/src/locales/pt.json
@@ -170,6 +170,7 @@
   "sync.progress.uploadComplete": "Envio concluído",
   "sync.progress.countOf": "{{current}} de {{total}}",
   "sync.progress.inProgress": "Em curso…",
+  "sync.progress.cancelling": "A cancelar…",
   "settings.switchServerTitle": "Mudar de servidor?",
   "settings.switchServerWipeMessage": "Mudar de servidor irá apagar todos os dados locais do servidor anterior.",
   "settings.switchServerPendingMessage": "Observações por sincronizar: {{observations}}\nAnexos por sincronizar: {{attachments}}\n\nRecomenda-se sincronizar antes de mudar.",

--- a/formulus/src/screens/SyncScreen.tsx
+++ b/formulus/src/screens/SyncScreen.tsx
@@ -266,7 +266,7 @@ const SyncScreen = () => {
   );
 
   const handleSync = useCallback(async () => {
-    if (syncState.isActive) return;
+    if (syncState.isActive || syncService.getIsSyncing()) return;
 
     let syncError: string | undefined;
 
@@ -277,7 +277,9 @@ const SyncScreen = () => {
       await syncService.syncObservations(true);
       await refreshAfterOperation();
     } catch (error) {
-      if (isRepositoryResetRequiredError(error)) {
+      if (isSyncCancelledError(error)) {
+        // Cancel is requested, not a failure — do not Alert or paint the card red.
+      } else if (isRepositoryResetRequiredError(error)) {
         syncError = getUserFacingSyncErrorMessage(error);
         runRepositoryResetRecovery(
           error,
@@ -290,9 +292,7 @@ const SyncScreen = () => {
         );
       } else {
         syncError = getUserFacingSyncErrorMessage(error);
-        if (!isSyncCancelledError(error)) {
-          Alert.alert(t('sync.failed'), syncError);
-        }
+        Alert.alert(t('sync.failed'), syncError);
       }
     } finally {
       finishSync(syncError);
@@ -321,12 +321,16 @@ const SyncScreen = () => {
       const fs = await formService.FormService.getInstance();
       await fs.invalidateCache();
     } catch (error) {
-      const errorMessage = (error as Error).message;
-      finishSync(errorMessage);
-      if (errorMessage.includes('401')) {
-        Alert.alert(t('sync.authErrorTitle'), t('sync.sessionExpired'));
+      if (isSyncCancelledError(error)) {
+        finishSync();
       } else {
-        Alert.alert(t('sync.updateFailed'), errorMessage);
+        const errorMessage = (error as Error).message;
+        finishSync(errorMessage);
+        if (errorMessage.includes('401')) {
+          Alert.alert(t('sync.authErrorTitle'), t('sync.sessionExpired'));
+        } else {
+          Alert.alert(t('sync.updateFailed'), errorMessage);
+        }
       }
     } finally {
       setActiveOperation(null);
@@ -365,12 +369,12 @@ const SyncScreen = () => {
           },
           t('sync.operationFailed'),
         );
+      } else if (isSyncCancelledError(error)) {
+        finishSync();
       } else {
         const errorMessage = getUserFacingSyncErrorMessage(error);
         finishSync(errorMessage);
-        if (!isSyncCancelledError(error)) {
-          Alert.alert(t('sync.operationFailed'), errorMessage);
-        }
+        Alert.alert(t('sync.operationFailed'), errorMessage);
       }
     } finally {
       setActiveOperation(null);
@@ -384,7 +388,7 @@ const SyncScreen = () => {
   ]);
 
   const handleCustomAppUpdate = useCallback(async () => {
-    if (syncState.isActive) return;
+    if (syncState.isActive || syncService.getIsSyncing()) return;
 
     const userInfo = await getUserInfo();
     if (!userInfo) {

--- a/formulus/src/services/SyncService.ts
+++ b/formulus/src/services/SyncService.ts
@@ -278,15 +278,19 @@ export class SyncService {
 
       return finalVersion;
     } catch (error) {
-      logger.error(
-        'sync',
-        error instanceof Error ? error.message : 'Sync failed',
-      );
-      if (
+      const cancelled =
         error instanceof Error &&
         error.message === 'Sync cancelled' &&
-        this.shouldCancel
-      ) {
+        this.shouldCancel;
+      if (cancelled) {
+        logger.info('sync', 'cancel observed, aborting');
+      } else {
+        logger.error(
+          'sync',
+          error instanceof Error ? error.message : 'Sync failed',
+        );
+      }
+      if (cancelled) {
         notificationService
           .showSyncCanceled()
           .catch(notifError =>

--- a/formulus/src/services/__tests__/SyncService.autoLogin.test.ts
+++ b/formulus/src/services/__tests__/SyncService.autoLogin.test.ts
@@ -346,4 +346,43 @@ describe('SyncService - Auto-Login Integration', () => {
       expect(result).toBe(true); // Update available (version changed from '0')
     });
   });
+
+  describe('cancel while a pull is in flight', () => {
+    test('rejects a second start until the cancelled run has finished', async () => {
+      let sawCancel = (_options: { isCancelled?: () => boolean }) => {};
+      const started = new Promise<{ isCancelled?: () => boolean }>(resolve => {
+        sawCancel = resolve;
+      });
+
+      (isUnauthorizedError as jest.Mock).mockReturnValue(false);
+      (synkronusApi.syncObservations as jest.Mock).mockImplementation(
+        (_include: boolean, options: { isCancelled?: () => boolean }) => {
+          sawCancel(options);
+          return new Promise((_resolve, reject) => {
+            const id = setInterval(() => {
+              if (options.isCancelled?.()) {
+                clearInterval(id);
+                reject(new Error('Sync cancelled'));
+              }
+            }, 5);
+          });
+        },
+      );
+
+      const first = syncService.syncObservations(true);
+      await started;
+      expect(syncService.getIsSyncing()).toBe(true);
+
+      syncService.cancelSync();
+      await expect(syncService.syncObservations(true)).rejects.toThrow(
+        'Sync already in progress',
+      );
+
+      await expect(first).rejects.toThrow('Sync cancelled');
+      expect(syncService.getIsSyncing()).toBe(false);
+
+      (synkronusApi.syncObservations as jest.Mock).mockResolvedValueOnce(7);
+      await expect(syncService.syncObservations(true)).resolves.toBe(7);
+    });
+  });
 });


### PR DESCRIPTION
# Include bundled sqlite

## Description

This PR fixes a bug, where WatermelongDBJSIPackage() wasn't in the packageList - which caused `use_jsi: true` to only request using the jsi bundled sqlite engine, but since it wasn't there it would fall back to the device sqlite engine.

On Android versions < 12, that sqlite engine typically does not include json_extract which we rely on for indexing and optimizations.. 

## Type of Change

- [x] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Maintenance / Chore
- [ ] Other (please specify):

---

## Component(s) Affected

- [x] **formulus** (React Native mobile app)
- [ ] **formulus-formplayer** (React web app)
- [ ] **synkronus** (Go backend server)
- [ ] **synkronus-cli** (Command-line utility)
- [ ] **Documentation**
- [ ] **DevOps / CI/CD**
- [ ] **Other:** <!-- Please specify -->

---

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested
- [x] Tested on multiple platforms (if applicable)
- [ ] Not applicable

---

## Breaking Changes

- [ ] This PR introduces breaking changes
- [x] This PR does NOT introduce breaking changes

**If breaking changes, please describe migration steps:**

---

## Documentation Updates

- [ ] Documentation has been updated
- [x] Documentation update is not required

---

## Checklist

- [x] Code follows project style guidelines
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] PR title follows Conventional Commits format

---

**Thank you for contributing to Open Data Ensemble (ODE)!**
