### PR TITLE
fix(formulus): ship universal APK on GitHub releases

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -119,9 +119,9 @@ Builds Android APK for the Formulus React Native application, and builds/consume
 
 #### Triggers
 
-- **Push to `main`/`dev`** (formulus or formulus-formplayer changes): Builds Formplayer assets and then a release APK using those assets
+- **Push to `main`/`dev`** (formulus or formulus-formplayer changes): Builds Formplayer assets and then a release APK + AAB using those assets
 - **Pull Requests** (formulus or formulus-formplayer changes): Builds Formplayer assets and then a debug APK for validation
-- **Release**: Publishes APK to GitHub Release
+- **Release**: Publishes the universal APK and AAB to GitHub Release
 
 #### Path Filters
 
@@ -150,10 +150,10 @@ Formplayer assets are **not committed to git** and are ignored via `.gitignore`.
 #### Build Types
 
 - **Pull Requests**: Debug APK (unsigned), **arm64-v8a only** (smoke)
-- **Push to main/dev**: Release APK + AAB (signed), **arm64-v8a only** — CI artifacts, not F-Droid shippable
-- **GitHub Release**: Release APK + AAB (signed), **all four ABIs** from `formulus/android/gradle.properties` (F-Droid / Play); assets attached to the release
+- **Push to main/dev**: Release universal APK + AAB (signed) — CI artifacts
+- **GitHub Release**: Release universal APK + AAB (signed); assets attached to the release
 
-APK and AAB are built in **one** Gradle invocation (`assembleRelease bundleRelease`) so Metro/native work is shared. Gradle uses `gradle/actions/setup-gradle` (daemon left on). Vendored Notifee (`formulus/third_party/notifee`) is cached across runs (key = hash of `vendor-notifee-core.mjs`). CI enables parallel workers (local `gradle.properties` keeps them low for laptops).
+APK and AAB are built in **one** Gradle invocation (`assembleRelease bundleRelease`) so Metro/native work is shared. GitHub release/distribution should use the **universal APK** to avoid wrong-ABI selection and cross-ABI `versionCode` update failures. F-Droid keeps its own per-ABI builds from the same source tag via metadata/build properties; that split path is not the GitHub release artifact. Gradle uses `gradle/actions/setup-gradle` (daemon left on). Vendored Notifee (`formulus/third_party/notifee`) is cached across runs (key = hash of `vendor-notifee-core.mjs`). CI enables parallel workers (local `gradle.properties` keeps them low for laptops).
 
 NDK `ccache` is **not** wired yet: it needs CI-only CMake launcher hooks into React Native’s native build and can flake; revisit if release builds are still too slow after the above.
 

--- a/.github/workflows/formulus-android.yml
+++ b/.github/workflows/formulus-android.yml
@@ -184,8 +184,9 @@ jobs:
           echo "FORMULUS_RELEASE_KEY_PASSWORD=${FORMULUS_RELEASE_KEY_PASSWORD}" >> formulus/android/local.properties
 
       # ABI policy:
-      # - PR + push to main/dev: arm64-v8a only (smoke / CI artifacts — not F-Droid shippable)
-      # - release: all four ABIs (F-Droid / Play)
+      # - PR: arm64-v8a only debug smoke build
+      # - push to main/dev + release: universal APK + AAB for GitHub/direct distribution
+      # - F-Droid: per-ABI APKs from the same source tag via fdroiddata metadata/build props
       # Local gradle.properties keeps parallel/workers low for laptops; CI overrides those.
       # setup-gradle prefers leaving the daemon on (no --no-daemon).
       - name: Build debug APK (PR, arm64-v8a only)
@@ -199,7 +200,7 @@ jobs:
           -Dorg.gradle.workers.max=4
           -PreactNativeArchitectures=${{ env.FORMULUS_ABIS_SMOKE }}
 
-      - name: Build release APK + AAB (push main/dev, arm64-v8a only)
+      - name: Build release universal APK + AAB (push main/dev)
         if: github.event_name == 'push'
         working-directory: formulus/android
         env:
@@ -210,7 +211,7 @@ jobs:
           -Dorg.gradle.workers.max=4
           -PreactNativeArchitectures=${{ env.FORMULUS_ABIS_SMOKE }}
 
-      - name: Build release APK + AAB (GitHub Release, all ABIs)
+      - name: Build release universal APK + AAB (GitHub Release)
         if: github.event_name == 'release'
         working-directory: formulus/android
         env:
@@ -236,12 +237,12 @@ jobs:
           path: |
             formulus/android/app/build/outputs/bundle/release/*.aab
 
-      - name: Upload APK to GitHub Release
+      - name: Upload universal APK + AAB to GitHub Release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
-            formulus/android/app/build/outputs/apk/**/**/*.apk
+            formulus/android/app/build/outputs/apk/**/**/*-universal-*.apk
             formulus/android/app/build/outputs/bundle/release/*.aab
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ For stable, you usually **do not** re-bump client manifests if they already matc
 ### Increment rules
 
 - **Semver:** bump `MAJOR.MINOR.PATCH` in client manifests to match the release line (e.g. `1.1.1`).
-- **Android `versionCode`:** must increase monotonically for Google Play (+10 per release is a common convention; +1 per shipped alpha build is also fine).
+- **Android `versionCode`:** upstream `formulus/android/app/build.gradle` keeps one monotonic base code for Play and GitHub universal APKs (+10 per release is a common convention; +1 per shipped alpha build is also fine). F-Droid per-ABI codes are derived in F-Droid metadata/build configuration.
 - **In-app version display:** Formulus About/Settings use native `versionName` + `versionCode` via [`AppVersionService`](formulus/src/services/AppVersionService.ts); Desktop About uses Tauri `getVersion()`.
 
 ### Commands

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -128,8 +128,8 @@ When the release is published, the following workflows are triggered by the `rel
   - Attaches all binaries to the GitHub Release as assets
 
 - **Formulus Android (`formulus-android.yml`)**
-  - Uses the configured keystore (via GitHub secrets) to build a signed **release** APK
-  - Attaches the APK to the GitHub Release as an asset
+  - Uses the configured keystore (via GitHub secrets) to build a signed **universal release APK** and **AAB**
+  - Attaches the universal APK (direct installs / Obtainium) and AAB to the GitHub Release as assets
 
 ### 5. Usage of a pre‑release
 
@@ -186,15 +186,16 @@ Triggered by the `release: published` event:
   - Attaches them to the `v1.2.0` GitHub Release
 
 - **Formulus Android (`formulus-android.yml`)**
-  - Builds a **signed release APK**
-  - Attaches it to the `v1.2.0` GitHub Release
+  - Builds a signed **universal release APK** and **AAB**
+  - Attaches them to the `v1.2.0` GitHub Release
 
 ### 5. Usage of a full release
 
 - This GitHub Release is the **single source of truth** for:
   - Docker image versions
   - CLI downloads
-  - Android APK distribution
+  - Android universal APK distribution
+- F-Droid continues to build per-ABI Formulus APKs from the same source tag using its own metadata/build properties.
 - Production deployments should generally use the stable semver tag (`v1.2.0`) or the corresponding major/minor tags (`v1.2`), not `latest`, unless documented otherwise.
 
 

--- a/formulus/android/ANDROID_RELEASE.md
+++ b/formulus/android/ANDROID_RELEASE.md
@@ -1,6 +1,6 @@
 # Android release: Google Play and F-Droid
 
-Formulus ships from one FOSS codebase. Play Store and F-Droid use the same dependency patches and build steps; only packaging and version-code handling differ.
+Formulus ships from one FOSS codebase. Play Store, GitHub sideloads, and F-Droid use the same dependency patches and build steps; packaging and version-code handling differ by channel.
 
 ## Shared release prep
 
@@ -13,6 +13,9 @@ Formulus ships from one FOSS codebase. Play Store and F-Droid use the same depen
    pnpm run generate
    ```
 3. Tag the release commit on the upstream repo, e.g. `v1.0.2` (F-Droid update checks use stable tags matching `v[\d.]+$`).
+4. For a release that touches Android packaging, verify both outputs locally or in CI:
+   - universal release APK for GitHub/direct installs
+   - single-ABI APK path via `-PabiFilters=<abi>` for F-Droid
 
 ## Google Play
 
@@ -21,19 +24,18 @@ Formulus ships from one FOSS codebase. Play Store and F-Droid use the same depen
 - **versionCode:** Uses `defaultConfig.versionCode` in the AAB (single code per release).
 - **Signing:** See [SIGNING_CONFIG.md](./SIGNING_CONFIG.md). CI uses repository secrets; local builds use `android/local.properties`.
 
-Optional split APKs for sideloading or GitHub Release assets:
+## GitHub Releases / direct sideloads
 
-```sh
-./gradlew assembleRelease
-```
-
-Split APKs use per-ABI version codes: `baseVersionCode + abiOffset` (2–5 when base is 2).
+- **Artifact:** One signed **universal APK** for manual installs and updaters such as Obtainium.
+- **Gradle:** `assembleRelease` should emit a universal APK for normal/release builds.
+- **Why:** A single sideload artifact avoids wrong-ABI selection and cross-ABI `versionCode` downgrade/update failures.
+- **versionCode:** Uses `defaultConfig.versionCode` unchanged.
 
 ## F-Droid
 
 - **Artifact:** One APK per ABI, built from source by F-Droid.
 - **Metadata:** `fdroiddata/metadata/org.opendataensemble.formulus.yml` — four builds with `abiFilters` and explicit `versionCode` per ABI.
-- **Gradle:** Pass `-PabiFilters=<abi>`; F-Droid prebuild strips custom APK naming and sets `versionCode = $$VERCODE$$`.
+- **Gradle:** F-Droid passes `-PabiFilters=<abi>` to force a single ABI build from the same upstream tag/source. This path keeps ABI-specific outputs only for F-Droid.
 - **Init steps:** Same as shared prep above (`vendor:notifee`, `patch:android-foss`, `generate`).
 
 After tagging, update the metadata commit SHA and version fields, then open/update the fdroiddata merge request.
@@ -43,7 +45,11 @@ After tagging, update the metadata commit SHA and version fields, then open/upda
 | Channel | versionCode |
 |---------|-------------|
 | Play AAB | `defaultConfig.versionCode` |
-| Play / local split APKs | base + ABI offset (armeabi-v7a +0, arm64-v8a +1, x86 +2, x86_64 +3) |
-| F-Droid per-ABI build | Set in metadata prebuild (`$$VERCODE$$`) |
+| GitHub universal APK | `defaultConfig.versionCode` |
+| F-Droid per-ABI build | Set in metadata (for example `3601`–`3604` when upstream `defaultConfig.versionCode` is `36`) |
 
-When bumping a release, increase `defaultConfig.versionCode` and update F-Droid build entries (and `CurrentVersionCode`) to match the highest per-ABI code.
+Rules:
+
+- Upstream Gradle keeps a single monotonic `defaultConfig.versionCode` for Play and GitHub sideloads.
+- Do **not** apply per-ABI `versionCodeOverride` to the normal GitHub release build.
+- F-Droid-specific per-ABI version codes live in F-Droid metadata/build configuration, not in the default upstream release path.

--- a/formulus/android/app/build.gradle
+++ b/formulus/android/app/build.gradle
@@ -88,11 +88,6 @@ def enableProguardInReleaseBuilds = false
  */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
-def perAbiVersionCode(int baseVersionCode, String abi) {
-    def offsets = ['armeabi-v7a': 1, 'arm64-v8a': 2, 'x86': 3, 'x86_64': 4]
-    return baseVersionCode + offsets.get(abi, 0) - 1
-}
-
 android {
     ndkVersion = rootProject.ext.ndkVersion
     buildToolsVersion = rootProject.ext.buildToolsVersion
@@ -122,7 +117,7 @@ android {
                 enable true
                 reset()
                 include "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
-                universalApk false
+                universalApk true
             }
         }
     }
@@ -156,18 +151,6 @@ android {
         }
     }
 
-    // Per-ABI versionCode when building split APKs (F-Droid uses explicit versionCode per gradleprops build).
-    if (!fdroidAbiFilter) {
-        applicationVariants.configureEach { variant ->
-            variant.outputs.each { output ->
-                def abi = output.getFilter(com.android.build.OutputFile.ABI)
-                if (abi != null) {
-                    output.versionCodeOverride = perAbiVersionCode(defaultConfig.versionCode, abi)
-                }
-            }
-        }
-    }
-
     // Custom APK naming (local builds; F-Droid metadata strips this block in prebuild).
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
@@ -176,7 +159,7 @@ android {
             def buildType = variant.buildType.name
             def date = new Date().format('yyyyMMdd')
             def abi = output.getFilter(com.android.build.OutputFile.ABI)
-            def abiSuffix = abi != null ? "-${abi}" : ""
+            def abiSuffix = abi != null ? "-${abi}" : "-universal"
 
             outputFileName = "formulus-v${versionName}-${versionCode}${abiSuffix}-${buildType}-${date}.apk"
         }


### PR DESCRIPTION
## Summary

This updates the Formulus Android release pipeline so GitHub/direct installs use a universal APK, while F-Droid continues to build per-ABI APKs from the same source tag.

## Changes

- enable `universalApk true` for normal Formulus Android builds
- remove upstream per-ABI `versionCodeOverride` from the default release path
- keep the `-PabiFilters=<abi>` F-Droid build path intact
- update GitHub Release upload globs to attach only the universal APK and AAB
- update release/build documentation to reflect the new channel strategy

## Why

We were seeing reports of Formulus updates hanging at "Updating app" on some Android devices.

The most likely cause was our GitHub release packaging:
- multiple ABI-specific APK assets
- no universal APK
- different `versionCode`s per ABI

That combination is brittle for direct installs and updaters like Obtainium, because it can lead to wrong-ABI selection or cross-ABI downgrade/update failures.

This change keeps F-Droid-compatible ABI-specific builds, but removes that complexity from the GitHub/direct-install path.

## Channel behavior after this change

- **GitHub Releases / direct sideloads**: universal APK + AAB
- **Google Play**: AAB
- **F-Droid**: per-ABI APKs via metadata/build props

## Notes

- upstream `defaultConfig.versionCode` remains the single base code for Play and GitHub releases
- F-Droid-specific per-ABI version codes should remain in F-Droid metadata/build configuration

## Validation

- verified `build.gradle` no longer applies upstream `versionCodeOverride`
- verified `universalApk true` is enabled for the non-F-Droid path
- verified `abiFilters` path remains for F-Droid
- verified GitHub Release upload now targets only `*-universal-*.apk`

Full Android builds were not run in this change.
