### PR TITLE
fix(ios): Applied explicit UTF-8 encoding to placerholder

### DIFF
--- a/formulus/assets/webview/placeholder_app.html
+++ b/formulus/assets/webview/placeholder_app.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>Custom App Placeholder</title>
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <style>
       /* ODE_TOKENS_START */


### PR DESCRIPTION
Fix for the wrong encoding on the startpage in IOS