### PR TITLE
feat(formulus): Updated Grant Permission button title for App Store compliance

### DIFF
--- a/formulus/src/components/QRScannerModalImpl.tsx
+++ b/formulus/src/components/QRScannerModalImpl.tsx
@@ -185,11 +185,12 @@ const QRScannerModalImpl: React.FC<QRScannerModalProps> = ({
         <View style={styles.container}>
           <View style={styles.permissionContainer}>
             <Text style={styles.permissionText}>
-              Camera permission is required to scan QR codes
+              Camera permission is required to scan QR codes. Select continue to
+              grant these permissions.
             </Text>
             <View style={styles.permissionButtonRow}>
               <Button
-                title="Grant Permission"
+                title="Continue"
                 onPress={requestCameraPermission}
                 variant="primary"
                 style={styles.permissionButton}


### PR DESCRIPTION
This addresses the following feedback from Apple App Store:

### Guideline 5.1.1(iv) - Legal - Privacy - Data Collection and Storage

**Issue Description**

The app encourages or directs users to allow the app to access the camera. Specifically, the app directs the user to grant permission in the following way(s): 

- A custom message appears before the permission request, and to proceed users press a "Grant Permission" button. Use words like "Continue" or "Next" on the button instead.

Permission requests give users control of their personal information. It is important to respect their decision about how their data is used.